### PR TITLE
feat(desktop-tag): add secure desktop agent surface

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -159,11 +159,10 @@
         "ompk-tag": "src/cli.ts",
       },
       "dependencies": {
-        "@pk-nerdsaver-ai/pi-agent-core": "workspace:*",
         "@pk-nerdsaver-ai/pi-ai": "workspace:*",
         "@pk-nerdsaver-ai/pi-coding-agent": "workspace:*",
+        "@pk-nerdsaver-ai/pi-tui": "workspace:*",
         "@pk-nerdsaver-ai/pi-utils": "workspace:*",
-        "arktype": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",

--- a/bun.lock
+++ b/bun.lock
@@ -152,6 +152,24 @@
         "@types/react-dom": "catalog:",
       },
     },
+    "packages/desktop-tag": {
+      "name": "@pk-nerdsaver-ai/pi-desktop-tag",
+      "version": "16.2.6",
+      "bin": {
+        "ompk-tag": "src/cli.ts",
+      },
+      "dependencies": {
+        "@pk-nerdsaver-ai/pi-agent-core": "workspace:*",
+        "@pk-nerdsaver-ai/pi-ai": "workspace:*",
+        "@pk-nerdsaver-ai/pi-coding-agent": "workspace:*",
+        "@pk-nerdsaver-ai/pi-utils": "workspace:*",
+        "arktype": "catalog:",
+      },
+      "devDependencies": {
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/hashline": {
       "name": "@pk-nerdsaver-ai/hashline",
       "version": "16.2.6",
@@ -804,6 +822,8 @@
     "@pk-nerdsaver-ai/pi-catalog": ["@pk-nerdsaver-ai/pi-catalog@workspace:packages/catalog"],
 
     "@pk-nerdsaver-ai/pi-coding-agent": ["@pk-nerdsaver-ai/pi-coding-agent@workspace:packages/coding-agent"],
+
+    "@pk-nerdsaver-ai/pi-desktop-tag": ["@pk-nerdsaver-ai/pi-desktop-tag@workspace:packages/desktop-tag"],
 
     "@pk-nerdsaver-ai/pi-mnemopi": ["@pk-nerdsaver-ai/pi-mnemopi@workspace:packages/mnemopi"],
 

--- a/packages/desktop-tag/README.md
+++ b/packages/desktop-tag/README.md
@@ -1,0 +1,30 @@
+# pi-desktop-tag
+
+Oh My Pi extension that turns your desktop into an agent trigger surface.
+
+Press a shortcut (or run `ompk tag`) to capture the current screen, selected region, active browser tab, or selected text, type an instruction, and let `omp` route the task to the right executor: local tools, the IX Bridge browser, a remote hub, or a vision-only answer.
+
+## Quick start
+
+```bash
+# Run as a standalone wrapper (starts the gateway and opens the overlay)
+bun --cwd=packages/desktop-tag src/cli.ts
+
+# Or load it as an omp extension and use the slash command
+omp --extension packages/desktop-tag/src/extension.ts
+/tag
+```
+
+## Architecture
+
+- `context.ts` — `ContextPacket` capture (screenshot, foreground app, browser URL/DOM, clipboard, selection).
+- `router.ts` — intent + capability router that maps a request to an executor and constrained tool set.
+- `events.ts` — unified `AgentEvent` protocol consumed by the overlay.
+- `pi-worker.ts` — `AgentSession` worker adapter (`pi` as the runtime).
+- `gateway.ts` — local HTTP + WebSocket gateway for the overlay.
+- `extension.ts` — `omp` extension entrypoint (`/tag` command).
+- `cli.ts` — `ompk-tag` wrapper that boots the gateway and overlay.
+
+## Status
+
+This is the Phase 1 desktop delegation surface: screenshot/region/selection capture, a compact web overlay, and `pi` AgentSession execution. Later phases will add the IX Bridge DOM snapshot, Desktop Commander native actions, and hub-based remote routing.

--- a/packages/desktop-tag/README.md
+++ b/packages/desktop-tag/README.md
@@ -1,30 +1,33 @@
 # pi-desktop-tag
 
-Oh My Pi extension that turns your desktop into an agent trigger surface.
+Oh My Pi extension that captures desktop context and delegates a request to an agent.
 
-Press a shortcut (or run `ompk tag`) to capture the current screen, selected region, active browser tab, or selected text, type an instruction, and let `omp` route the task to the right executor: local tools, the IX Bridge browser, a remote hub, or a vision-only answer.
-
-## Quick start
+## Use
 
 ```bash
-# Run as a standalone wrapper (starts the gateway and opens the overlay)
+# Standalone gateway and overlay
 bun --cwd=packages/desktop-tag src/cli.ts
 
-# Or load it as an omp extension and use the slash command
+# omp extension
 omp --extension packages/desktop-tag/src/extension.ts
 /tag
 ```
 
-## Architecture
+`/tag [screen|window|browser] [request]` immediately captures context and sends it to the current agent; `/tag` defaults to a screen description. Region syntax is `/tag region <x> <y> <width> <height> [request]`. The standalone command prints the loopback overlay URL. Region coordinates use physical pixels: `x` and `y` are finite signed values; `width` and `height` are finite positive values.
 
-- `context.ts` — `ContextPacket` capture (screenshot, foreground app, browser URL/DOM, clipboard, selection).
-- `router.ts` — intent + capability router that maps a request to an executor and constrained tool set.
-- `events.ts` — unified `AgentEvent` protocol consumed by the overlay.
-- `worker.ts` — `AgentSession` worker adapter (`omp` as the runtime).
-- `gateway.ts` — local HTTP + WebSocket gateway for the overlay.
-- `extension.ts` — `omp` extension entrypoint (`/tag` command).
-- `cli.ts` — `ompk-tag` wrapper that boots the gateway and overlay.
+## Security and lifecycle
 
-## Status
+The gateway binds only to loopback (`127.0.0.1`, `localhost`, or `::1`) and rejects non-loopback `Host` values. Browser HTTP and WebSocket requests must use the gateway's exact loopback origin and port. An absent `Origin` remains supported for local native clients; it does not permit a non-loopback host.
 
-This is the Phase 1 desktop delegation surface: screenshot/region/selection capture, a compact web overlay, and `pi` AgentSession execution. Later phases will add the IX Bridge DOM snapshot, Desktop Commander native actions, and hub-based remote routing.
+Task execution is asynchronous. A task completes only when the agent emits `agent_end`; dispatch failures emit `task.failed`. Cancellation is idempotent, rejects pending approvals, and disposes the agent session. `TagGatewayServer.stop()` is async and must be awaited so active tasks and sockets are closed before shutdown.
+
+## Components
+
+- `context.ts` — capture and validate desktop context.
+- `router.ts` — select an executor and constrained tools.
+- `events.ts` — stream overlay-facing task events.
+- `worker.ts` — adapt local `AgentSession` execution.
+- `gateway.ts` — serve the loopback-only HTTP and WebSocket API.
+- `extension.ts` / `cli.ts` — extension and standalone entrypoints.
+
+Phase 1 ships screenshot, region, selection, and browser-context capture with local `pi` AgentSession execution. IX Bridge DOM snapshots, native desktop actions, and remote hubs are future work.

--- a/packages/desktop-tag/README.md
+++ b/packages/desktop-tag/README.md
@@ -20,7 +20,7 @@ omp --extension packages/desktop-tag/src/extension.ts
 - `context.ts` — `ContextPacket` capture (screenshot, foreground app, browser URL/DOM, clipboard, selection).
 - `router.ts` — intent + capability router that maps a request to an executor and constrained tool set.
 - `events.ts` — unified `AgentEvent` protocol consumed by the overlay.
-- `pi-worker.ts` — `AgentSession` worker adapter (`pi` as the runtime).
+- `worker.ts` — `AgentSession` worker adapter (`omp` as the runtime).
 - `gateway.ts` — local HTTP + WebSocket gateway for the overlay.
 - `extension.ts` — `omp` extension entrypoint (`/tag` command).
 - `cli.ts` — `ompk-tag` wrapper that boots the gateway and overlay.

--- a/packages/desktop-tag/package.json
+++ b/packages/desktop-tag/package.json
@@ -1,0 +1,51 @@
+{
+	"name": "@pk-nerdsaver-ai/pi-desktop-tag",
+	"version": "16.2.6",
+	"description": "Oh My Pi extension: trigger and manage agents from the desktop using screenshots, selected text, and screen regions",
+	"type": "module",
+	"main": "src/index.ts",
+	"types": "src/index.ts",
+	"exports": {
+		".": {
+			"import": "./src/index.ts",
+			"types": "./src/index.ts"
+		},
+		"./cli": {
+			"import": "./src/cli.ts",
+			"types": "./src/cli.ts"
+		}
+	},
+	"bin": {
+		"ompk-tag": "src/cli.ts"
+	},
+	"scripts": {
+		"check": "biome check . && bun run check:types",
+		"check:types": "tsgo -p tsconfig.json --noEmit",
+		"lint": "biome lint .",
+		"fix": "biome check --write --unsafe .",
+		"fmt": "biome format --write .",
+		"test": "bun test --parallel=4 test src",
+		"dev": "bun src/cli.ts"
+	},
+	"dependencies": {
+		"@pk-nerdsaver-ai/pi-agent-core": "workspace:*",
+		"@pk-nerdsaver-ai/pi-ai": "workspace:*",
+		"@pk-nerdsaver-ai/pi-coding-agent": "workspace:*",
+		"@pk-nerdsaver-ai/pi-utils": "workspace:*",
+		"arktype": "catalog:"
+	},
+	"devDependencies": {
+		"@types/bun": "catalog:",
+		"typescript": "catalog:"
+	},
+	"omp": {
+		"extensions": [
+			"./src/extension.ts"
+		]
+	},
+	"files": [
+		"src",
+		"CHANGELOG.md",
+		"README.md"
+	]
+}

--- a/packages/desktop-tag/package.json
+++ b/packages/desktop-tag/package.json
@@ -28,11 +28,10 @@
 		"dev": "bun src/cli.ts"
 	},
 	"dependencies": {
-		"@pk-nerdsaver-ai/pi-agent-core": "workspace:*",
 		"@pk-nerdsaver-ai/pi-ai": "workspace:*",
 		"@pk-nerdsaver-ai/pi-coding-agent": "workspace:*",
-		"@pk-nerdsaver-ai/pi-utils": "workspace:*",
-		"arktype": "catalog:"
+		"@pk-nerdsaver-ai/pi-tui": "workspace:*",
+		"@pk-nerdsaver-ai/pi-utils": "workspace:*"
 	},
 	"devDependencies": {
 		"@types/bun": "catalog:",

--- a/packages/desktop-tag/package.json
+++ b/packages/desktop-tag/package.json
@@ -45,7 +45,6 @@
 	},
 	"files": [
 		"src",
-		"CHANGELOG.md",
 		"README.md"
 	]
 }

--- a/packages/desktop-tag/src/cli.ts
+++ b/packages/desktop-tag/src/cli.ts
@@ -16,16 +16,17 @@ function main(): void {
 	logger.info("ompk-tag running", { url: server.url });
 	console.log(`ompk-tag listening at ${server.url}`);
 
-	process.on("SIGINT", () => {
-		logger.info("Shutting down ompk-tag");
-		server.stop();
+	let stopping = false;
+	const shutdown = async (signal: string): Promise<void> => {
+		if (stopping) return;
+		stopping = true;
+		logger.info("Shutting down ompk-tag", { signal });
+		await server.stop();
 		process.exit(0);
-	});
+	};
 
-	process.on("SIGTERM", () => {
-		server.stop();
-		process.exit(0);
-	});
+	process.on("SIGINT", () => void shutdown("SIGINT"));
+	process.on("SIGTERM", () => void shutdown("SIGTERM"));
 }
 
 main();

--- a/packages/desktop-tag/src/cli.ts
+++ b/packages/desktop-tag/src/cli.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env bun
+import { logger } from "@pk-nerdsaver-ai/pi-utils";
+
+import { TagGatewayServer } from "./gateway";
+
+function main(): void {
+	const args = process.argv.slice(2);
+	const portArg = args.find(a => a.startsWith("--port="))?.split("=")[1];
+	const hostArg = args.find(a => a.startsWith("--host="))?.split("=")[1];
+	const port = portArg ? Number.parseInt(portArg, 10) : Number(Bun.env.OMP_DESKTOP_TAG_PORT ?? 18087);
+	const hostname = hostArg ?? (Bun.env.OMP_DESKTOP_TAG_HOST || "127.0.0.1");
+
+	const server = new TagGatewayServer({ port, hostname });
+	server.start();
+
+	logger.info("ompk-tag running", { url: server.url });
+	console.log(`ompk-tag listening at ${server.url}`);
+
+	process.on("SIGINT", () => {
+		logger.info("Shutting down ompk-tag");
+		server.stop();
+		process.exit(0);
+	});
+
+	process.on("SIGTERM", () => {
+		server.stop();
+		process.exit(0);
+	});
+}
+
+main();

--- a/packages/desktop-tag/src/context.ts
+++ b/packages/desktop-tag/src/context.ts
@@ -3,25 +3,89 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { logger } from "@pk-nerdsaver-ai/pi-utils";
-
 import type {
 	Annotation,
 	BrowserContext,
 	CaptureMode,
+	CaptureRegion,
 	ContextPacket,
 	ForegroundAppContext,
 	SelectionContext,
 	VisualContext,
 } from "./types";
+import { isCaptureMode } from "./types";
 
 /** Options for a single capture. */
 export interface CaptureOptions {
 	mode: CaptureMode;
-	region?: { x: number; y: number; width: number; height: number };
+	region?: CaptureRegion;
 	includeClipboard?: boolean;
 	includeActiveAppState?: boolean;
 	userRequest: string;
 	annotations?: Annotation[];
+}
+
+const annotationTypes = new Set<string>(["rectangle", "point", "arrow", "blur"]);
+
+/** Reject malformed capture input before any filesystem or screenshot operation begins. */
+export function assertCaptureOptions(options: unknown): asserts options is CaptureOptions {
+	if (!isRecord(options)) throw new TypeError("Capture options must be an object");
+	if (!isCaptureMode(options.mode)) {
+		throw new TypeError(`Unsupported capture mode: ${String(options.mode)}`);
+	}
+	if (typeof options.userRequest !== "string" || options.userRequest.trim().length === 0) {
+		throw new TypeError("Capture userRequest must be a nonblank string");
+	}
+	if (options.includeClipboard !== undefined && typeof options.includeClipboard !== "boolean") {
+		throw new TypeError("Capture includeClipboard must be a boolean");
+	}
+	if (options.includeActiveAppState !== undefined && typeof options.includeActiveAppState !== "boolean") {
+		throw new TypeError("Capture includeActiveAppState must be a boolean");
+	}
+	if (options.region !== undefined) assertCaptureRegion(options.region);
+	if (options.mode === "region" && options.region === undefined) {
+		throw new TypeError("Region capture requires a region");
+	}
+	if (options.annotations !== undefined) {
+		if (!Array.isArray(options.annotations)) throw new TypeError("Capture annotations must be an array");
+		for (const annotation of options.annotations) {
+			if (
+				!isRecord(annotation) ||
+				typeof annotation.id !== "string" ||
+				typeof annotation.type !== "string" ||
+				!annotationTypes.has(annotation.type)
+			) {
+				throw new TypeError("Capture annotation is malformed");
+			}
+			if (
+				!Array.isArray(annotation.bounds) ||
+				annotation.bounds.length !== 4 ||
+				!annotation.bounds.every(value => typeof value === "number" && Number.isFinite(value))
+			) {
+				throw new TypeError("Capture annotation bounds must contain four finite numbers");
+			}
+			if (annotation.label !== undefined && typeof annotation.label !== "string")
+				throw new TypeError("Capture annotation label must be a string");
+		}
+	}
+}
+
+function assertCaptureRegion(region: unknown): asserts region is CaptureRegion {
+	if (!isRecord(region)) throw new TypeError("Capture region must be an object");
+	for (const name of ["x", "y", "width", "height"] as const) {
+		const value = region[name];
+		if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+			throw new TypeError(`Capture region ${name} must be a finite positive number`);
+		}
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertNever(value: never): never {
+	throw new TypeError(`Unsupported capture mode: ${String(value)}`);
 }
 
 /** Service that captures the desktop context for a tag request. */
@@ -37,6 +101,7 @@ export class CaptureService {
 	}
 
 	async capture(options: CaptureOptions): Promise<ContextPacket> {
+		assertCaptureOptions(options);
 		await this.init();
 
 		const captureId = crypto.randomUUID();
@@ -44,7 +109,7 @@ export class CaptureService {
 		const screenshotPath = path.join(this.#tempDir, `${captureId}.png`);
 
 		const [visual, foregroundApp, selection, browser, availableCapabilities] = await Promise.all([
-			this.#captureVisual(options, captureId, screenshotPath),
+			this.#captureVisual(options, screenshotPath),
 			options.includeActiveAppState ? this.#captureForegroundApp() : Promise.resolve({}),
 			options.includeClipboard ? this.#captureSelection() : Promise.resolve({}),
 			this.#captureBrowserContext(),
@@ -64,13 +129,22 @@ export class CaptureService {
 		};
 	}
 
-	async #captureVisual(options: CaptureOptions, captureId: string, screenshotPath: string): Promise<VisualContext> {
+	async #captureVisual(options: CaptureOptions, screenshotPath: string): Promise<VisualContext> {
 		try {
 			const { region } = options;
-			if (options.mode === "screen" || options.mode === "browser" || options.mode === "window") {
-				await captureScreenshot(screenshotPath, options.mode === "window" ? undefined : region);
-			} else if (options.mode === "region" && region) {
-				await captureScreenshot(screenshotPath, region);
+			switch (options.mode) {
+				case "screen":
+				case "browser":
+					await captureScreenshot(screenshotPath, region);
+					break;
+				case "window":
+					await captureScreenshot(screenshotPath);
+					break;
+				case "region":
+					await captureScreenshot(screenshotPath, region);
+					break;
+				default:
+					assertNever(options.mode);
 			}
 
 			return {
@@ -123,7 +197,9 @@ if ($process) {
 				executablePath: parsed.Path,
 			};
 		} catch (error) {
-			logger.debug("Foreground app capture failed", { error: error instanceof Error ? error.message : String(error) });
+			logger.debug("Foreground app capture failed", {
+				error: error instanceof Error ? error.message : String(error),
+			});
 			return {};
 		}
 	}
@@ -212,7 +288,8 @@ async function extractJsonText(response: Response | undefined, key: string): Pro
 	return undefined;
 }
 
-export async function captureScreenshot(screenshotPath: string, region?: { x: number; y: number; width: number; height: number }): Promise<void> {
+export async function captureScreenshot(screenshotPath: string, region?: CaptureRegion): Promise<void> {
+	if (region !== undefined) assertCaptureRegion(region);
 	if (process.platform !== "win32") {
 		throw new Error(`Screenshot capture not implemented for ${process.platform}`);
 	}

--- a/packages/desktop-tag/src/context.ts
+++ b/packages/desktop-tag/src/context.ts
@@ -1,0 +1,269 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { logger } from "@pk-nerdsaver-ai/pi-utils";
+
+import type {
+	Annotation,
+	BrowserContext,
+	CaptureMode,
+	ContextPacket,
+	ForegroundAppContext,
+	SelectionContext,
+	VisualContext,
+} from "./types";
+
+/** Options for a single capture. */
+export interface CaptureOptions {
+	mode: CaptureMode;
+	region?: { x: number; y: number; width: number; height: number };
+	includeClipboard?: boolean;
+	includeActiveAppState?: boolean;
+	userRequest: string;
+	annotations?: Annotation[];
+}
+
+/** Service that captures the desktop context for a tag request. */
+export class CaptureService {
+	readonly #tempDir: string;
+
+	constructor(tempDir?: string) {
+		this.#tempDir = tempDir ?? path.join(os.tmpdir(), "pi-desktop-tag");
+	}
+
+	async init(): Promise<void> {
+		await fs.mkdir(this.#tempDir, { recursive: true });
+	}
+
+	async capture(options: CaptureOptions): Promise<ContextPacket> {
+		await this.init();
+
+		const captureId = crypto.randomUUID();
+		const timestamp = new Date().toISOString();
+		const screenshotPath = path.join(this.#tempDir, `${captureId}.png`);
+
+		const [visual, foregroundApp, selection, browser, availableCapabilities] = await Promise.all([
+			this.#captureVisual(options, captureId, screenshotPath),
+			options.includeActiveAppState ? this.#captureForegroundApp() : Promise.resolve({}),
+			options.includeClipboard ? this.#captureSelection() : Promise.resolve({}),
+			this.#captureBrowserContext(),
+			this.#resolveAvailableCapabilities(),
+		]);
+
+		return {
+			captureId,
+			timestamp,
+			userRequest: options.userRequest,
+			captureMode: options.mode,
+			visual,
+			foregroundApp,
+			selection,
+			browser,
+			availableCapabilities,
+		};
+	}
+
+	async #captureVisual(options: CaptureOptions, captureId: string, screenshotPath: string): Promise<VisualContext> {
+		try {
+			const { region } = options;
+			if (options.mode === "screen" || options.mode === "browser" || options.mode === "window") {
+				await captureScreenshot(screenshotPath, options.mode === "window" ? undefined : region);
+			} else if (options.mode === "region" && region) {
+				await captureScreenshot(screenshotPath, region);
+			}
+
+			return {
+				screenshotPath,
+				selectedRegion: region,
+				displayScale: 1,
+				annotations: options.annotations ?? [],
+			};
+		} catch (error) {
+			logger.debug("Screenshot capture failed", { error: error instanceof Error ? error.message : String(error) });
+			return { screenshotPath: undefined, selectedRegion: options.region, displayScale: 1, annotations: [] };
+		}
+	}
+
+	async #captureForegroundApp(): Promise<ForegroundAppContext> {
+		if (process.platform !== "win32") {
+			return {};
+		}
+		try {
+			const script = `
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public class Win32 {
+  [DllImport("user32.dll")]
+  public static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll", SetLastError=true)]
+  public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+}
+"@
+$hwnd = [Win32]::GetForegroundWindow()
+$processId = 0
+[void][Win32]::GetWindowThreadProcessId($hwnd, [ref]$processId)
+$process = Get-Process -Id $processId -ErrorAction SilentlyContinue
+if ($process) {
+    @{ Name = $process.Name; MainWindowTitle = $process.MainWindowTitle; Path = $process.Path } | ConvertTo-Json -Compress
+} else {
+    "{}"
+}
+`;
+			const output = await runPowershell(script);
+			const parsed = JSON.parse(output || "{}") as {
+				Name?: string;
+				MainWindowTitle?: string;
+				Path?: string;
+			};
+			return {
+				processName: parsed.Name,
+				windowTitle: parsed.MainWindowTitle,
+				executablePath: parsed.Path,
+			};
+		} catch (error) {
+			logger.debug("Foreground app capture failed", { error: error instanceof Error ? error.message : String(error) });
+			return {};
+		}
+	}
+
+	async #captureSelection(): Promise<SelectionContext> {
+		if (process.platform !== "win32") {
+			return {};
+		}
+		try {
+			const script = `
+$text = Get-Clipboard -TextFormatType Text -ErrorAction SilentlyContinue
+if ($text) { @{ text = $text } | ConvertTo-Json -Compress } else { "{}" }
+`;
+			const output = await runPowershell(script);
+			const parsed = JSON.parse(output || "{}") as { text?: string };
+			return { clipboardText: parsed.text };
+		} catch (error) {
+			logger.debug("Clipboard capture failed", { error: error instanceof Error ? error.message : String(error) });
+			return {};
+		}
+	}
+
+	async #captureBrowserContext(): Promise<BrowserContext> {
+		try {
+			const controller = new AbortController();
+			const timer = setTimeout(() => controller.abort(), 1_500);
+			const response = await fetch("http://127.0.0.1:18086/ix-bridge/status", { signal: controller.signal });
+			clearTimeout(timer);
+			if (!response.ok) return {};
+
+			const body = (await response.json().catch(() => ({}))) as {
+				running?: boolean;
+				extension_connected?: boolean;
+			};
+			if (!body.extension_connected) return {};
+
+			const urlRes = await fetch("http://127.0.0.1:18086/ix-bridge/command", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ lane: "agent-a", action: "get_url", args: {} }),
+				signal: controller.signal,
+			}).catch(() => undefined);
+			const titleRes = await fetch("http://127.0.0.1:18086/ix-bridge/command", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ lane: "agent-a", action: "get_title", args: {} }),
+				signal: controller.signal,
+			}).catch(() => undefined);
+
+			const url = await extractJsonText(urlRes, "url");
+			const title = await extractJsonText(titleRes, "title");
+			return { url, title };
+		} catch {
+			return {};
+		}
+	}
+
+	async #resolveAvailableCapabilities(): Promise<string[]> {
+		const capabilities = ["visual"];
+		if (process.platform === "win32") {
+			capabilities.push("clipboard", "foreground-app");
+		}
+		try {
+			const controller = new AbortController();
+			const timer = setTimeout(() => controller.abort(), 1_000);
+			const response = await fetch("http://127.0.0.1:18086/ix-bridge/status", { signal: controller.signal });
+			clearTimeout(timer);
+			if (response.ok) capabilities.push("browser");
+		} catch {
+			// ignore
+		}
+		return capabilities;
+	}
+}
+
+async function extractJsonText(response: Response | undefined, key: string): Promise<string | undefined> {
+	if (!response) return undefined;
+	const body = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+	const value = body[key];
+	if (typeof value === "string") return value;
+	const result = body.result;
+	if (result && typeof result === "object" && key in result) {
+		const nested = (result as Record<string, unknown>)[key];
+		return typeof nested === "string" ? nested : undefined;
+	}
+	return undefined;
+}
+
+export async function captureScreenshot(screenshotPath: string, region?: { x: number; y: number; width: number; height: number }): Promise<void> {
+	if (process.platform !== "win32") {
+		throw new Error(`Screenshot capture not implemented for ${process.platform}`);
+	}
+
+	const x = region?.x ?? 0;
+	const y = region?.y ?? 0;
+	const width = region?.width ?? 0;
+	const height = region?.height ?? 0;
+
+	const script = region
+		? `
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+$bmp = New-Object System.Drawing.Bitmap(${width}, ${height})
+$g = [System.Drawing.Graphics]::FromImage($bmp)
+$g.CopyFromScreen(${x}, ${y}, 0, 0, $bmp.Size)
+$bmp.Save("${screenshotPath}", [System.Drawing.Imaging.ImageFormat]::Png)
+$g.Dispose()
+$bmp.Dispose()
+`
+		: `
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+$bounds = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
+$bmp = New-Object System.Drawing.Bitmap($bounds.Width, $bounds.Height)
+$g = [System.Drawing.Graphics]::FromImage($bmp)
+$g.CopyFromScreen($bounds.Location, [System.Drawing.Point]::Empty, $bounds.Size)
+$bmp.Save("${screenshotPath}", [System.Drawing.Imaging.ImageFormat]::Png)
+$g.Dispose()
+$bmp.Dispose()
+`;
+
+	await runPowershell(script);
+}
+
+async function runPowershell(script: string): Promise<string> {
+	const scriptPath = path.join(os.tmpdir(), `pi-desktop-tag-${crypto.randomUUID()}.ps1`);
+	await fs.writeFile(scriptPath, script, "utf8");
+	try {
+		const proc = Bun.spawn(["powershell.exe", "-ExecutionPolicy", "Bypass", "-File", scriptPath], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		await proc.exited;
+		const stdout = await new Response(proc.stdout).text();
+		const stderr = await new Response(proc.stderr).text();
+		if (proc.exitCode !== 0) {
+			throw new Error(`PowerShell failed: ${stderr || stdout}`);
+		}
+		return stdout.trim();
+	} finally {
+		await fs.unlink(scriptPath).catch(() => {});
+	}
+}

--- a/packages/desktop-tag/src/context.ts
+++ b/packages/desktop-tag/src/context.ts
@@ -72,7 +72,13 @@ export function assertCaptureOptions(options: unknown): asserts options is Captu
 
 function assertCaptureRegion(region: unknown): asserts region is CaptureRegion {
 	if (!isRecord(region)) throw new TypeError("Capture region must be an object");
-	for (const name of ["x", "y", "width", "height"] as const) {
+	for (const name of ["x", "y"] as const) {
+		const value = region[name];
+		if (typeof value !== "number" || !Number.isFinite(value)) {
+			throw new TypeError(`Capture region ${name} must be a finite number`);
+		}
+	}
+	for (const name of ["width", "height"] as const) {
 		const value = region[name];
 		if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
 			throw new TypeError(`Capture region ${name} must be a finite positive number`);
@@ -138,7 +144,7 @@ export class CaptureService {
 					await captureScreenshot(screenshotPath, region);
 					break;
 				case "window":
-					await captureScreenshot(screenshotPath);
+					await captureWindowScreenshot(screenshotPath);
 					break;
 				case "region":
 					await captureScreenshot(screenshotPath, region);
@@ -224,10 +230,7 @@ if ($text) { @{ text = $text } | ConvertTo-Json -Compress } else { "{}" }
 
 	async #captureBrowserContext(): Promise<BrowserContext> {
 		try {
-			const controller = new AbortController();
-			const timer = setTimeout(() => controller.abort(), 1_500);
-			const response = await fetch("http://127.0.0.1:18086/ix-bridge/status", { signal: controller.signal });
-			clearTimeout(timer);
+			const response = await fetchWithTimeout("http://127.0.0.1:18086/ix-bridge/status", {}, 1_500);
 			if (!response.ok) return {};
 
 			const body = (await response.json().catch(() => ({}))) as {
@@ -236,18 +239,10 @@ if ($text) { @{ text = $text } | ConvertTo-Json -Compress } else { "{}" }
 			};
 			if (!body.extension_connected) return {};
 
-			const urlRes = await fetch("http://127.0.0.1:18086/ix-bridge/command", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ lane: "agent-a", action: "get_url", args: {} }),
-				signal: controller.signal,
-			}).catch(() => undefined);
-			const titleRes = await fetch("http://127.0.0.1:18086/ix-bridge/command", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ lane: "agent-a", action: "get_title", args: {} }),
-				signal: controller.signal,
-			}).catch(() => undefined);
+			const [urlRes, titleRes] = await Promise.all([
+				requestIxBridgeCommand("get_url").catch(() => undefined),
+				requestIxBridgeCommand("get_title").catch(() => undefined),
+			]);
 
 			const url = await extractJsonText(urlRes, "url");
 			const title = await extractJsonText(titleRes, "title");
@@ -263,16 +258,50 @@ if ($text) { @{ text = $text } | ConvertTo-Json -Compress } else { "{}" }
 			capabilities.push("clipboard", "foreground-app");
 		}
 		try {
-			const controller = new AbortController();
-			const timer = setTimeout(() => controller.abort(), 1_000);
-			const response = await fetch("http://127.0.0.1:18086/ix-bridge/status", { signal: controller.signal });
-			clearTimeout(timer);
+			const response = await fetchWithTimeout("http://127.0.0.1:18086/ix-bridge/status", {}, 1_000);
 			if (response.ok) capabilities.push("browser");
 		} catch {
 			// ignore
 		}
 		return capabilities;
 	}
+}
+
+const IX_BRIDGE_COMMAND_TIMEOUT_MS = 1_500;
+
+export async function fetchWithTimeout(
+	input: string | URL | Request,
+	init: RequestInit,
+	timeoutMs: number,
+): Promise<Response> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+	try {
+		const response = await fetch(input, { ...init, signal: controller.signal });
+		const body = await response.arrayBuffer();
+		return new Response(body.byteLength === 0 ? null : body, {
+			status: response.status,
+			statusText: response.statusText,
+			headers: response.headers,
+		});
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+export function requestIxBridgeCommand(
+	action: "get_url" | "get_title",
+	timeoutMs = IX_BRIDGE_COMMAND_TIMEOUT_MS,
+): Promise<Response> {
+	return fetchWithTimeout(
+		"http://127.0.0.1:18086/ix-bridge/command",
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ lane: "agent-a", action, args: {} }),
+		},
+		timeoutMs,
+	);
 }
 
 async function extractJsonText(response: Response | undefined, key: string): Promise<string | undefined> {
@@ -294,35 +323,91 @@ export async function captureScreenshot(screenshotPath: string, region?: Capture
 		throw new Error(`Screenshot capture not implemented for ${process.platform}`);
 	}
 
-	const x = region?.x ?? 0;
-	const y = region?.y ?? 0;
-	const width = region?.width ?? 0;
-	const height = region?.height ?? 0;
+	await runPowershell(buildScreenshotScript(screenshotPath, region));
+}
 
-	const script = region
-		? `
-Add-Type -AssemblyName System.Windows.Forms
+/** Capture the actual foreground window rather than falling back to the primary screen. */
+export async function captureWindowScreenshot(screenshotPath: string): Promise<void> {
+	if (process.platform !== "win32") {
+		throw new Error(`Window screenshot capture not implemented for ${process.platform}`);
+	}
+
+	await runPowershell(buildWindowScreenshotScript(screenshotPath));
+}
+
+export function buildScreenshotScript(screenshotPath: string, region?: CaptureRegion): string {
+	const outputPath = quotePowerShellString(screenshotPath);
+	if (region) {
+		assertCaptureRegion(region);
+		return `
 Add-Type -AssemblyName System.Drawing
-$bmp = New-Object System.Drawing.Bitmap(${width}, ${height})
+$bmp = New-Object System.Drawing.Bitmap(${region.width}, ${region.height})
 $g = [System.Drawing.Graphics]::FromImage($bmp)
-$g.CopyFromScreen(${x}, ${y}, 0, 0, $bmp.Size)
-$bmp.Save("${screenshotPath}", [System.Drawing.Imaging.ImageFormat]::Png)
-$g.Dispose()
-$bmp.Dispose()
-`
-		: `
+try {
+    $g.CopyFromScreen(${region.x}, ${region.y}, 0, 0, $bmp.Size)
+    $bmp.Save(${outputPath}, [System.Drawing.Imaging.ImageFormat]::Png)
+} finally {
+    $g.Dispose()
+    $bmp.Dispose()
+}
+`;
+	}
+
+	return `
 Add-Type -AssemblyName System.Windows.Forms
 Add-Type -AssemblyName System.Drawing
 $bounds = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
 $bmp = New-Object System.Drawing.Bitmap($bounds.Width, $bounds.Height)
 $g = [System.Drawing.Graphics]::FromImage($bmp)
-$g.CopyFromScreen($bounds.Location, [System.Drawing.Point]::Empty, $bounds.Size)
-$bmp.Save("${screenshotPath}", [System.Drawing.Imaging.ImageFormat]::Png)
-$g.Dispose()
-$bmp.Dispose()
+try {
+    $g.CopyFromScreen($bounds.Location, [System.Drawing.Point]::Empty, $bounds.Size)
+    $bmp.Save(${outputPath}, [System.Drawing.Imaging.ImageFormat]::Png)
+} finally {
+    $g.Dispose()
+    $bmp.Dispose()
+}
 `;
+}
 
-	await runPowershell(script);
+export function buildWindowScreenshotScript(screenshotPath: string): string {
+	const outputPath = quotePowerShellString(screenshotPath);
+	return `
+Add-Type -AssemblyName System.Drawing
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class DesktopTagWindowCapture {
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RECT { public int Left; public int Top; public int Right; public int Bottom; }
+    [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool GetWindowRect(IntPtr hWnd, out RECT rect);
+}
+"@
+$hwnd = [DesktopTagWindowCapture]::GetForegroundWindow()
+if ($hwnd -eq [IntPtr]::Zero) { throw "No foreground window is available" }
+$bounds = New-Object 'DesktopTagWindowCapture+RECT'
+if (-not [DesktopTagWindowCapture]::GetWindowRect($hwnd, [ref]$bounds)) {
+    throw "GetWindowRect failed for foreground window"
+}
+$width = $bounds.Right - $bounds.Left
+$height = $bounds.Bottom - $bounds.Top
+if ($width -le 0 -or $height -le 0) { throw "Foreground window has invalid bounds" }
+$bmp = New-Object System.Drawing.Bitmap($width, $height)
+$g = [System.Drawing.Graphics]::FromImage($bmp)
+try {
+    $g.CopyFromScreen($bounds.Left, $bounds.Top, 0, 0, $bmp.Size)
+    $bmp.Save(${outputPath}, [System.Drawing.Imaging.ImageFormat]::Png)
+} finally {
+    $g.Dispose()
+    $bmp.Dispose()
+}
+`;
+}
+
+function quotePowerShellString(value: string): string {
+	return `'${value.replaceAll("'", "''")}'`;
 }
 
 async function runPowershell(script: string): Promise<string> {

--- a/packages/desktop-tag/src/events.ts
+++ b/packages/desktop-tag/src/events.ts
@@ -2,55 +2,66 @@ import { logger } from "@pk-nerdsaver-ai/pi-utils";
 
 import type { AgentEvent } from "./types";
 
-/** A typed channel that lets one or more consumers subscribe to {@link AgentEvent}s. */
-export class AgentEventChannel {
-	readonly #pending: AgentEvent[] = [];
-	readonly #waiters: Array<(event: AgentEvent) => void> = [];
+/** A replaying typed channel that lets consumers independently subscribe to {@link AgentEvent}s. */
+export class TaskEventChannel {
+	readonly #events: AgentEvent[] = [];
+	readonly #waiters = new Set<() => void>();
 	#closed = false;
 
 	push(event: AgentEvent): void {
 		if (this.#closed) return;
-		const waiter = this.#waiters.shift();
-		if (waiter) {
-			waiter(event);
-		} else {
-			this.#pending.push(event);
-		}
+		this.#events.push(event);
+		this.#wakeWaiters();
 	}
 
 	close(): void {
+		if (this.#closed) return;
 		this.#closed = true;
-		while (this.#waiters.length > 0) {
-			const waiter = this.#waiters.shift();
-			if (waiter) waiter({ type: "task.completed", taskId: "", summary: "" });
-		}
+		this.#wakeWaiters();
 	}
 
-	subscribe(): AsyncIterable<AgentEvent> {
-		const pending = this.#pending;
-		const waiters = this.#waiters;
-		const closed = () => this.#closed;
+	subscribe(signal?: AbortSignal): AsyncIterable<AgentEvent> {
+		const channel = this;
 		return {
 			async *[Symbol.asyncIterator](): AsyncIterator<AgentEvent> {
-				while (true) {
-					if (pending.length > 0) {
-						yield pending.shift()!;
+				let cursor = 0;
+				while (!signal?.aborted) {
+					if (cursor < channel.#events.length) {
+						yield channel.#events[cursor++];
 						continue;
 					}
-					if (closed()) return;
-					const { promise, resolve } = Promise.withResolvers<AgentEvent>();
-					waiters.push(resolve);
-					try {
-						yield await promise;
-					} catch (error) {
-						logger.error("Agent event channel iterator error", { error: String(error) });
-						return;
-					}
+					if (channel.#closed) return;
+					await channel.#waitForEvent(signal);
 				}
 			},
 		};
 	}
+
+	#waitForEvent(signal?: AbortSignal): Promise<void> {
+		if (signal?.aborted) return Promise.resolve();
+
+		const { promise, resolve } = Promise.withResolvers<void>();
+		const wake = (): void => {
+			this.#waiters.delete(wake);
+			signal?.removeEventListener("abort", wake);
+			resolve();
+		};
+
+		this.#waiters.add(wake);
+		signal?.addEventListener("abort", wake, { once: true });
+		if (signal?.aborted) wake();
+		return promise;
+	}
+
+	#wakeWaiters(): void {
+		const waiters = [...this.#waiters];
+		this.#waiters.clear();
+		for (const wake of waiters) wake();
+	}
 }
+
+/** Backward-compatible name for the task event channel. */
+export { TaskEventChannel as AgentEventChannel };
 
 /** Serialize an event for wire transport. */
 export function serializeAgentEvent(event: AgentEvent): string {
@@ -64,7 +75,10 @@ export function parseAgentEvent(text: string): AgentEvent | undefined {
 		if (!parsed || typeof parsed !== "object" || !("type" in parsed)) return undefined;
 		return parsed;
 	} catch (error) {
-		logger.debug("Failed to parse agent event", { error: error instanceof Error ? error.message : String(error), text });
+		logger.debug("Failed to parse agent event", {
+			error: error instanceof Error ? error.message : String(error),
+			text,
+		});
 		return undefined;
 	}
 }

--- a/packages/desktop-tag/src/events.ts
+++ b/packages/desktop-tag/src/events.ts
@@ -1,0 +1,70 @@
+import { logger } from "@pk-nerdsaver-ai/pi-utils";
+
+import type { AgentEvent } from "./types";
+
+/** A typed channel that lets one or more consumers subscribe to {@link AgentEvent}s. */
+export class AgentEventChannel {
+	readonly #pending: AgentEvent[] = [];
+	readonly #waiters: Array<(event: AgentEvent) => void> = [];
+	#closed = false;
+
+	push(event: AgentEvent): void {
+		if (this.#closed) return;
+		const waiter = this.#waiters.shift();
+		if (waiter) {
+			waiter(event);
+		} else {
+			this.#pending.push(event);
+		}
+	}
+
+	close(): void {
+		this.#closed = true;
+		while (this.#waiters.length > 0) {
+			const waiter = this.#waiters.shift();
+			if (waiter) waiter({ type: "task.completed", taskId: "", summary: "" });
+		}
+	}
+
+	subscribe(): AsyncIterable<AgentEvent> {
+		const pending = this.#pending;
+		const waiters = this.#waiters;
+		const closed = () => this.#closed;
+		return {
+			async *[Symbol.asyncIterator](): AsyncIterator<AgentEvent> {
+				while (true) {
+					if (pending.length > 0) {
+						yield pending.shift()!;
+						continue;
+					}
+					if (closed()) return;
+					const { promise, resolve } = Promise.withResolvers<AgentEvent>();
+					waiters.push(resolve);
+					try {
+						yield await promise;
+					} catch (error) {
+						logger.error("Agent event channel iterator error", { error: String(error) });
+						return;
+					}
+				}
+			},
+		};
+	}
+}
+
+/** Serialize an event for wire transport. */
+export function serializeAgentEvent(event: AgentEvent): string {
+	return JSON.stringify(event);
+}
+
+/** Parse an event received over the wire. */
+export function parseAgentEvent(text: string): AgentEvent | undefined {
+	try {
+		const parsed = JSON.parse(text) as AgentEvent;
+		if (!parsed || typeof parsed !== "object" || !("type" in parsed)) return undefined;
+		return parsed;
+	} catch (error) {
+		logger.debug("Failed to parse agent event", { error: error instanceof Error ? error.message : String(error), text });
+		return undefined;
+	}
+}

--- a/packages/desktop-tag/src/events.ts
+++ b/packages/desktop-tag/src/events.ts
@@ -1,6 +1,6 @@
 import { logger } from "@pk-nerdsaver-ai/pi-utils";
 
-import type { AgentEvent } from "./types";
+import { type AgentEvent, isCaptureMode } from "./types";
 
 /** A replaying typed channel that lets consumers independently subscribe to {@link AgentEvent}s. */
 export class TaskEventChannel {
@@ -68,12 +68,182 @@ export function serializeAgentEvent(event: AgentEvent): string {
 	return JSON.stringify(event);
 }
 
-/** Parse an event received over the wire. */
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every(item => typeof item === "string");
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+	return value === undefined || typeof value === "string";
+}
+
+function isActionLevel(value: unknown): value is 0 | 1 | 2 | 3 {
+	return value === 0 || value === 1 || value === 2 || value === 3;
+}
+
+function isImageContent(value: unknown): boolean {
+	if (!isRecord(value)) return false;
+	return (
+		value.type === "image" &&
+		typeof value.data === "string" &&
+		typeof value.mimeType === "string" &&
+		(value.detail === undefined ||
+			value.detail === "auto" ||
+			value.detail === "low" ||
+			value.detail === "high" ||
+			value.detail === "original")
+	);
+}
+
+function isCaptureRegion(value: unknown): boolean {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.x === "number" &&
+		typeof value.y === "number" &&
+		typeof value.width === "number" &&
+		typeof value.height === "number"
+	);
+}
+
+function isAnnotation(value: unknown): boolean {
+	if (!isRecord(value)) return false;
+	const bounds = value.bounds;
+	return (
+		typeof value.id === "string" &&
+		(value.type === "rectangle" || value.type === "point" || value.type === "arrow" || value.type === "blur") &&
+		Array.isArray(bounds) &&
+		bounds.length === 4 &&
+		bounds.every(coordinate => typeof coordinate === "number") &&
+		isOptionalString(value.label)
+	);
+}
+
+function isVisualContext(value: unknown): boolean {
+	if (!isRecord(value)) return false;
+	return (
+		isOptionalString(value.screenshotPath) &&
+		(value.screenshotImage === undefined || isImageContent(value.screenshotImage)) &&
+		(value.selectedRegion === undefined || isCaptureRegion(value.selectedRegion)) &&
+		typeof value.displayScale === "number" &&
+		Array.isArray(value.annotations) &&
+		value.annotations.every(isAnnotation)
+	);
+}
+
+function isForegroundAppContext(value: unknown): boolean {
+	return (
+		isRecord(value) &&
+		isOptionalString(value.processName) &&
+		isOptionalString(value.windowTitle) &&
+		isOptionalString(value.executablePath)
+	);
+}
+
+function isBrowserContext(value: unknown): boolean {
+	return (
+		isRecord(value) &&
+		isOptionalString(value.url) &&
+		isOptionalString(value.title) &&
+		isOptionalString(value.tabId) &&
+		isOptionalString(value.domSnapshotRef) &&
+		isOptionalString(value.accessibilityTreeRef)
+	);
+}
+
+function isSelectionContext(value: unknown): boolean {
+	return isRecord(value) && isOptionalString(value.text) && isOptionalString(value.clipboardText);
+}
+
+function isContextPacket(value: unknown): boolean {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.captureId === "string" &&
+		typeof value.timestamp === "string" &&
+		typeof value.userRequest === "string" &&
+		isCaptureMode(value.captureMode) &&
+		isVisualContext(value.visual) &&
+		isForegroundAppContext(value.foregroundApp) &&
+		isBrowserContext(value.browser) &&
+		isSelectionContext(value.selection) &&
+		isStringArray(value.availableCapabilities)
+	);
+}
+
+function isPlanStep(value: unknown): boolean {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.id === "string" &&
+		typeof value.executorId === "string" &&
+		typeof value.capability === "string" &&
+		isRecord(value.arguments) &&
+		isActionLevel(value.level) &&
+		typeof value.description === "string" &&
+		typeof value.requiresApproval === "boolean"
+	);
+}
+
+function isApprovalRequest(value: unknown): boolean {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.actionId === "string" &&
+		typeof value.stepId === "string" &&
+		isActionLevel(value.level) &&
+		typeof value.toolName === "string" &&
+		isRecord(value.arguments) &&
+		typeof value.effects === "string" &&
+		(value.scope === undefined ||
+			value.scope === "once" ||
+			value.scope === "group" ||
+			value.scope === "session" ||
+			value.scope === "application")
+	);
+}
+
+function isAgentEvent(value: unknown): value is AgentEvent {
+	if (!isRecord(value)) return false;
+	switch (value.type) {
+		case "task.started":
+			return typeof value.taskId === "string";
+		case "agent.message.delta":
+			return typeof value.text === "string";
+		case "plan.updated":
+			return Array.isArray(value.steps) && value.steps.every(isPlanStep);
+		case "tool.requested":
+			return typeof value.callId === "string" && typeof value.toolName === "string" && isRecord(value.arguments);
+		case "approval.requested":
+			return isApprovalRequest(value.request);
+		case "tool.started":
+			return typeof value.callId === "string" && typeof value.toolName === "string";
+		case "tool.completed":
+			return (
+				typeof value.callId === "string" && Object.hasOwn(value, "result") && typeof value.isError === "boolean"
+			);
+		case "observation.updated":
+			return (
+				isOptionalString(value.screenshotRef) &&
+				(value.contextPacket === undefined || isContextPacket(value.contextPacket))
+			);
+		case "task.blocked":
+			return typeof value.taskId === "string" && typeof value.reason === "string";
+		case "task.completed":
+			return typeof value.taskId === "string" && typeof value.summary === "string";
+		case "task.failed":
+			return typeof value.taskId === "string" && typeof value.error === "string";
+		default:
+			return false;
+	}
+}
+
+/** Parse and validate an event received over the wire. */
 export function parseAgentEvent(text: string): AgentEvent | undefined {
 	try {
-		const parsed = JSON.parse(text) as AgentEvent;
-		if (!parsed || typeof parsed !== "object" || !("type" in parsed)) return undefined;
-		return parsed;
+		const parsed: unknown = JSON.parse(text);
+		return isAgentEvent(parsed) ? parsed : undefined;
 	} catch (error) {
 		logger.debug("Failed to parse agent event", {
 			error: error instanceof Error ? error.message : String(error),

--- a/packages/desktop-tag/src/extension.ts
+++ b/packages/desktop-tag/src/extension.ts
@@ -5,9 +5,11 @@ import { logger } from "@pk-nerdsaver-ai/pi-utils";
 
 import { CaptureService } from "./context";
 import { type CapabilityRegistry, createDefaultRegistry, routeContext, updateAvailability } from "./router";
-import type { CaptureMode, ContextPacket } from "./types";
+import type { CaptureMode, CaptureRegion, ContextPacket } from "./types";
 
 const MODES: CaptureMode[] = ["screen", "window", "region", "browser"];
+
+const DEFAULT_REQUEST = "Describe what is on my screen.";
 
 /** Default factory function loaded by the pi extension system. */
 export default function desktopTagExtension(pi: ExtensionAPI): void {
@@ -19,8 +21,14 @@ export default function desktopTagExtension(pi: ExtensionAPI): void {
 	pi.registerCommand("tag", {
 		description: "Capture desktop context and send it to the agent",
 		async handler(args, ctx) {
-			const { mode, request } = parseCommandArgs(args);
-			await captureAndSend(pi, ctx, captureService, registry, mode, request);
+			try {
+				const { mode, request, region } = parseCommandArgs(args);
+				await captureAndSend(pi, ctx, captureService, registry, mode, request, region);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				logger.error("desktop-tag command rejected", { error: message });
+				if (ctx.hasUI) ctx.ui.notify(message, "error");
+			}
 		},
 	});
 
@@ -40,11 +48,12 @@ async function captureAndSend(
 	registry: CapabilityRegistry,
 	mode: CaptureMode,
 	userRequest: string,
+	region?: CaptureRegion,
 ): Promise<void> {
 	try {
 		if (ctx.hasUI) ctx.ui.setStatus("desktop-tag", "Capturing desktop context...");
 
-		const packet = await captureService.capture({ mode, userRequest, includeClipboard: true });
+		const packet = await captureService.capture({ mode, userRequest, region, includeClipboard: true });
 		await updateAvailability(registry);
 		const routing = routeContext(registry, packet);
 
@@ -58,10 +67,11 @@ async function captureAndSend(
 		}
 
 		pi.sendUserMessage(content);
-		if (ctx.hasUI) ctx.ui.setStatus("desktop-tag", undefined);
 	} catch (error) {
 		logger.error("desktop-tag extension failed", { error: error instanceof Error ? error.message : String(error) });
 		if (ctx.hasUI) ctx.ui.notify("Failed to capture desktop context", "error");
+	} finally {
+		if (ctx.hasUI) ctx.ui.setStatus("desktop-tag", undefined);
 	}
 }
 
@@ -90,11 +100,34 @@ async function loadImage(path: string): Promise<ImageContent> {
 	return { type: "image", data: bytes.toBase64(), mimeType: "image/png", detail: "high" };
 }
 
-function parseCommandArgs(args: string): { mode: CaptureMode; request: string } {
+export interface ParsedTagCommand {
+	mode: CaptureMode;
+	request: string;
+	region?: CaptureRegion;
+}
+
+const REGION_USAGE = "Usage: /tag region <x> <y> <width> <height> [request]";
+
+export function parseCommandArgs(args: string): ParsedTagCommand {
 	const tokens = args.trim().split(/\s+/).filter(Boolean);
 	const firstMode = tokens[0] as CaptureMode | undefined;
-	if (firstMode && MODES.includes(firstMode)) {
-		return { mode: firstMode, request: tokens.slice(1).join(" ") };
+	if (firstMode === "region") {
+		if (tokens.length < 5) throw new TypeError(REGION_USAGE);
+		const [x, y, width, height] = tokens.slice(1, 5).map(Number);
+		if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(width) || !Number.isFinite(height)) {
+			throw new TypeError(`${REGION_USAGE}. Coordinates must be finite numbers.`);
+		}
+		if (width <= 0 || height <= 0) {
+			throw new TypeError(`${REGION_USAGE}. Width and height must be positive.`);
+		}
+		return {
+			mode: "region",
+			region: { x, y, width, height },
+			request: tokens.slice(5).join(" ") || DEFAULT_REQUEST,
+		};
 	}
-	return { mode: "screen", request: args.trim() };
+	if (firstMode && MODES.includes(firstMode)) {
+		return { mode: firstMode, request: tokens.slice(1).join(" ") || DEFAULT_REQUEST };
+	}
+	return { mode: "screen", request: args.trim() || DEFAULT_REQUEST };
 }

--- a/packages/desktop-tag/src/extension.ts
+++ b/packages/desktop-tag/src/extension.ts
@@ -1,0 +1,102 @@
+import * as fs from "node:fs/promises";
+
+import type { ImageContent, TextContent } from "@pk-nerdsaver-ai/pi-ai";
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@pk-nerdsaver-ai/pi-coding-agent/extensibility/extensions";
+import { logger } from "@pk-nerdsaver-ai/pi-utils";
+
+import { CaptureService } from "./context";
+import { createDefaultRegistry, routeContext, updateAvailability } from "./router";
+import type { CaptureMode } from "./types";
+
+const MODES: CaptureMode[] = ["screen", "window", "region", "browser"];
+
+/** Default factory function loaded by the pi extension system. */
+export default function desktopTagExtension(pi: ExtensionAPI): void {
+	const captureService = new CaptureService();
+	const registry = createDefaultRegistry();
+
+	pi.setLabel("Desktop Tag");
+
+	pi.registerCommand("tag", {
+		description: "Capture desktop context and send it to the agent",
+		async handler(args, ctx) {
+			const { mode, request } = parseCommandArgs(args, ctx);
+			await captureAndSend(pi, ctx, captureService, registry, mode, request);
+		},
+	});
+
+	pi.registerShortcut("ctrl+shift+space" as KeyId, {
+		description: "Capture the screen and tag the agent",
+		async handler(ctx) {
+			const request = ctx.hasUI ? await ctx.ui.input("What should pi do with this screen?") : "";
+			await captureAndSend(pi, ctx, captureService, registry, "screen", request ?? "");
+		},
+	});
+}
+
+async function captureAndSend(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	captureService: CaptureService,
+	registry: ReturnType<typeof createDefaultRegistry>,
+	mode: CaptureMode,
+	userRequest: string,
+): Promise<void> {
+	try {
+		if (ctx.hasUI) ctx.ui.setStatus("desktop-tag", "Capturing desktop context...");
+
+		const packet = await captureService.capture({ mode, userRequest, includeClipboard: true });
+		await updateAvailability(registry);
+		const routing = routeContext(registry, packet);
+
+		const content: (TextContent | ImageContent)[] = [
+			{ type: "text", text: buildPromptText(packet, routing.message) },
+		];
+
+		if (packet.visual.screenshotPath) {
+			const image = await loadImage(packet.visual.screenshotPath);
+			content.push(image);
+		}
+
+		pi.sendUserMessage(content);
+		if (ctx.hasUI) ctx.ui.setStatus("desktop-tag", undefined);
+	} catch (error) {
+		logger.error("desktop-tag extension failed", { error: error instanceof Error ? error.message : String(error) });
+		if (ctx.hasUI) ctx.ui.notify("Failed to capture desktop context", "error");
+	}
+}
+
+function buildPromptText(packet: Awaited<ReturnType<CaptureService["capture"]>>, routingMessage: string): string {
+	const lines = [
+		`[desktop-tag] ${routingMessage}`,
+		`Capture mode: ${packet.captureMode}`,
+		`User request: ${packet.userRequest}`,
+	];
+	if (packet.foregroundApp.processName) {
+		lines.push(`Foreground app: ${packet.foregroundApp.processName} — ${packet.foregroundApp.windowTitle ?? "unknown window"}`);
+	}
+	if (packet.browser.url) {
+		lines.push(`Browser tab: ${packet.browser.title ?? ""} (${packet.browser.url})`);
+	}
+	if (packet.selection.clipboardText) {
+		lines.push(`Selection/clipboard: ${packet.selection.clipboardText}`);
+	}
+	return lines.join("\n");
+}
+
+async function loadImage(path: string): Promise<ImageContent> {
+	const bytes = await fs.readFile(path);
+	return { type: "image", data: bytes.toString("base64"), mimeType: "image/png", detail: "high" };
+}
+
+function parseCommandArgs(args: string, ctx: ExtensionCommandContext): { mode: CaptureMode; request: string } {
+	const tokens = args.trim().split(/\s+/).filter(Boolean);
+	const firstMode = tokens[0] as CaptureMode | undefined;
+	if (firstMode && MODES.includes(firstMode)) {
+		return { mode: firstMode, request: tokens.slice(1).join(" ") };
+	}
+	return { mode: "screen", request: args.trim() };
+}
+
+// KeyId is intentionally a branded string type; cast the shortcut literal.
+type KeyId = import("@pk-nerdsaver-ai/pi-tui").KeyId;

--- a/packages/desktop-tag/src/extension.ts
+++ b/packages/desktop-tag/src/extension.ts
@@ -1,12 +1,11 @@
-import * as fs from "node:fs/promises";
-
 import type { ImageContent, TextContent } from "@pk-nerdsaver-ai/pi-ai";
-import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@pk-nerdsaver-ai/pi-coding-agent/extensibility/extensions";
+import type { ExtensionAPI, ExtensionContext } from "@pk-nerdsaver-ai/pi-coding-agent/extensibility/extensions";
+import type { KeyId } from "@pk-nerdsaver-ai/pi-tui";
 import { logger } from "@pk-nerdsaver-ai/pi-utils";
 
 import { CaptureService } from "./context";
-import { createDefaultRegistry, routeContext, updateAvailability } from "./router";
-import type { CaptureMode } from "./types";
+import { type CapabilityRegistry, createDefaultRegistry, routeContext, updateAvailability } from "./router";
+import type { CaptureMode, ContextPacket } from "./types";
 
 const MODES: CaptureMode[] = ["screen", "window", "region", "browser"];
 
@@ -20,7 +19,7 @@ export default function desktopTagExtension(pi: ExtensionAPI): void {
 	pi.registerCommand("tag", {
 		description: "Capture desktop context and send it to the agent",
 		async handler(args, ctx) {
-			const { mode, request } = parseCommandArgs(args, ctx);
+			const { mode, request } = parseCommandArgs(args);
 			await captureAndSend(pi, ctx, captureService, registry, mode, request);
 		},
 	});
@@ -38,7 +37,7 @@ async function captureAndSend(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,
 	captureService: CaptureService,
-	registry: ReturnType<typeof createDefaultRegistry>,
+	registry: CapabilityRegistry,
 	mode: CaptureMode,
 	userRequest: string,
 ): Promise<void> {
@@ -66,14 +65,16 @@ async function captureAndSend(
 	}
 }
 
-function buildPromptText(packet: Awaited<ReturnType<CaptureService["capture"]>>, routingMessage: string): string {
+function buildPromptText(packet: ContextPacket, routingMessage: string): string {
 	const lines = [
 		`[desktop-tag] ${routingMessage}`,
 		`Capture mode: ${packet.captureMode}`,
 		`User request: ${packet.userRequest}`,
 	];
 	if (packet.foregroundApp.processName) {
-		lines.push(`Foreground app: ${packet.foregroundApp.processName} — ${packet.foregroundApp.windowTitle ?? "unknown window"}`);
+		lines.push(
+			`Foreground app: ${packet.foregroundApp.processName} — ${packet.foregroundApp.windowTitle ?? "unknown window"}`,
+		);
 	}
 	if (packet.browser.url) {
 		lines.push(`Browser tab: ${packet.browser.title ?? ""} (${packet.browser.url})`);
@@ -85,11 +86,11 @@ function buildPromptText(packet: Awaited<ReturnType<CaptureService["capture"]>>,
 }
 
 async function loadImage(path: string): Promise<ImageContent> {
-	const bytes = await fs.readFile(path);
-	return { type: "image", data: bytes.toString("base64"), mimeType: "image/png", detail: "high" };
+	const bytes = await Bun.file(path).bytes();
+	return { type: "image", data: bytes.toBase64(), mimeType: "image/png", detail: "high" };
 }
 
-function parseCommandArgs(args: string, ctx: ExtensionCommandContext): { mode: CaptureMode; request: string } {
+function parseCommandArgs(args: string): { mode: CaptureMode; request: string } {
 	const tokens = args.trim().split(/\s+/).filter(Boolean);
 	const firstMode = tokens[0] as CaptureMode | undefined;
 	if (firstMode && MODES.includes(firstMode)) {
@@ -97,6 +98,3 @@ function parseCommandArgs(args: string, ctx: ExtensionCommandContext): { mode: C
 	}
 	return { mode: "screen", request: args.trim() };
 }
-
-// KeyId is intentionally a branded string type; cast the shortcut literal.
-type KeyId = import("@pk-nerdsaver-ai/pi-tui").KeyId;

--- a/packages/desktop-tag/src/gateway.ts
+++ b/packages/desktop-tag/src/gateway.ts
@@ -1,0 +1,282 @@
+import * as path from "node:path";
+
+import { logger } from "@pk-nerdsaver-ai/pi-utils";
+
+import { CaptureService } from "./context";
+import { serializeAgentEvent, parseAgentEvent } from "./events";
+import { createDefaultRegistry, routeContext, updateAvailability, type CapabilityRegistry } from "./router";
+import type { AgentEvent, AgentWorker, ApprovalDecision, CaptureMode, ContextPacket } from "./types";
+import { PiWorker } from "./worker";
+
+interface ServerOptions {
+	port: number;
+	hostname?: string;
+	overlayHtmlPath?: string;
+}
+
+interface SocketData {
+	taskId?: string;
+	pumpAbort?: AbortController;
+}
+
+/** Local gateway that serves the overlay and wires it to an {@link AgentWorker}. */
+export class TagGatewayServer {
+	readonly captureService: CaptureService;
+	readonly registry: CapabilityRegistry;
+	readonly worker: AgentWorker;
+	readonly #options: ServerOptions;
+	#server?: Bun.Server<SocketData>;
+	#overlayHtml?: string;
+
+	constructor(options: ServerOptions) {
+		this.#options = options;
+		this.captureService = new CaptureService();
+		this.registry = createDefaultRegistry();
+		this.worker = new PiWorker();
+	}
+
+	start(): Bun.Server<SocketData> {
+		const server = Bun.serve<SocketData>({
+			port: this.#options.port,
+			hostname: this.#options.hostname ?? "127.0.0.1",
+			fetch: (req, server) => this.#handleFetch(req, server),
+			websocket: {
+				open: ws => {
+					logger.debug("Overlay connected");
+					ws.data = {} as SocketData;
+				},
+				message: (ws, message) => this.#handleSocketMessage(ws, message),
+				close: (ws, code, reason) => this.#handleSocketClose(ws, code, reason),
+			},
+		});
+
+		this.#server = server;
+		logger.info("Tag gateway listening", { url: `http://${server.hostname}:${server.port}` });
+		return server;
+	}
+
+	stop(): void {
+		this.#server?.stop(true);
+		this.#server = undefined;
+	}
+
+	get url(): string {
+		if (!this.#server) return "";
+		return `http://${this.#server.hostname}:${this.#server.port}`;
+	}
+
+	async #handleFetch(req: Request, server: Bun.Server<SocketData>): Promise<Response | undefined> {
+		const url = new URL(req.url);
+
+		if (url.pathname === "/ws") {
+			const upgraded = server.upgrade(req, { data: {} as SocketData });
+			if (upgraded) return undefined;
+			return new Response("WebSocket upgrade failed", { status: 400 });
+		}
+
+		if (url.pathname.startsWith("/api/")) {
+			return this.#handleApi(req, url.pathname);
+		}
+
+		const html = await this.#getOverlayHtml();
+		return new Response(html, { headers: { "Content-Type": "text/html" } });
+	}
+
+	async #handleApi(req: Request, pathname: string): Promise<Response> {
+		if (req.method !== "POST") {
+			return new Response("Method not allowed", { status: 405 });
+		}
+		let body: unknown;
+		try {
+			body = await req.json();
+		} catch {
+			return new Response("Invalid JSON", { status: 400 });
+		}
+
+		if (pathname === "/api/capture") {
+			const result = await this.#runCapture(body);
+			return Response.json(result, { status: result.ok ? 200 : 400 });
+		}
+
+		return new Response("Not found", { status: 404 });
+	}
+
+	async #handleSocketMessage(ws: Bun.ServerWebSocket<SocketData>, raw: string | Buffer): Promise<void> {
+		const message = typeof raw === "string" ? parseClientMessage(raw) : undefined;
+		if (!message) {
+			ws.send(JSON.stringify({ type: "protocol_error", error: "expected JSON text message" }));
+			return;
+		}
+
+		switch (message.type) {
+			case "capture": {
+				const { mode, userRequest, includeClipboard } = message;
+				const taskId = crypto.randomUUID();
+				await this.#startTask(ws, taskId, mode, userRequest, includeClipboard ?? true);
+				break;
+			}
+			case "message": {
+				if (!ws.data.taskId) return;
+				await this.worker.sendMessage(ws.data.taskId, message.text);
+				break;
+			}
+			case "approve": {
+				if (!ws.data.taskId) return;
+				const decision: ApprovalDecision = {
+					allowed: message.allowed,
+					scope: message.scope,
+					editedArguments: message.editedArguments,
+				};
+				await this.worker.approve(ws.data.taskId, message.actionId, decision);
+				break;
+			}
+			case "cancel": {
+				if (!ws.data.taskId) return;
+				await this.worker.cancel(ws.data.taskId);
+				break;
+			}
+			default:
+				send(ws, { type: "task.failed", taskId: ws.data.taskId ?? "", error: "Unknown message type" });
+		}
+	}
+
+	async #startTask(
+		ws: Bun.ServerWebSocket<SocketData>,
+		taskId: string,
+		mode: CaptureMode,
+		userRequest: string,
+		includeClipboard: boolean,
+	): Promise<void> {
+		this.#closeTask(ws);
+		ws.data.taskId = taskId;
+
+		try {
+			const packet = await this.captureService.capture({ mode, userRequest, includeClipboard });
+			await updateAvailability(this.registry);
+			const routing = routeContext(this.registry, packet);
+
+			send(ws, { type: "task.started", taskId });
+			send(ws, { type: "agent.message.delta", text: routing.message });
+
+			await this.worker.createSession(taskId, { contextPacket: packet, routing });
+
+			const abortController = new AbortController();
+			ws.data.pumpAbort = abortController;
+			void this.#pumpEvents(ws, taskId, abortController.signal);
+		} catch (error) {
+			logger.error("Failed to start desktop task", { error: error instanceof Error ? error.message : String(error) });
+			send(ws, { type: "task.failed", taskId, error: error instanceof Error ? error.message : String(error) });
+		}
+	}
+
+	#closeTask(ws: Bun.ServerWebSocket<SocketData>): void {
+		if (ws.data.taskId) {
+			ws.data.pumpAbort?.abort();
+			ws.data.taskId = undefined;
+			ws.data.pumpAbort = undefined;
+		}
+	}
+
+	async #pumpEvents(ws: Bun.ServerWebSocket<SocketData>, taskId: string, signal: AbortSignal): Promise<void> {
+		try {
+			for await (const event of this.worker.subscribe(taskId)) {
+				if (signal.aborted) return;
+				send(ws, event);
+			}
+		} catch (error) {
+			if (signal.aborted) return;
+			logger.error("Event pump error", { error: error instanceof Error ? error.message : String(error) });
+		}
+	}
+
+	#handleSocketClose(ws: Bun.ServerWebSocket<SocketData>, code: number, reason: string): void {
+		logger.debug("Overlay disconnected", { code, reason });
+		this.#closeTask(ws);
+	}
+
+	async #runCapture(body: unknown): Promise<{ ok: boolean; taskId?: string; error?: string; packet?: ContextPacket }> {
+		const parsed = parseCaptureBody(body);
+		if (!parsed.ok) return { ok: false, error: parsed.error };
+
+		try {
+			const packet = await this.captureService.capture(parsed.options);
+			await updateAvailability(this.registry);
+			const routing = routeContext(this.registry, packet);
+			const taskId = crypto.randomUUID();
+			return { ok: true, taskId, packet, routing: routing as unknown as Record<string, unknown> } as {
+				ok: boolean;
+				taskId?: string;
+				error?: string;
+				packet?: ContextPacket;
+			};
+		} catch (error) {
+			return { ok: false, error: error instanceof Error ? error.message : String(error) };
+		}
+	}
+
+	async #getOverlayHtml(): Promise<string> {
+		if (this.#overlayHtml) return this.#overlayHtml;
+		const filePath = this.#options.overlayHtmlPath ?? path.join(import.meta.dir, "overlay.html");
+		const file = Bun.file(filePath);
+		this.#overlayHtml = await file.text();
+		return this.#overlayHtml;
+	}
+}
+
+function send(ws: Bun.ServerWebSocket<SocketData>, event: AgentEvent): void {
+	try {
+		ws.send(serializeAgentEvent(event));
+	} catch (error) {
+		logger.debug("Failed to send event to overlay", { error: error instanceof Error ? error.message : String(error) });
+	}
+}
+
+interface ClientCaptureMessage {
+	type: "capture";
+	mode: CaptureMode;
+	userRequest: string;
+	includeClipboard?: boolean;
+}
+
+interface ClientTextMessage {
+	type: "message";
+	text: string;
+}
+
+interface ClientApproveMessage {
+	type: "approve";
+	actionId: string;
+	allowed: boolean;
+	scope?: "once" | "group" | "session" | "application";
+	editedArguments?: Record<string, unknown>;
+}
+
+interface ClientCancelMessage {
+	type: "cancel";
+}
+
+type ClientMessage = ClientCaptureMessage | ClientTextMessage | ClientApproveMessage | ClientCancelMessage;
+
+function parseClientMessage(raw: string): ClientMessage | undefined {
+	const parsed = parseAgentEvent(raw) as ClientMessage | undefined;
+	if (!parsed || typeof parsed !== "object" || !("type" in parsed)) return undefined;
+	return parsed;
+}
+
+function parseCaptureBody(body: unknown):
+	| { ok: true; options: { mode: CaptureMode; userRequest: string; includeClipboard: boolean } }
+	| { ok: false; error: string } {
+	if (!body || typeof body !== "object") return { ok: false, error: "body must be an object" };
+	const record = body as Record<string, unknown>;
+	const mode = record.mode;
+	if (typeof mode !== "string" || !["screen", "window", "region", "browser"].includes(mode)) {
+		return { ok: false, error: "mode must be one of screen, window, region, browser" };
+	}
+	const userRequest = record.userRequest;
+	if (typeof userRequest !== "string" || !userRequest.trim()) {
+		return { ok: false, error: "userRequest must be a non-empty string" };
+	}
+	const includeClipboard = record.includeClipboard ?? true;
+	if (typeof includeClipboard !== "boolean") return { ok: false, error: "includeClipboard must be a boolean" };
+	return { ok: true, options: { mode: mode as CaptureMode, userRequest, includeClipboard } };
+}

--- a/packages/desktop-tag/src/gateway.ts
+++ b/packages/desktop-tag/src/gateway.ts
@@ -3,15 +3,18 @@ import * as path from "node:path";
 import { logger } from "@pk-nerdsaver-ai/pi-utils";
 
 import { CaptureService } from "./context";
-import { serializeAgentEvent, parseAgentEvent } from "./events";
-import { createDefaultRegistry, routeContext, updateAvailability, type CapabilityRegistry } from "./router";
+import { parseAgentEvent, serializeAgentEvent } from "./events";
+import { type CapabilityRegistry, createDefaultRegistry, routeContext, updateAvailability } from "./router";
 import type { AgentEvent, AgentWorker, ApprovalDecision, CaptureMode, ContextPacket } from "./types";
 import { PiWorker } from "./worker";
 
-interface ServerOptions {
+export interface ServerOptions {
 	port: number;
 	hostname?: string;
 	overlayHtmlPath?: string;
+	captureService?: CaptureService;
+	registry?: CapabilityRegistry;
+	worker?: AgentWorker;
 }
 
 interface SocketData {
@@ -19,26 +22,32 @@ interface SocketData {
 	pumpAbort?: AbortController;
 }
 
+const LOOPBACK_HOSTNAMES: Readonly<Record<string, true>> = { "127.0.0.1": true, localhost: true, "::1": true };
+
 /** Local gateway that serves the overlay and wires it to an {@link AgentWorker}. */
 export class TagGatewayServer {
 	readonly captureService: CaptureService;
 	readonly registry: CapabilityRegistry;
 	readonly worker: AgentWorker;
 	readonly #options: ServerOptions;
+	readonly #activeTasks = new Map<string, { socket: Bun.ServerWebSocket<SocketData>; pumpAbort: AbortController }>();
 	#server?: Bun.Server<SocketData>;
 	#overlayHtml?: string;
-
 	constructor(options: ServerOptions) {
 		this.#options = options;
-		this.captureService = new CaptureService();
-		this.registry = createDefaultRegistry();
-		this.worker = new PiWorker();
+		this.captureService = options.captureService ?? new CaptureService();
+		this.registry = options.registry ?? createDefaultRegistry();
+		this.worker = options.worker ?? new PiWorker();
 	}
 
 	start(): Bun.Server<SocketData> {
+		const hostname = this.#options.hostname ?? "127.0.0.1";
+		if (!isLoopbackHostname(hostname)) {
+			throw new Error(`Desktop tag gateway must bind to a loopback host, received: ${hostname}`);
+		}
 		const server = Bun.serve<SocketData>({
 			port: this.#options.port,
-			hostname: this.#options.hostname ?? "127.0.0.1",
+			hostname,
 			fetch: (req, server) => this.#handleFetch(req, server),
 			websocket: {
 				open: ws => {
@@ -46,35 +55,44 @@ export class TagGatewayServer {
 					ws.data = {} as SocketData;
 				},
 				message: (ws, message) => this.#handleSocketMessage(ws, message),
-				close: (ws, code, reason) => this.#handleSocketClose(ws, code, reason),
+				close: (ws, code, reason) => void this.#handleSocketClose(ws, code, reason),
 			},
 		});
 
 		this.#server = server;
-		logger.info("Tag gateway listening", { url: `http://${server.hostname}:${server.port}` });
+		logger.info("Tag gateway listening", { url: this.url });
 		return server;
 	}
 
 	stop(): void {
+		for (const { socket } of this.#activeTasks.values()) void this.#closeTask(socket);
 		this.#server?.stop(true);
 		this.#server = undefined;
 	}
 
 	get url(): string {
 		if (!this.#server) return "";
-		return `http://${this.#server.hostname}:${this.#server.port}`;
+		return `http://${formatUrlHostname(this.#server.hostname ?? this.#options.hostname ?? "127.0.0.1")}:${this.#server.port ?? this.#options.port}`;
 	}
 
 	async #handleFetch(req: Request, server: Bun.Server<SocketData>): Promise<Response | undefined> {
 		const url = new URL(req.url);
+		const serverPort = server.port;
+		if (serverPort === undefined) return new Response("Gateway port unavailable", { status: 503 });
 
 		if (url.pathname === "/ws") {
+			if (!isAllowedWebSocketOrigin(req.headers.get("Origin"), serverPort)) {
+				return new Response("WebSocket origin forbidden", { status: 403 });
+			}
 			const upgraded = server.upgrade(req, { data: {} as SocketData });
 			if (upgraded) return undefined;
 			return new Response("WebSocket upgrade failed", { status: 400 });
 		}
 
 		if (url.pathname.startsWith("/api/")) {
+			if (!isAllowedWebSocketOrigin(req.headers.get("Origin"), serverPort)) {
+				return new Response("Origin forbidden", { status: 403 });
+			}
 			return this.#handleApi(req, url.pathname);
 		}
 
@@ -147,33 +165,68 @@ export class TagGatewayServer {
 		userRequest: string,
 		includeClipboard: boolean,
 	): Promise<void> {
-		this.#closeTask(ws);
+		const previousTaskId = this.#detachTask(ws);
+		const abortController = new AbortController();
 		ws.data.taskId = taskId;
+		ws.data.pumpAbort = abortController;
+		this.#activeTasks.set(taskId, { socket: ws, pumpAbort: abortController });
+		if (previousTaskId) await this.#cancelWorkerTask(previousTaskId);
 
 		try {
 			const packet = await this.captureService.capture({ mode, userRequest, includeClipboard });
+			if (!this.#isCurrentTask(ws, taskId)) return;
 			await updateAvailability(this.registry);
+			if (!this.#isCurrentTask(ws, taskId)) return;
 			const routing = routeContext(this.registry, packet);
 
 			send(ws, { type: "task.started", taskId });
 			send(ws, { type: "agent.message.delta", text: routing.message });
 
 			await this.worker.createSession(taskId, { contextPacket: packet, routing });
+			if (!this.#isCurrentTask(ws, taskId)) {
+				await this.#cancelWorkerTask(taskId);
+				return;
+			}
 
-			const abortController = new AbortController();
-			ws.data.pumpAbort = abortController;
 			void this.#pumpEvents(ws, taskId, abortController.signal);
 		} catch (error) {
-			logger.error("Failed to start desktop task", { error: error instanceof Error ? error.message : String(error) });
+			if (!this.#isCurrentTask(ws, taskId)) return;
+			logger.error("Failed to start desktop task", {
+				error: error instanceof Error ? error.message : String(error),
+			});
 			send(ws, { type: "task.failed", taskId, error: error instanceof Error ? error.message : String(error) });
+			await this.#closeTask(ws);
 		}
 	}
 
-	#closeTask(ws: Bun.ServerWebSocket<SocketData>): void {
-		if (ws.data.taskId) {
-			ws.data.pumpAbort?.abort();
-			ws.data.taskId = undefined;
-			ws.data.pumpAbort = undefined;
+	async #closeTask(ws: Bun.ServerWebSocket<SocketData>): Promise<void> {
+		const taskId = this.#detachTask(ws);
+		if (taskId) await this.#cancelWorkerTask(taskId);
+	}
+
+	#detachTask(ws: Bun.ServerWebSocket<SocketData>): string | undefined {
+		const taskId = ws.data.taskId;
+		if (!taskId) return undefined;
+
+		ws.data.pumpAbort?.abort();
+		ws.data.taskId = undefined;
+		ws.data.pumpAbort = undefined;
+		this.#activeTasks.delete(taskId);
+		return taskId;
+	}
+
+	#isCurrentTask(ws: Bun.ServerWebSocket<SocketData>, taskId: string): boolean {
+		return ws.data.taskId === taskId && !ws.data.pumpAbort?.signal.aborted;
+	}
+
+	async #cancelWorkerTask(taskId: string): Promise<void> {
+		try {
+			await this.worker.cancel(taskId);
+		} catch (error) {
+			logger.debug("Failed to cancel desktop task", {
+				taskId,
+				error: error instanceof Error ? error.message : String(error),
+			});
 		}
 	}
 
@@ -186,12 +239,18 @@ export class TagGatewayServer {
 		} catch (error) {
 			if (signal.aborted) return;
 			logger.error("Event pump error", { error: error instanceof Error ? error.message : String(error) });
+		} finally {
+			this.#activeTasks.delete(taskId);
+			if (ws.data.taskId === taskId) {
+				ws.data.taskId = undefined;
+				ws.data.pumpAbort = undefined;
+			}
 		}
 	}
 
-	#handleSocketClose(ws: Bun.ServerWebSocket<SocketData>, code: number, reason: string): void {
+	async #handleSocketClose(ws: Bun.ServerWebSocket<SocketData>, code: number, reason: string): Promise<void> {
 		logger.debug("Overlay disconnected", { code, reason });
-		this.#closeTask(ws);
+		await this.#closeTask(ws);
 	}
 
 	async #runCapture(body: unknown): Promise<{ ok: boolean; taskId?: string; error?: string; packet?: ContextPacket }> {
@@ -223,11 +282,35 @@ export class TagGatewayServer {
 	}
 }
 
+function formatUrlHostname(hostname: string): string {
+	return hostname.includes(":") ? `[${hostname}]` : hostname;
+}
+
+export function isLoopbackHostname(hostname: string): boolean {
+	const normalized = hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+	return LOOPBACK_HOSTNAMES[normalized.toLowerCase()] === true;
+}
+
+export function isAllowedWebSocketOrigin(origin: string | null, port: number): boolean {
+	if (origin === null) return true;
+
+	try {
+		const parsed = new URL(origin);
+		if (parsed.origin !== origin || parsed.protocol !== "http:" || !isLoopbackHostname(parsed.hostname)) return false;
+		const originPort = parsed.port ? Number.parseInt(parsed.port, 10) : 80;
+		return originPort === port;
+	} catch {
+		return false;
+	}
+}
+
 function send(ws: Bun.ServerWebSocket<SocketData>, event: AgentEvent): void {
 	try {
 		ws.send(serializeAgentEvent(event));
 	} catch (error) {
-		logger.debug("Failed to send event to overlay", { error: error instanceof Error ? error.message : String(error) });
+		logger.debug("Failed to send event to overlay", {
+			error: error instanceof Error ? error.message : String(error),
+		});
 	}
 }
 
@@ -263,7 +346,9 @@ function parseClientMessage(raw: string): ClientMessage | undefined {
 	return parsed;
 }
 
-function parseCaptureBody(body: unknown):
+function parseCaptureBody(
+	body: unknown,
+):
 	| { ok: true; options: { mode: CaptureMode; userRequest: string; includeClipboard: boolean } }
 	| { ok: false; error: string } {
 	if (!body || typeof body !== "object") return { ok: false, error: "body must be an object" };

--- a/packages/desktop-tag/src/gateway.ts
+++ b/packages/desktop-tag/src/gateway.ts
@@ -3,9 +3,9 @@ import * as path from "node:path";
 import { logger } from "@pk-nerdsaver-ai/pi-utils";
 
 import { CaptureService } from "./context";
-import { parseAgentEvent, serializeAgentEvent } from "./events";
+import { serializeAgentEvent } from "./events";
 import { type CapabilityRegistry, createDefaultRegistry, routeContext, updateAvailability } from "./router";
-import type { AgentEvent, AgentWorker, ApprovalDecision, CaptureMode, ContextPacket } from "./types";
+import type { AgentEvent, AgentWorker, ApprovalDecision, CaptureMode, CaptureRegion, ContextPacket } from "./types";
 import { PiWorker } from "./worker";
 
 export interface ServerOptions {
@@ -31,8 +31,11 @@ export class TagGatewayServer {
 	readonly worker: AgentWorker;
 	readonly #options: ServerOptions;
 	readonly #activeTasks = new Map<string, { socket: Bun.ServerWebSocket<SocketData>; pumpAbort: AbortController }>();
+	readonly #inFlightOperations = new Set<Promise<void>>();
 	#server?: Bun.Server<SocketData>;
+	#stopPromise?: Promise<void>;
 	#overlayHtml?: string;
+	#stopping = false;
 	constructor(options: ServerOptions) {
 		this.#options = options;
 		this.captureService = options.captureService ?? new CaptureService();
@@ -41,10 +44,12 @@ export class TagGatewayServer {
 	}
 
 	start(): Bun.Server<SocketData> {
+		if (this.#stopPromise) throw new Error("Desktop tag gateway shutdown is still in progress");
 		const hostname = this.#options.hostname ?? "127.0.0.1";
 		if (!isLoopbackHostname(hostname)) {
 			throw new Error(`Desktop tag gateway must bind to a loopback host, received: ${hostname}`);
 		}
+		this.#stopping = false;
 		const server = Bun.serve<SocketData>({
 			port: this.#options.port,
 			hostname,
@@ -54,8 +59,11 @@ export class TagGatewayServer {
 					logger.debug("Overlay connected");
 					ws.data = {} as SocketData;
 				},
-				message: (ws, message) => this.#handleSocketMessage(ws, message),
-				close: (ws, code, reason) => void this.#handleSocketClose(ws, code, reason),
+				message: (ws, message) => {
+					if (this.#stopping) return;
+					this.#trackSocketOperation(this.#handleSocketMessage(ws, message));
+				},
+				close: (ws, code, reason) => this.#trackSocketOperation(this.#handleSocketClose(ws, code, reason)),
 			},
 		});
 
@@ -64,10 +72,54 @@ export class TagGatewayServer {
 		return server;
 	}
 
-	stop(): void {
-		for (const { socket } of this.#activeTasks.values()) void this.#closeTask(socket);
-		this.#server?.stop(true);
+	stop(): Promise<void> {
+		if (this.#stopPromise) return this.#stopPromise;
+		this.#stopping = true;
+		const stopping = this.#finishStop();
+		this.#stopPromise = stopping;
+		void stopping.then(
+			() => {
+				if (this.#stopPromise === stopping) this.#stopPromise = undefined;
+			},
+			() => {
+				if (this.#stopPromise === stopping) this.#stopPromise = undefined;
+			},
+		);
+		return stopping;
+	}
+
+	async #finishStop(): Promise<void> {
+		const server = this.#server;
 		this.#server = undefined;
+		const sockets = new Set([...this.#activeTasks.values()].map(({ socket }) => socket));
+		await Promise.all([...sockets].map(socket => this.#closeTask(socket)));
+		await this.#awaitOperations();
+		await server?.stop(true);
+		await this.#awaitOperations();
+	}
+
+	async #awaitOperations(): Promise<void> {
+		while (this.#inFlightOperations.size > 0) {
+			await Promise.all(this.#inFlightOperations);
+		}
+	}
+
+	#trackSocketOperation(operation: Promise<void>): void {
+		void this.#trackOperation(operation).catch(error => {
+			logger.error("Gateway socket operation failed", {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		});
+	}
+
+	#trackOperation<T>(operation: Promise<T>): Promise<T> {
+		const tracked = operation.then(
+			() => undefined,
+			() => undefined,
+		);
+		this.#inFlightOperations.add(tracked);
+		void tracked.finally(() => this.#inFlightOperations.delete(tracked));
+		return operation;
 	}
 
 	get url(): string {
@@ -81,21 +133,24 @@ export class TagGatewayServer {
 		if (serverPort === undefined) return new Response("Gateway port unavailable", { status: 503 });
 
 		if (url.pathname === "/ws") {
-			if (!isAllowedWebSocketOrigin(req.headers.get("Origin"), serverPort)) {
+			if (!isAllowedWebSocketOrigin(req.headers.get("Origin"), url)) {
 				return new Response("WebSocket origin forbidden", { status: 403 });
 			}
+			if (this.#stopping) return new Response("Gateway is shutting down", { status: 503 });
 			const upgraded = server.upgrade(req, { data: {} as SocketData });
 			if (upgraded) return undefined;
 			return new Response("WebSocket upgrade failed", { status: 400 });
 		}
 
 		if (url.pathname.startsWith("/api/")) {
-			if (!isAllowedWebSocketOrigin(req.headers.get("Origin"), serverPort)) {
+			if (!isAllowedWebSocketOrigin(req.headers.get("Origin"), url)) {
 				return new Response("Origin forbidden", { status: 403 });
 			}
+			if (this.#stopping) return new Response("Gateway is shutting down", { status: 503 });
 			return this.#handleApi(req, url.pathname);
 		}
 
+		if (this.#stopping) return new Response("Gateway is shutting down", { status: 503 });
 		const html = await this.#getOverlayHtml();
 		return new Response(html, { headers: { "Content-Type": "text/html" } });
 	}
@@ -110,9 +165,10 @@ export class TagGatewayServer {
 		} catch {
 			return new Response("Invalid JSON", { status: 400 });
 		}
+		if (this.#stopping) return new Response("Gateway is shutting down", { status: 503 });
 
 		if (pathname === "/api/capture") {
-			const result = await this.#runCapture(body);
+			const result = await this.#trackOperation(this.#runCapture(body));
 			return Response.json(result, { status: result.ok ? 200 : 400 });
 		}
 
@@ -120,17 +176,28 @@ export class TagGatewayServer {
 	}
 
 	async #handleSocketMessage(ws: Bun.ServerWebSocket<SocketData>, raw: string | Buffer): Promise<void> {
-		const message = typeof raw === "string" ? parseClientMessage(raw) : undefined;
-		if (!message) {
-			ws.send(JSON.stringify({ type: "protocol_error", error: "expected JSON text message" }));
+		if (this.#stopping) return;
+		const parsed =
+			typeof raw === "string"
+				? parseClientMessage(raw)
+				: { ok: false as const, error: "expected JSON text message" };
+		if (!parsed.ok) {
+			ws.send(JSON.stringify({ type: "protocol_error", error: parsed.error }));
 			return;
 		}
+		const message = parsed.message;
 
 		switch (message.type) {
 			case "capture": {
-				const { mode, userRequest, includeClipboard } = message;
 				const taskId = crypto.randomUUID();
-				await this.#startTask(ws, taskId, mode, userRequest, includeClipboard ?? true);
+				await this.#startTask(
+					ws,
+					taskId,
+					message.mode,
+					message.request,
+					message.includeClipboard ?? true,
+					message.region,
+				);
 				break;
 			}
 			case "message": {
@@ -143,18 +210,15 @@ export class TagGatewayServer {
 				const decision: ApprovalDecision = {
 					allowed: message.allowed,
 					scope: message.scope,
-					editedArguments: message.editedArguments,
 				};
 				await this.worker.approve(ws.data.taskId, message.actionId, decision);
 				break;
 			}
 			case "cancel": {
-				if (!ws.data.taskId) return;
-				await this.worker.cancel(ws.data.taskId);
+				const taskId = this.#detachTask(ws);
+				if (taskId) await this.#cancelWorkerTask(taskId);
 				break;
 			}
-			default:
-				send(ws, { type: "task.failed", taskId: ws.data.taskId ?? "", error: "Unknown message type" });
 		}
 	}
 
@@ -164,6 +228,7 @@ export class TagGatewayServer {
 		mode: CaptureMode,
 		userRequest: string,
 		includeClipboard: boolean,
+		region?: CaptureRegion,
 	): Promise<void> {
 		const previousTaskId = this.#detachTask(ws);
 		const abortController = new AbortController();
@@ -171,9 +236,10 @@ export class TagGatewayServer {
 		ws.data.pumpAbort = abortController;
 		this.#activeTasks.set(taskId, { socket: ws, pumpAbort: abortController });
 		if (previousTaskId) await this.#cancelWorkerTask(previousTaskId);
+		if (!this.#isCurrentTask(ws, taskId)) return;
 
 		try {
-			const packet = await this.captureService.capture({ mode, userRequest, includeClipboard });
+			const packet = await this.captureService.capture({ mode, userRequest, includeClipboard, region });
 			if (!this.#isCurrentTask(ws, taskId)) return;
 			await updateAvailability(this.registry);
 			if (!this.#isCurrentTask(ws, taskId)) return;
@@ -188,7 +254,7 @@ export class TagGatewayServer {
 				return;
 			}
 
-			void this.#pumpEvents(ws, taskId, abortController.signal);
+			this.#trackSocketOperation(this.#pumpEvents(ws, taskId, abortController.signal));
 		} catch (error) {
 			if (!this.#isCurrentTask(ws, taskId)) return;
 			logger.error("Failed to start desktop task", {
@@ -258,7 +324,7 @@ export class TagGatewayServer {
 		if (!parsed.ok) return { ok: false, error: parsed.error };
 
 		try {
-			const packet = await this.captureService.capture(parsed.options);
+			const packet = await this.captureService.capture(parsed.value);
 			await updateAvailability(this.registry);
 			const routing = routeContext(this.registry, packet);
 			const taskId = crypto.randomUUID();
@@ -291,14 +357,11 @@ export function isLoopbackHostname(hostname: string): boolean {
 	return LOOPBACK_HOSTNAMES[normalized.toLowerCase()] === true;
 }
 
-export function isAllowedWebSocketOrigin(origin: string | null, port: number): boolean {
-	if (origin === null) return true;
-
+export function isAllowedWebSocketOrigin(origin: string | null, requestUrl: string | URL): boolean {
 	try {
-		const parsed = new URL(origin);
-		if (parsed.origin !== origin || parsed.protocol !== "http:" || !isLoopbackHostname(parsed.hostname)) return false;
-		const originPort = parsed.port ? Number.parseInt(parsed.port, 10) : 80;
-		return originPort === port;
+		const url = typeof requestUrl === "string" ? new URL(requestUrl) : requestUrl;
+		if (url.protocol !== "http:" || !isLoopbackHostname(url.hostname)) return false;
+		return origin === null || origin === url.origin;
 	} catch {
 		return false;
 	}
@@ -317,8 +380,9 @@ function send(ws: Bun.ServerWebSocket<SocketData>, event: AgentEvent): void {
 interface ClientCaptureMessage {
 	type: "capture";
 	mode: CaptureMode;
-	userRequest: string;
+	request: string;
 	includeClipboard?: boolean;
+	region?: CaptureRegion;
 }
 
 interface ClientTextMessage {
@@ -330,8 +394,7 @@ interface ClientApproveMessage {
 	type: "approve";
 	actionId: string;
 	allowed: boolean;
-	scope?: "once" | "group" | "session" | "application";
-	editedArguments?: Record<string, unknown>;
+	scope?: "once" | "session";
 }
 
 interface ClientCancelMessage {
@@ -339,29 +402,152 @@ interface ClientCancelMessage {
 }
 
 type ClientMessage = ClientCaptureMessage | ClientTextMessage | ClientApproveMessage | ClientCancelMessage;
+type ParseResult<T> = { ok: true; value: T } | { ok: false; error: string };
 
-function parseClientMessage(raw: string): ClientMessage | undefined {
-	const parsed = parseAgentEvent(raw) as ClientMessage | undefined;
-	if (!parsed || typeof parsed !== "object" || !("type" in parsed)) return undefined;
-	return parsed;
+function parseClientMessage(raw: string): { ok: true; message: ClientMessage } | { ok: false; error: string } {
+	let value: unknown;
+	try {
+		value = JSON.parse(raw);
+	} catch {
+		return { ok: false, error: "expected valid JSON text message" };
+	}
+	if (!isRecord(value) || typeof value.type !== "string")
+		return { ok: false, error: "message must be an object with a type" };
+
+	let result: ParseResult<ClientMessage>;
+	switch (value.type) {
+		case "capture":
+			result = parseCaptureMessage(value);
+			break;
+		case "message":
+			result = parseTextMessage(value);
+			break;
+		case "approve":
+			result = parseApproveMessage(value);
+			break;
+		case "cancel":
+			result = hasOnlyKeys(value, ["type"])
+				? { ok: true, value: { type: "cancel" } }
+				: { ok: false, error: "cancel contains unknown fields" };
+			break;
+		default:
+			return { ok: false, error: "unknown message type" };
+	}
+	return result.ok ? { ok: true, message: result.value } : result;
 }
 
-function parseCaptureBody(
-	body: unknown,
-):
-	| { ok: true; options: { mode: CaptureMode; userRequest: string; includeClipboard: boolean } }
-	| { ok: false; error: string } {
-	if (!body || typeof body !== "object") return { ok: false, error: "body must be an object" };
-	const record = body as Record<string, unknown>;
+function parseCaptureMessage(record: Record<string, unknown>): ParseResult<ClientCaptureMessage> {
+	if (!hasOnlyKeys(record, ["type", "mode", "request", "includeClipboard", "region"])) {
+		return { ok: false, error: "capture contains unknown fields" };
+	}
+	const capture = parseCaptureFields(record);
+	return capture.ok ? { ok: true, value: { type: "capture", ...capture.value } } : capture;
+}
+
+function parseTextMessage(record: Record<string, unknown>): ParseResult<ClientTextMessage> {
+	if (!hasOnlyKeys(record, ["type", "text"])) return { ok: false, error: "message contains unknown fields" };
+	if (typeof record.text !== "string" || !record.text.trim())
+		return { ok: false, error: "text must be a non-empty string" };
+	return { ok: true, value: { type: "message", text: record.text } };
+}
+
+function parseApproveMessage(record: Record<string, unknown>): ParseResult<ClientApproveMessage> {
+	if (record.editedArguments !== undefined) {
+		return { ok: false, error: "editedArguments are not supported by the desktop-tag worker" };
+	}
+	if (!hasOnlyKeys(record, ["type", "actionId", "allowed", "scope"])) {
+		return { ok: false, error: "approve contains unknown fields" };
+	}
+	if (typeof record.actionId !== "string" || !record.actionId.trim()) {
+		return { ok: false, error: "actionId must be a non-empty string" };
+	}
+	if (typeof record.allowed !== "boolean") return { ok: false, error: "allowed must be a boolean" };
+	const scope = record.scope;
+	if (scope !== undefined && scope !== "once" && scope !== "session") {
+		return { ok: false, error: "scope must be once or session" };
+	}
+	return {
+		ok: true,
+		value: {
+			type: "approve",
+			actionId: record.actionId,
+			allowed: record.allowed,
+			scope,
+		},
+	};
+}
+
+function parseCaptureBody(body: unknown): ParseResult<{
+	mode: CaptureMode;
+	userRequest: string;
+	includeClipboard: boolean;
+	region?: CaptureRegion;
+}> {
+	if (!isRecord(body)) return { ok: false, error: "body must be an object" };
+	if (!hasOnlyKeys(body, ["mode", "request", "includeClipboard", "region"])) {
+		return { ok: false, error: "body contains unknown fields" };
+	}
+	const parsed = parseCaptureFields(body);
+	if (!parsed.ok) return parsed;
+	return {
+		ok: true,
+		value: {
+			mode: parsed.value.mode,
+			userRequest: parsed.value.request,
+			includeClipboard: parsed.value.includeClipboard ?? true,
+			region: parsed.value.region,
+		},
+	};
+}
+
+function parseCaptureFields(record: Record<string, unknown>): ParseResult<Omit<ClientCaptureMessage, "type">> {
 	const mode = record.mode;
 	if (typeof mode !== "string" || !["screen", "window", "region", "browser"].includes(mode)) {
 		return { ok: false, error: "mode must be one of screen, window, region, browser" };
 	}
-	const userRequest = record.userRequest;
-	if (typeof userRequest !== "string" || !userRequest.trim()) {
-		return { ok: false, error: "userRequest must be a non-empty string" };
+	if (typeof record.request !== "string" || !record.request.trim()) {
+		return { ok: false, error: "request must be a non-empty string" };
 	}
-	const includeClipboard = record.includeClipboard ?? true;
-	if (typeof includeClipboard !== "boolean") return { ok: false, error: "includeClipboard must be a boolean" };
-	return { ok: true, options: { mode: mode as CaptureMode, userRequest, includeClipboard } };
+	if (record.includeClipboard !== undefined && typeof record.includeClipboard !== "boolean") {
+		return { ok: false, error: "includeClipboard must be a boolean" };
+	}
+	const region = parseRegion(record.region, mode === "region");
+	if (!region.ok) return region;
+	return {
+		ok: true,
+		value: {
+			mode: mode as CaptureMode,
+			request: record.request,
+			includeClipboard: record.includeClipboard as boolean | undefined,
+			region: region.value,
+		},
+	};
+}
+
+function parseRegion(value: unknown, required: boolean): ParseResult<CaptureRegion | undefined> {
+	if (value === undefined) {
+		return required ? { ok: false, error: "region is required for region capture" } : { ok: true, value: undefined };
+	}
+	if (!isRecord(value) || !hasOnlyKeys(value, ["x", "y", "width", "height"])) {
+		return { ok: false, error: "region must contain only x, y, width, and height" };
+	}
+	for (const key of ["x", "y"] as const) {
+		if (typeof value[key] !== "number" || !Number.isFinite(value[key])) {
+			return { ok: false, error: `region ${key} must be a finite number` };
+		}
+	}
+	for (const key of ["width", "height"] as const) {
+		if (typeof value[key] !== "number" || !Number.isFinite(value[key]) || value[key] <= 0) {
+			return { ok: false, error: `region ${key} must be a finite positive number` };
+		}
+	}
+	return { ok: true, value: value as unknown as CaptureRegion };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(record: Record<string, unknown>, allowed: readonly string[]): boolean {
+	return Object.keys(record).every(key => allowed.includes(key));
 }

--- a/packages/desktop-tag/src/index.ts
+++ b/packages/desktop-tag/src/index.ts
@@ -1,0 +1,7 @@
+export * from "./types";
+export * from "./context";
+export * from "./router";
+export * from "./events";
+export * from "./worker";
+export * from "./gateway";
+export { default as desktopTagExtension } from "./extension";

--- a/packages/desktop-tag/src/index.ts
+++ b/packages/desktop-tag/src/index.ts
@@ -1,7 +1,7 @@
-export * from "./types";
 export * from "./context";
-export * from "./router";
 export * from "./events";
-export * from "./worker";
-export * from "./gateway";
 export { default as desktopTagExtension } from "./extension";
+export * from "./gateway";
+export * from "./router";
+export * from "./types";
+export * from "./worker";

--- a/packages/desktop-tag/src/overlay.html
+++ b/packages/desktop-tag/src/overlay.html
@@ -18,6 +18,12 @@
     button.active { outline: 2px solid var(--accent); }
     textarea { width: 100%; min-height: 80px; background: #0b0c0f; color: var(--text); border: 1px solid #2f353d; border-radius: 10px; padding: 14px; font-size: 15px; resize: vertical; }
     label { display: flex; align-items: center; gap: 8px; color: var(--muted); font-size: 13px; margin: 12px 0; }
+    input[type="number"] { width: 100%; background: #0b0c0f; color: var(--text); border: 1px solid #2f353d; border-radius: 8px; padding: 9px 10px; font-size: 14px; }
+    .region-inputs { margin: 0 0 16px; padding: 14px; border: 1px solid #2f353d; border-radius: 10px; }
+    .region-inputs legend { padding: 0 6px; color: var(--text); font-size: 13px; font-weight: 600; }
+    .region-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(100px, 1fr)); gap: 12px; }
+    .region-grid label { display: block; margin: 0; }
+    .region-grid input { display: block; margin-top: 6px; }
     #status { margin-top: 16px; font-size: 13px; color: var(--muted); min-height: 1.2em; }
     #log { margin-top: 16px; max-height: 260px; overflow: auto; font-size: 13px; line-height: 1.45; color: var(--muted); white-space: pre-wrap; }
     .approval { margin-top: 12px; padding: 12px; border: 1px solid #2f353d; border-radius: 10px; background: #0b0c0f; }
@@ -40,6 +46,16 @@
 
     <textarea id="request" placeholder="What would you like to do with this? (e.g. Explain this error, file a bug, update Salesforce...)"></textarea>
 
+    <fieldset id="region-inputs" class="region-inputs hidden" disabled>
+      <legend>Region coordinates</legend>
+      <div class="region-grid">
+        <label for="region-x">X <input type="number" id="region-x" value="0" step="any" required></label>
+        <label for="region-y">Y <input type="number" id="region-y" value="0" step="any" required></label>
+        <label for="region-width">Width <input type="number" id="region-width" value="640" step="any" required></label>
+        <label for="region-height">Height <input type="number" id="region-height" value="480" step="any" required></label>
+      </div>
+    </fieldset>
+
     <label><input type="checkbox" id="clipboard" checked> Include clipboard / selected text</label>
 
     <div class="row">
@@ -54,11 +70,15 @@
 
   <script>
     const modeButtons = [...document.querySelectorAll('.mode')];
+    const regionInputsEl = document.getElementById('region-inputs');
     let mode = 'screen';
     modeButtons.forEach(btn => btn.addEventListener('click', () => {
       modeButtons.forEach(b => b.classList.remove('active'));
       btn.classList.add('active');
       mode = btn.id.replace('mode-', '');
+      const regionMode = mode === 'region';
+      regionInputsEl.classList.toggle('hidden', !regionMode);
+      regionInputsEl.disabled = !regionMode;
     }));
 
     const requestEl = document.getElementById('request');
@@ -69,6 +89,20 @@
 
     function log(text) { logEl.textContent += text + '\n'; logEl.scrollTop = logEl.scrollHeight; }
     function setStatus(text) { statusEl.textContent = text; }
+
+    function readRegion() {
+      const fields = ['x', 'y', 'width', 'height'];
+      const region = Object.fromEntries(fields.map(name => [name, document.getElementById(`region-${name}`).valueAsNumber]));
+      if (!Number.isFinite(region.x) || !Number.isFinite(region.y)) {
+        setStatus('Region X and Y must be finite numbers.');
+        return;
+      }
+      if (!Number.isFinite(region.width) || region.width <= 0 || !Number.isFinite(region.height) || region.height <= 0) {
+        setStatus('Region width and height must be positive finite numbers.');
+        return;
+      }
+      return region;
+    }
 
     function connect() {
       const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -92,9 +126,14 @@
       const payload = {
         type: 'capture',
         mode,
-        userRequest: requestEl.value.trim(),
+        request: requestEl.value.trim(),
         includeClipboard: document.getElementById('clipboard').checked,
       };
+      if (mode === 'region') {
+        const region = readRegion();
+        if (!region) return;
+        payload.region = region;
+      }
       ws.send(JSON.stringify(payload));
       logEl.textContent = '';
       setStatus('Capturing...');

--- a/packages/desktop-tag/src/overlay.html
+++ b/packages/desktop-tag/src/overlay.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tag Anything — pi desktop</title>
+  <style>
+    :root { --bg: #0b0c0f; --panel: #141619; --accent: #7c5cff; --text: #e6e6e6; --muted: #8b92a8; }
+    * { box-sizing: border-box; }
+    html, body { height: 100%; margin: 0; background: var(--bg); color: var(--text); font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+    body { display: grid; place-items: center; padding: 24px; }
+    .card { width: min(720px, 100%); background: var(--panel); border: 1px solid #22262d; border-radius: 16px; padding: 24px; box-shadow: 0 20px 60px rgba(0,0,0,.4); }
+    h1 { margin: 0 0 8px; font-size: 22px; }
+    p.muted { margin: 0 0 20px; color: var(--muted); font-size: 14px; }
+    .row { display: flex; gap: 12px; margin-bottom: 16px; flex-wrap: wrap; }
+    button { background: #22262d; color: var(--text); border: 1px solid #2f353d; border-radius: 10px; padding: 10px 16px; cursor: pointer; font-weight: 500; }
+    button.primary { background: var(--accent); border-color: var(--accent); color: white; }
+    button.active { outline: 2px solid var(--accent); }
+    textarea { width: 100%; min-height: 80px; background: #0b0c0f; color: var(--text); border: 1px solid #2f353d; border-radius: 10px; padding: 14px; font-size: 15px; resize: vertical; }
+    label { display: flex; align-items: center; gap: 8px; color: var(--muted); font-size: 13px; margin: 12px 0; }
+    #status { margin-top: 16px; font-size: 13px; color: var(--muted); min-height: 1.2em; }
+    #log { margin-top: 16px; max-height: 260px; overflow: auto; font-size: 13px; line-height: 1.45; color: var(--muted); white-space: pre-wrap; }
+    .approval { margin-top: 12px; padding: 12px; border: 1px solid #2f353d; border-radius: 10px; background: #0b0c0f; }
+    .approval .tool { color: var(--text); font-weight: 600; }
+    .approval pre { background: #141619; padding: 8px; border-radius: 6px; overflow: auto; }
+    .hidden { display: none; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Tag Anything</h1>
+    <p class="muted">Capture your screen and tell pi what to do.</p>
+
+    <div class="row">
+      <button id="mode-screen" class="mode active">Screen</button>
+      <button id="mode-window" class="mode">Window</button>
+      <button id="mode-region" class="mode">Region</button>
+      <button id="mode-browser" class="mode">Browser</button>
+    </div>
+
+    <textarea id="request" placeholder="What would you like to do with this? (e.g. Explain this error, file a bug, update Salesforce...)"></textarea>
+
+    <label><input type="checkbox" id="clipboard" checked> Include clipboard / selected text</label>
+
+    <div class="row">
+      <button id="submit" class="primary">Tag it</button>
+      <button id="cancel">Cancel</button>
+    </div>
+
+    <div id="status">Ready</div>
+    <div id="log"></div>
+    <div id="approvals"></div>
+  </div>
+
+  <script>
+    const modeButtons = [...document.querySelectorAll('.mode')];
+    let mode = 'screen';
+    modeButtons.forEach(btn => btn.addEventListener('click', () => {
+      modeButtons.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      mode = btn.id.replace('mode-', '');
+    }));
+
+    const requestEl = document.getElementById('request');
+    const statusEl = document.getElementById('status');
+    const logEl = document.getElementById('log');
+    const approvalsEl = document.getElementById('approvals');
+    let ws;
+
+    function log(text) { logEl.textContent += text + '\n'; logEl.scrollTop = logEl.scrollHeight; }
+    function setStatus(text) { statusEl.textContent = text; }
+
+    function connect() {
+      const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+      ws = new WebSocket(`${protocol}//${location.host}/ws`);
+      ws.onopen = () => setStatus('Connected');
+      ws.onclose = () => setStatus('Disconnected');
+      ws.onerror = () => setStatus('WebSocket error');
+      ws.onmessage = (event) => {
+        const msg = JSON.parse(event.data);
+        if (msg.type === 'agent.message.delta') log(msg.text);
+        if (msg.type === 'tool.started') log(`[tool] ${msg.toolName}`);
+        if (msg.type === 'tool.completed') log(`[tool done] ${msg.isError ? 'error' : 'ok'}`);
+        if (msg.type === 'approval.requested') showApproval(msg.request);
+        if (msg.type === 'task.completed') setStatus('Done');
+        if (msg.type === 'task.failed') setStatus('Failed: ' + msg.error);
+      };
+    }
+    connect();
+
+    document.getElementById('submit').addEventListener('click', () => {
+      const payload = {
+        type: 'capture',
+        mode,
+        userRequest: requestEl.value.trim(),
+        includeClipboard: document.getElementById('clipboard').checked,
+      };
+      ws.send(JSON.stringify(payload));
+      logEl.textContent = '';
+      setStatus('Capturing...');
+      approvalsEl.innerHTML = '';
+    });
+
+    document.getElementById('cancel').addEventListener('click', () => {
+      ws.send(JSON.stringify({ type: 'cancel' }));
+    });
+
+    function showApproval(req) {
+      const div = document.createElement('div');
+      div.className = 'approval';
+      div.innerHTML = `<div class="tool">${req.toolName}</div><p>${req.effects}</p><pre>${JSON.stringify(req.arguments, null, 2)}</pre><div class="row"><button id="allow-${req.actionId}" class="primary">Allow</button><button id="deny-${req.actionId}">Deny</button></div>`;
+      approvalsEl.appendChild(div);
+      document.getElementById(`allow-${req.actionId}`).addEventListener('click', () => {
+        ws.send(JSON.stringify({ type: 'approve', actionId: req.actionId, allowed: true, scope: req.scope || 'once' }));
+        div.remove();
+      });
+      document.getElementById(`deny-${req.actionId}`).addEventListener('click', () => {
+        ws.send(JSON.stringify({ type: 'approve', actionId: req.actionId, allowed: false }));
+        div.remove();
+      });
+    }
+  </script>
+</body>
+</html>

--- a/packages/desktop-tag/src/overlay.html
+++ b/packages/desktop-tag/src/overlay.html
@@ -98,7 +98,7 @@
       ws.send(JSON.stringify(payload));
       logEl.textContent = '';
       setStatus('Capturing...');
-      approvalsEl.innerHTML = '';
+      approvalsEl.replaceChildren();
     });
 
     document.getElementById('cancel').addEventListener('click', () => {
@@ -108,13 +108,35 @@
     function showApproval(req) {
       const div = document.createElement('div');
       div.className = 'approval';
-      div.innerHTML = `<div class="tool">${req.toolName}</div><p>${req.effects}</p><pre>${JSON.stringify(req.arguments, null, 2)}</pre><div class="row"><button id="allow-${req.actionId}" class="primary">Allow</button><button id="deny-${req.actionId}">Deny</button></div>`;
+
+      const tool = document.createElement('div');
+      tool.className = 'tool';
+      tool.textContent = String(req.toolName ?? 'Unknown tool');
+
+      const effects = document.createElement('p');
+      effects.textContent = String(req.effects ?? '');
+
+      const argumentsEl = document.createElement('pre');
+      argumentsEl.textContent = JSON.stringify(req.arguments, null, 2);
+
+      const actions = document.createElement('div');
+      actions.className = 'row';
+      const allow = document.createElement('button');
+      allow.className = 'primary';
+      allow.type = 'button';
+      allow.textContent = 'Allow';
+      const deny = document.createElement('button');
+      deny.type = 'button';
+      deny.textContent = 'Deny';
+      actions.append(allow, deny);
+
+      div.append(tool, effects, argumentsEl, actions);
       approvalsEl.appendChild(div);
-      document.getElementById(`allow-${req.actionId}`).addEventListener('click', () => {
+      allow.addEventListener('click', () => {
         ws.send(JSON.stringify({ type: 'approve', actionId: req.actionId, allowed: true, scope: req.scope || 'once' }));
         div.remove();
       });
-      document.getElementById(`deny-${req.actionId}`).addEventListener('click', () => {
+      deny.addEventListener('click', () => {
         ws.send(JSON.stringify({ type: 'approve', actionId: req.actionId, allowed: false }));
         div.remove();
       });

--- a/packages/desktop-tag/src/router.ts
+++ b/packages/desktop-tag/src/router.ts
@@ -1,0 +1,188 @@
+import { logger } from "@pk-nerdsaver-ai/pi-utils";
+
+import type { ActionLevel, Capability, ContextPacket, Executor, RoutingDecision } from "./types";
+
+/** Registry of available executors and their declared capabilities. */
+export class CapabilityRegistry {
+	readonly #executors = new Map<string, Executor>();
+
+	register(executor: Executor): void {
+		this.#executors.set(executor.id, executor);
+	}
+
+	getExecutor(id: string): Executor | undefined {
+		return this.#executors.get(id);
+	}
+
+	listExecutors(): Executor[] {
+		return [...this.#executors.values()];
+	}
+
+	findMatching(capabilityName: string, application?: string): Executor | undefined {
+		for (const executor of this.#executors.values()) {
+			if (!executor.available) continue;
+			if (executor.capabilities.some(c => c.name === capabilityName)) {
+				if (application && executor.applications && !executor.applications.includes(application)) continue;
+				return executor;
+			}
+		}
+		return undefined;
+	}
+}
+
+/** Default executor definitions shipped with the desktop-tag extension. */
+export function createDefaultRegistry(): CapabilityRegistry {
+	const registry = new CapabilityRegistry();
+
+	registry.register({
+		id: "answer-only",
+		name: "Vision answer",
+		location: "local",
+		riskLevel: "low",
+		available: true,
+		capabilities: [
+			{ name: "answer", description: "Answer from a screenshot or selected context", sideEffect: false, reversible: true, approval: "none" },
+		],
+	});
+
+	registry.register({
+		id: "local-pi",
+		name: "Local pi session",
+		location: "local",
+		riskLevel: "medium",
+		available: true,
+		capabilities: [
+			{ name: "filesystem.read", sideEffect: false, reversible: true, approval: "none" },
+			{ name: "filesystem.write", sideEffect: true, reversible: true, approval: "per-action" },
+			{ name: "terminal.execute", sideEffect: true, reversible: true, approval: "per-action" },
+			{ name: "codebase.edit", sideEffect: true, reversible: true, approval: "per-action" },
+		],
+	});
+
+	registry.register({
+		id: "ix-bridge",
+		name: "IX Bridge browser executor",
+		location: "local",
+		riskLevel: "medium",
+		available: true,
+		applications: ["salesforce", "powerclerk", "xcel-portal"],
+		capabilities: [
+			{ name: "browser.navigate", sideEffect: false, reversible: true, approval: "none" },
+			{ name: "browser.inspect_dom", sideEffect: false, reversible: true, approval: "none" },
+			{ name: "browser.click", sideEffect: true, reversible: true, approval: "per-action" },
+			{ name: "browser.type", sideEffect: true, reversible: true, approval: "per-action" },
+			{ name: "browser.capture_trace", sideEffect: false, reversible: true, approval: "none" },
+		],
+	});
+
+	registry.register({
+		id: "gmail-mcp",
+		name: "Gmail connector",
+		location: "remote",
+		riskLevel: "high",
+		available: false,
+		applications: ["gmail"],
+		capabilities: [
+			{ name: "email.search", sideEffect: false, reversible: true, approval: "none" },
+			{ name: "email.read", sideEffect: false, reversible: true, approval: "none" },
+			{ name: "email.draft", sideEffect: true, reversible: true, approval: "per-action" },
+			{ name: "email.send", sideEffect: true, reversible: false, approval: "per-action" },
+		],
+	});
+
+	registry.register({
+		id: "remote-hub",
+		name: "Remote hub worker",
+		location: "remote",
+		riskLevel: "high",
+		available: false,
+		capabilities: [
+			{ name: "remote.execute", sideEffect: true, reversible: true, approval: "per-action" },
+			{ name: "server.run", sideEffect: true, reversible: true, approval: "per-action" },
+		],
+	});
+
+	registry.register({
+		id: "computer-use",
+		name: "Computer-use vision executor",
+		location: "local",
+		riskLevel: "high",
+		available: false,
+		capabilities: [
+			{ name: "screen.click", sideEffect: true, reversible: true, approval: "per-action" },
+			{ name: "screen.type", sideEffect: true, reversible: true, approval: "per-action" },
+			{ name: "screen.keypress", sideEffect: true, reversible: true, approval: "per-action" },
+		],
+	});
+
+	return registry;
+}
+
+/** Route a captured context packet to an executor and a constrained tool set. */
+export function routeContext(registry: CapabilityRegistry, packet: ContextPacket): RoutingDecision {
+	const request = packet.userRequest.toLowerCase();
+	const url = packet.browser.url?.toLowerCase() ?? "";
+	const title = packet.browser.title?.toLowerCase() ?? "";
+	const app = packet.foregroundApp.processName?.toLowerCase() ?? "";
+
+	if (request.match(/\bemail\b|\bmail\b|\bgmail\b/)) {
+		return decision("gmail-mcp", ["email.search", "email.read", "email.draft"], 2);
+	}
+
+	if (request.match(/\bserver\b|\bremote\b|\bssh\b|\brun on the server\b/)) {
+		return decision("remote-hub", ["remote.execute", "ssh"], 2);
+	}
+
+	if (request.match(/\bclick\b|\bpress\b|\btype in\b|\bscreen\b/)) {
+		return decision("computer-use", ["screen.click", "screen.type", "screen.keypress"], 3);
+	}
+
+	if (request.match(/\bsalesforce\b/) || url.includes("salesforce.com") || title.includes("salesforce")) {
+		return decision("ix-bridge", ["ix_bridge", "browser", "web_search"], 2);
+	}
+
+	if (request.match(/\bportal\b|\bpowerclerk\b|\bxcel\b/)) {
+		return decision("ix-bridge", ["ix_bridge", "browser"], 2);
+	}
+
+	if (request.match(/\bfix\b|\bcode\b|\bedit\b|\brefactor\b|\btest\b|\bbuild\b/)) {
+		return decision("local-pi", ["bash", "read", "edit", "write", "search", "find", "lsp"], 2);
+	}
+
+	if (request.match(/\bupdate\b|\bchange\b|\bsave\b|\bcreate\b|\bdelete\b/)) {
+		return decision("local-pi", ["bash", "read", "write", "edit"], 2);
+	}
+
+	if (request.match(/\bwhat\b|\bwhy\b|\bhow\b|\bexplain\b|\berror\b|\bmean\b/) || !packet.visual.screenshotPath) {
+		return decision("answer-only", ["inspect_image", "web_search", "ask"], 0);
+	}
+
+	return decision("answer-only", ["inspect_image", "web_search", "ask"], 0);
+}
+
+function decision(executorId: string, tools: string[], level: ActionLevel): RoutingDecision {
+	return {
+		executorId,
+		tools,
+		message: `Routing to ${executorId} with tools [${tools.join(", ")}]`,
+		level,
+	};
+}
+
+/** Set executor availability based on runtime probes (e.g. IX Bridge reachable). */
+export async function updateAvailability(registry: CapabilityRegistry): Promise<void> {
+	try {
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), 1_500);
+		const response = await fetch("http://127.0.0.1:18086/ix-bridge/status", { signal: controller.signal });
+		clearTimeout(timer);
+		const ix = registry.getExecutor("ix-bridge");
+		if (ix) {
+			ix.available = response.ok;
+		}
+	} catch (error) {
+		logger.debug("IX Bridge availability probe failed", { error: error instanceof Error ? error.message : String(error) });
+		const ix = registry.getExecutor("ix-bridge");
+		if (ix) ix.available = false;
+	}
+}

--- a/packages/desktop-tag/src/router.ts
+++ b/packages/desktop-tag/src/router.ts
@@ -244,20 +244,22 @@ function decision(executorId: string, tools: string[], level: ActionLevel): Rout
 
 /** Set executor availability based on runtime probes (e.g. IX Bridge reachable). */
 export async function updateAvailability(registry: CapabilityRegistry): Promise<void> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), 1_500);
 	try {
-		const controller = new AbortController();
-		const timer = setTimeout(() => controller.abort(), 1_500);
 		const response = await fetch("http://127.0.0.1:18086/ix-bridge/status", { signal: controller.signal });
-		clearTimeout(timer);
+		const status = response.ok
+			? ((await response.json().catch(() => ({}))) as { extension_connected?: unknown })
+			: undefined;
 		const ix = registry.getExecutor("ix-bridge");
-		if (ix) {
-			ix.available = response.ok;
-		}
+		if (ix) ix.available = status?.extension_connected === true;
 	} catch (error) {
 		logger.debug("IX Bridge availability probe failed", {
 			error: error instanceof Error ? error.message : String(error),
 		});
 		const ix = registry.getExecutor("ix-bridge");
 		if (ix) ix.available = false;
+	} finally {
+		clearTimeout(timer);
 	}
 }

--- a/packages/desktop-tag/src/router.ts
+++ b/packages/desktop-tag/src/router.ts
@@ -1,6 +1,12 @@
 import { logger } from "@pk-nerdsaver-ai/pi-utils";
+import type { ActionLevel, ContextPacket, Executor, RoutingDecision } from "./types";
+import { isCaptureMode } from "./types";
 
-import type { ActionLevel, Capability, ContextPacket, Executor, RoutingDecision } from "./types";
+interface RouteSpec {
+	executorId: string;
+	tools: string[];
+	level: ActionLevel;
+}
 
 /** Registry of available executors and their declared capabilities. */
 export class CapabilityRegistry {
@@ -41,7 +47,13 @@ export function createDefaultRegistry(): CapabilityRegistry {
 		riskLevel: "low",
 		available: true,
 		capabilities: [
-			{ name: "answer", description: "Answer from a screenshot or selected context", sideEffect: false, reversible: true, approval: "none" },
+			{
+				name: "answer",
+				description: "Answer from a screenshot or selected context",
+				sideEffect: false,
+				reversible: true,
+				approval: "none",
+			},
 		],
 	});
 
@@ -120,44 +132,105 @@ export function createDefaultRegistry(): CapabilityRegistry {
 
 /** Route a captured context packet to an executor and a constrained tool set. */
 export function routeContext(registry: CapabilityRegistry, packet: ContextPacket): RoutingDecision {
+	assertContextPacket(packet);
+	const availableExecutors = registry.listExecutors().filter(executor => executor.available);
+	if (availableExecutors.length === 0) {
+		throw new Error("No available executors are registered");
+	}
+
 	const request = packet.userRequest.toLowerCase();
 	const url = packet.browser.url?.toLowerCase() ?? "";
 	const title = packet.browser.title?.toLowerCase() ?? "";
-	const app = packet.foregroundApp.processName?.toLowerCase() ?? "";
+	let preferred: RouteSpec;
 
 	if (request.match(/\bemail\b|\bmail\b|\bgmail\b/)) {
-		return decision("gmail-mcp", ["email.search", "email.read", "email.draft"], 2);
+		preferred = { executorId: "gmail-mcp", tools: ["email.search", "email.read", "email.draft"], level: 2 };
+	} else if (request.match(/\bserver\b|\bremote\b|\bssh\b|\brun on the server\b/)) {
+		preferred = { executorId: "remote-hub", tools: ["remote.execute", "ssh"], level: 2 };
+	} else if (request.match(/\bclick\b|\bpress\b|\btype in\b|\bscreen\b/)) {
+		preferred = { executorId: "computer-use", tools: ["screen.click", "screen.type", "screen.keypress"], level: 3 };
+	} else if (request.match(/\bsalesforce\b/) || url.includes("salesforce.com") || title.includes("salesforce")) {
+		preferred = { executorId: "ix-bridge", tools: ["ix_bridge", "browser", "web_search"], level: 2 };
+	} else if (request.match(/\bportal\b|\bpowerclerk\b|\bxcel\b/)) {
+		preferred = { executorId: "ix-bridge", tools: ["ix_bridge", "browser"], level: 2 };
+	} else if (request.match(/\bfix\b|\bcode\b|\bedit\b|\brefactor\b|\btest\b|\bbuild\b/)) {
+		preferred = {
+			executorId: "local-pi",
+			tools: ["bash", "read", "edit", "write", "search", "find", "lsp"],
+			level: 2,
+		};
+	} else if (request.match(/\bupdate\b|\bchange\b|\bsave\b|\bcreate\b|\bdelete\b/)) {
+		preferred = { executorId: "local-pi", tools: ["bash", "read", "write", "edit"], level: 2 };
+	} else {
+		preferred = { executorId: "answer-only", tools: ["inspect_image", "web_search", "ask"], level: 0 };
 	}
 
-	if (request.match(/\bserver\b|\bremote\b|\bssh\b|\brun on the server\b/)) {
-		return decision("remote-hub", ["remote.execute", "ssh"], 2);
-	}
+	const selected = availableExecutors.find(executor => executor.id === preferred.executorId);
+	if (selected) return decision(preferred.executorId, preferred.tools, preferred.level);
 
-	if (request.match(/\bclick\b|\bpress\b|\btype in\b|\bscreen\b/)) {
-		return decision("computer-use", ["screen.click", "screen.type", "screen.keypress"], 3);
-	}
+	const fallback = availableExecutors.find(executor => executor.id === "answer-only") ?? availableExecutors[0];
+	if (!fallback) throw new Error("No available executors are registered");
+	const level: ActionLevel = fallback.riskLevel === "high" ? 3 : fallback.riskLevel === "medium" ? 2 : 0;
+	return decision(
+		fallback.id,
+		fallback.capabilities.map(capability => capability.name),
+		level,
+	);
+}
 
-	if (request.match(/\bsalesforce\b/) || url.includes("salesforce.com") || title.includes("salesforce")) {
-		return decision("ix-bridge", ["ix_bridge", "browser", "web_search"], 2);
+/** Reject a malformed context packet before routing decisions inspect it. */
+export function assertContextPacket(packet: unknown): void {
+	if (!isRecord(packet)) throw new TypeError("Context packet must be an object");
+	assertNonblankString(packet.captureId, "Context packet captureId");
+	assertNonblankString(packet.timestamp, "Context packet timestamp");
+	if (Number.isNaN(Date.parse(packet.timestamp))) throw new TypeError("Context packet timestamp must be a valid date");
+	assertNonblankString(packet.userRequest, "Context packet userRequest");
+	if (!isCaptureMode(packet.captureMode)) {
+		throw new TypeError(`Unsupported context capture mode: ${String(packet.captureMode)}`);
 	}
-
-	if (request.match(/\bportal\b|\bpowerclerk\b|\bxcel\b/)) {
-		return decision("ix-bridge", ["ix_bridge", "browser"], 2);
+	if (!isRecord(packet.visual)) throw new TypeError("Context packet visual must be an object");
+	if (
+		typeof packet.visual.displayScale !== "number" ||
+		!Number.isFinite(packet.visual.displayScale) ||
+		packet.visual.displayScale <= 0
+	) {
+		throw new TypeError("Context packet visual.displayScale must be a finite positive number");
 	}
-
-	if (request.match(/\bfix\b|\bcode\b|\bedit\b|\brefactor\b|\btest\b|\bbuild\b/)) {
-		return decision("local-pi", ["bash", "read", "edit", "write", "search", "find", "lsp"], 2);
+	if (!Array.isArray(packet.visual.annotations))
+		throw new TypeError("Context packet visual.annotations must be an array");
+	assertOptionalString(packet.visual.screenshotPath, "Context packet visual.screenshotPath");
+	const foregroundApp = packet.foregroundApp;
+	const browser = packet.browser;
+	if (!isRecord(foregroundApp)) throw new TypeError("Context packet foregroundApp must be an object");
+	if (!isRecord(browser)) throw new TypeError("Context packet browser must be an object");
+	if (!isRecord(packet.selection)) throw new TypeError("Context packet selection must be an object");
+	assertOptionalString(foregroundApp.processName, "Context packet foregroundApp.processName");
+	assertOptionalNonblankString(foregroundApp.windowTitle, "Context packet foregroundApp.windowTitle");
+	assertOptionalString(browser.url, "Context packet browser.url");
+	assertOptionalString(browser.title, "Context packet browser.title");
+	if (
+		!Array.isArray(packet.availableCapabilities) ||
+		!packet.availableCapabilities.every(value => typeof value === "string")
+	) {
+		throw new TypeError("Context packet availableCapabilities must be an array of strings");
 	}
+}
 
-	if (request.match(/\bupdate\b|\bchange\b|\bsave\b|\bcreate\b|\bdelete\b/)) {
-		return decision("local-pi", ["bash", "read", "write", "edit"], 2);
-	}
+function assertOptionalString(value: unknown, name: string): void {
+	if (value !== undefined && typeof value !== "string") throw new TypeError(`${name} must be a string`);
+}
 
-	if (request.match(/\bwhat\b|\bwhy\b|\bhow\b|\bexplain\b|\berror\b|\bmean\b/) || !packet.visual.screenshotPath) {
-		return decision("answer-only", ["inspect_image", "web_search", "ask"], 0);
-	}
+function assertOptionalNonblankString(value: unknown, name: string): void {
+	if (value === undefined) return;
+	assertNonblankString(value, name);
+}
 
-	return decision("answer-only", ["inspect_image", "web_search", "ask"], 0);
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertNonblankString(value: unknown, name: string): asserts value is string {
+	if (typeof value !== "string" || value.trim().length === 0) throw new TypeError(`${name} must be a nonblank string`);
 }
 
 function decision(executorId: string, tools: string[], level: ActionLevel): RoutingDecision {
@@ -181,7 +254,9 @@ export async function updateAvailability(registry: CapabilityRegistry): Promise<
 			ix.available = response.ok;
 		}
 	} catch (error) {
-		logger.debug("IX Bridge availability probe failed", { error: error instanceof Error ? error.message : String(error) });
+		logger.debug("IX Bridge availability probe failed", {
+			error: error instanceof Error ? error.message : String(error),
+		});
 		const ix = registry.getExecutor("ix-bridge");
 		if (ix) ix.available = false;
 	}

--- a/packages/desktop-tag/src/types.ts
+++ b/packages/desktop-tag/src/types.ts
@@ -1,0 +1,169 @@
+import type { ImageContent } from "@pk-nerdsaver-ai/pi-ai";
+
+/** What surface to capture when the overlay is invoked. */
+export type CaptureMode = "screen" | "window" | "region" | "browser";
+
+/** Normalized annotation on a captured screenshot. */
+export interface Annotation {
+	id: string;
+	type: "rectangle" | "point" | "arrow" | "blur";
+	bounds: [number, number, number, number];
+	label?: string;
+}
+
+/** Visual context captured from the desktop. */
+export interface VisualContext {
+	screenshotPath?: string;
+	screenshotImage?: ImageContent;
+	selectedRegion?: {
+		x: number;
+		y: number;
+		width: number;
+		height: number;
+	};
+	displayScale: number;
+	annotations: Annotation[];
+}
+
+/** Foreground application metadata. */
+export interface ForegroundAppContext {
+	processName?: string;
+	windowTitle?: string;
+	executablePath?: string;
+}
+
+/** Browser context, when IX Bridge or a Chrome/Edge extension is available. */
+export interface BrowserContext {
+	url?: string;
+	title?: string;
+	tabId?: string;
+	domSnapshotRef?: string;
+	accessibilityTreeRef?: string;
+}
+
+/** Selection / clipboard text, if available. */
+export interface SelectionContext {
+	text?: string;
+	clipboardText?: string;
+}
+
+/** The full context payload sent from the overlay to the agent runtime. */
+export interface ContextPacket {
+	captureId: string;
+	timestamp: string;
+
+	userRequest: string;
+	captureMode: CaptureMode;
+
+	visual: VisualContext;
+	foregroundApp: ForegroundAppContext;
+	browser: BrowserContext;
+	selection: SelectionContext;
+
+	availableCapabilities: string[];
+}
+
+/** Risk / approval level for an action. */
+export type ActionLevel = 0 | 1 | 2 | 3;
+
+/** A declared executor capability. */
+export interface Capability {
+	name: string;
+	description?: string;
+	sideEffect?: boolean;
+	reversible?: boolean;
+	approval?: "none" | "per-action" | "group" | "session";
+	allowedFields?: string[];
+}
+
+/** A known executor that can run actions for the router. */
+export interface Executor {
+	id: string;
+	name: string;
+	location: "local" | "remote" | "cloud";
+	capabilities: Capability[];
+	applications?: string[];
+	riskLevel: "low" | "medium" | "high";
+	available: boolean;
+}
+
+/** A planned execution step produced by the router. */
+export interface PlanStep {
+	id: string;
+	executorId: string;
+	capability: string;
+	arguments: Record<string, unknown>;
+	level: ActionLevel;
+	description: string;
+	requiresApproval: boolean;
+}
+
+/** A task being delegated from the overlay. */
+export interface Task {
+	taskId: string;
+	contextPacket: ContextPacket;
+	plan: PlanStep[];
+	createdAt: string;
+	status: "pending" | "running" | "blocked" | "completed" | "failed";
+}
+
+/** An approval request surfaced to the user. */
+export interface ApprovalRequest {
+	actionId: string;
+	stepId: string;
+	level: ActionLevel;
+	toolName: string;
+	arguments: Record<string, unknown>;
+	effects: string;
+	scope?: "once" | "group" | "session" | "application";
+}
+
+/** Unified event protocol consumed by the overlay. */
+export type AgentEvent =
+	| { type: "task.started"; taskId: string }
+	| { type: "agent.message.delta"; text: string }
+	| { type: "plan.updated"; steps: PlanStep[] }
+	| { type: "tool.requested"; callId: string; toolName: string; arguments: Record<string, unknown> }
+	| { type: "approval.requested"; request: ApprovalRequest }
+	| { type: "tool.started"; callId: string; toolName: string }
+	| { type: "tool.completed"; callId: string; result: unknown; isError: boolean }
+	| { type: "observation.updated"; screenshotRef?: string; contextPacket?: ContextPacket }
+	| { type: "task.blocked"; taskId: string; reason: string }
+	| { type: "task.completed"; taskId: string; summary: string }
+	| { type: "task.failed"; taskId: string; error: string };
+
+/** Generic agent worker abstraction. */
+export interface AgentWorker {
+	createSession(taskId: string, input: TaskInput): Promise<SessionHandle>;
+	sendMessage(sessionId: string, message: string, images?: ImageContent[]): Promise<void>;
+	approve(sessionId: string, actionId: string, decision: ApprovalDecision): Promise<void>;
+	cancel(sessionId: string): Promise<void>;
+	subscribe(sessionId: string): AsyncIterable<AgentEvent>;
+}
+
+/** A concrete task input passed to the worker. */
+export interface TaskInput {
+	contextPacket: ContextPacket;
+	routing: RoutingDecision;
+	preferredExecutor?: string;
+}
+
+/** A worker session handle. */
+export interface SessionHandle {
+	sessionId: string;
+}
+
+/** An approval decision from the user. */
+export interface ApprovalDecision {
+	allowed: boolean;
+	scope?: "once" | "group" | "session" | "application";
+	editedArguments?: Record<string, unknown>;
+}
+
+/** Routing decision returned by the router. */
+export interface RoutingDecision {
+	executorId: string;
+	tools: string[];
+	message: string;
+	level: ActionLevel;
+}

--- a/packages/desktop-tag/src/types.ts
+++ b/packages/desktop-tag/src/types.ts
@@ -3,6 +3,27 @@ import type { ImageContent } from "@pk-nerdsaver-ai/pi-ai";
 /** What surface to capture when the overlay is invoked. */
 export type CaptureMode = "screen" | "window" | "region" | "browser";
 
+/** Whether a wire value names a supported capture mode. */
+export function isCaptureMode(value: unknown): value is CaptureMode {
+	switch (value) {
+		case "screen":
+		case "window":
+		case "region":
+		case "browser":
+			return true;
+		default:
+			return false;
+	}
+}
+
+/** A rectangular desktop capture area in physical pixels. */
+export interface CaptureRegion {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
 /** Normalized annotation on a captured screenshot. */
 export interface Annotation {
 	id: string;
@@ -15,12 +36,7 @@ export interface Annotation {
 export interface VisualContext {
 	screenshotPath?: string;
 	screenshotImage?: ImageContent;
-	selectedRegion?: {
-		x: number;
-		y: number;
-		width: number;
-		height: number;
-	};
+	selectedRegion?: CaptureRegion;
 	displayScale: number;
 	annotations: Annotation[];
 }

--- a/packages/desktop-tag/src/worker.ts
+++ b/packages/desktop-tag/src/worker.ts
@@ -1,7 +1,9 @@
-import * as fs from "node:fs/promises";
-
 import type { ImageContent } from "@pk-nerdsaver-ai/pi-ai";
-import { createAgentSession, type CreateAgentSessionOptions } from "@pk-nerdsaver-ai/pi-coding-agent";
+import {
+	type CreateAgentSessionOptions,
+	type CreateAgentSessionResult,
+	createAgentSession,
+} from "@pk-nerdsaver-ai/pi-coding-agent";
 import { AgentSessionGateway } from "@pk-nerdsaver-ai/pi-coding-agent/gateway/agent-session-gateway";
 import type { GatewayEvent } from "@pk-nerdsaver-ai/pi-coding-agent/gateway/types";
 import type { AgentSession } from "@pk-nerdsaver-ai/pi-coding-agent/session/agent-session";
@@ -27,22 +29,30 @@ import type {
 } from "./types";
 
 interface ActiveSession {
+	session: AgentSession;
 	gateway: AgentSessionGateway;
 	channel: AgentEventChannel;
 	bridge: DesktopTagClientBridge;
+	controller: AbortController;
 	taskId: string;
+	settled: boolean;
+	cancelling: boolean;
+	cancellation?: Promise<void>;
+	assistantError?: string;
 }
+
+type AgentSessionFactory = (options: CreateAgentSessionOptions) => Promise<CreateAgentSessionResult>;
 
 /** Bridges permission requests from the agent into the overlay approval flow. */
 class DesktopTagClientBridge implements ClientBridge {
 	readonly capabilities = { requestPermission: true };
 	readonly #channel: AgentEventChannel;
+	readonly #lifecycleSignal: AbortSignal;
 	readonly #pending = new Map<string, (outcome: ClientBridgePermissionOutcome) => void>();
-	readonly #taskId: string;
 
-	constructor(taskId: string, channel: AgentEventChannel) {
-		this.#taskId = taskId;
+	constructor(channel: AgentEventChannel, lifecycleSignal: AbortSignal) {
 		this.#channel = channel;
+		this.#lifecycleSignal = lifecycleSignal;
 	}
 
 	async requestPermission(
@@ -50,6 +60,7 @@ class DesktopTagClientBridge implements ClientBridge {
 		options: ClientBridgePermissionOption[],
 		signal?: AbortSignal,
 	): Promise<ClientBridgePermissionOutcome> {
+		if (this.#lifecycleSignal.aborted) return { outcome: "cancelled" };
 		const { promise, resolve } = Promise.withResolvers<ClientBridgePermissionOutcome>();
 		this.#pending.set(toolCall.toolCallId, resolve);
 
@@ -72,13 +83,15 @@ class DesktopTagClientBridge implements ClientBridge {
 			request,
 		});
 
-		if (signal) {
-			signal.addEventListener("abort", () => this.resolve(toolCall.toolCallId, { outcome: "cancelled" }), { once: true });
-		}
+		const cancel = () => this.resolve(toolCall.toolCallId, { outcome: "cancelled" });
+		signal?.addEventListener("abort", cancel, { once: true });
+		this.#lifecycleSignal.addEventListener("abort", cancel, { once: true });
 
 		try {
 			return await promise;
 		} finally {
+			signal?.removeEventListener("abort", cancel);
+			this.#lifecycleSignal.removeEventListener("abort", cancel);
 			this.#pending.delete(toolCall.toolCallId);
 		}
 	}
@@ -96,6 +109,11 @@ class DesktopTagClientBridge implements ClientBridge {
 /** A worker that delegates tasks to a local {@link AgentSession} through the gateway. */
 export class PiWorker implements AgentWorker {
 	readonly #sessions = new Map<string, ActiveSession>();
+	readonly #sessionFactory: AgentSessionFactory;
+
+	constructor(sessionFactory: AgentSessionFactory = createAgentSession) {
+		this.#sessionFactory = sessionFactory;
+	}
 
 	async createSession(taskId: string, input: TaskInput): Promise<SessionHandle> {
 		const { contextPacket, preferredExecutor } = input;
@@ -117,28 +135,40 @@ export class PiWorker implements AgentWorker {
 			appendSystemPrompt: promptLines.join("\n"),
 		};
 
-		const { session } = await createAgentSession(options);
-
-		const channel = new AgentEventChannel();
-		const bridge = new DesktopTagClientBridge(taskId, channel);
-		session.setClientBridge(bridge);
-
-		const gateway = new AgentSessionGateway(session as AgentSession);
-		const active: ActiveSession = { gateway, channel, bridge, taskId };
-		this.#sessions.set(taskId, active);
-
-		this.#attachListener(active, gateway);
-
 		const message = buildInitialMessage(contextPacket, routing);
 		const images = contextPacket.visual.screenshotPath ? [await loadImage(contextPacket.visual.screenshotPath)] : [];
 
-		await gateway.dispatch({
-			id: crypto.randomUUID(),
-			type: "prompt",
-			identity: { channelId: "desktop-tag", sessionKey: taskId },
-			message,
-			images,
-		});
+		const { session } = await this.#sessionFactory(options);
+
+		const channel = new AgentEventChannel();
+		const controller = new AbortController();
+		const bridge = new DesktopTagClientBridge(channel, controller.signal);
+		session.setClientBridge(bridge);
+
+		const gateway = new AgentSessionGateway(session);
+		const active: ActiveSession = {
+			session,
+			gateway,
+			channel,
+			bridge,
+			controller,
+			taskId,
+			settled: false,
+			cancelling: false,
+		};
+		this.#sessions.set(taskId, active);
+		this.#attachListener(active);
+
+		// Let the caller attach its replaying subscription before a fast session can settle and leave the active registry.
+		void Bun.sleep(0).then(() =>
+			gateway.dispatch({
+				id: crypto.randomUUID(),
+				type: "prompt",
+				identity: { channelId: "desktop-tag", sessionKey: taskId },
+				message,
+				images,
+			}),
+		);
 
 		return { sessionId: taskId };
 	}
@@ -159,21 +189,35 @@ export class PiWorker implements AgentWorker {
 		const active = this.#sessions.get(sessionId);
 		if (!active) throw new Error(`Session ${sessionId} not found`);
 		if (decision.allowed) {
-			const optionId = decision.scope === "session" || decision.scope === "application" ? "allow_always" : "allow_once";
+			const optionId =
+				decision.scope === "session" || decision.scope === "application" ? "allow_always" : "allow_once";
 			active.bridge.resolve(actionId, { outcome: "selected", optionId });
 		} else {
 			active.bridge.resolve(actionId, { outcome: "cancelled" });
 		}
 	}
 
-	async cancel(sessionId: string): Promise<void> {
+	/** Abort and dispose an active task. Idempotent; concurrent callers await the same settlement. */
+	cancel(sessionId: string): Promise<void> {
 		const active = this.#sessions.get(sessionId);
-		if (!active) return;
-		await active.gateway.dispatch({
-			id: crypto.randomUUID(),
-			type: "abort",
-			identity: { channelId: "desktop-tag", sessionKey: sessionId },
-		});
+		if (!active || active.settled) return Promise.resolve();
+		if (active.cancellation) return active.cancellation;
+		active.cancelling = true;
+		active.controller.abort();
+		active.cancellation = this.#abortAndSettle(active, sessionId);
+		return active.cancellation;
+	}
+
+	async #abortAndSettle(active: ActiveSession, sessionId: string): Promise<void> {
+		try {
+			await active.gateway.dispatch({
+				id: crypto.randomUUID(),
+				type: "abort",
+				identity: { channelId: "desktop-tag", sessionKey: sessionId },
+			});
+		} finally {
+			await this.#settle(active, { type: "task.failed", taskId: active.taskId, error: "Task cancelled." });
+		}
 	}
 
 	subscribe(sessionId: string): AsyncIterable<AgentEvent> {
@@ -182,21 +226,55 @@ export class PiWorker implements AgentWorker {
 		return active.channel.subscribe();
 	}
 
-	#attachListener(active: ActiveSession, gateway: AgentSessionGateway): void {
-		gateway.subscribe(event => {
+	#attachListener(active: ActiveSession): void {
+		active.gateway.subscribe(event => {
+			if (active.settled) return;
+			if (active.cancelling) return;
+			if (event.type === "session_event" && event.event.type === "assistant_end") {
+				active.assistantError = event.event.hasError ? "Assistant turn ended with an error." : undefined;
+			}
+			if (event.type === "session_event" && event.event.type === "agent_end") {
+				const terminal: AgentEvent = active.assistantError
+					? { type: "task.failed", taskId: active.taskId, error: active.assistantError }
+					: { type: "task.completed", taskId: active.taskId, summary: "" };
+				void this.#settle(active, terminal);
+				return;
+			}
+
 			const translated = translateGatewayEvent(active.taskId, event);
-			for (const e of translated) {
-				active.channel.push(e);
+			for (const translatedEvent of translated) {
+				if (translatedEvent.type === "task.failed") {
+					void this.#settle(active, translatedEvent);
+					return;
+				}
+				active.channel.push(translatedEvent);
 			}
 		});
+	}
+
+	async #settle(active: ActiveSession, terminal: AgentEvent): Promise<void> {
+		if (active.settled) return;
+		active.settled = true;
+		this.#sessions.delete(active.taskId);
+		active.channel.push(terminal);
+		active.channel.close();
+		active.gateway.dispose();
+		try {
+			await active.session.dispose();
+		} catch (error) {
+			logger.error("Failed to dispose desktop-tag agent session", {
+				error: error instanceof Error ? error.message : String(error),
+				taskId: active.taskId,
+			});
+		}
 	}
 }
 
 async function loadImage(path: string): Promise<ImageContent> {
-	const bytes = await fs.readFile(path);
+	const bytes = await Bun.file(path).bytes();
 	return {
 		type: "image",
-		data: bytes.toString("base64"),
+		data: bytes.toBase64(),
 		mimeType: "image/png",
 		detail: "high",
 	};
@@ -209,7 +287,9 @@ function buildInitialMessage(packet: ContextPacket, routing: RoutingDecision): s
 		`Routing: ${routing.message}`,
 	];
 	if (packet.foregroundApp.processName) {
-		lines.push(`Foreground app: ${packet.foregroundApp.processName} - ${packet.foregroundApp.windowTitle ?? "unknown window"}`);
+		lines.push(
+			`Foreground app: ${packet.foregroundApp.processName} - ${packet.foregroundApp.windowTitle ?? "unknown window"}`,
+		);
 	}
 	if (packet.browser.url) {
 		lines.push(`Active browser tab: ${packet.browser.title ?? ""} (${packet.browser.url})`);
@@ -235,9 +315,7 @@ function translateGatewayEvent(taskId: string, event: GatewayEvent): AgentEvent[
 				case "assistant_text_delta":
 					return [{ type: "agent.message.delta", text: ev.text }];
 				case "assistant_end":
-					return ev.hasError
-						? [{ type: "task.failed", taskId, error: "Assistant turn ended with an error." }]
-						: [{ type: "task.completed", taskId, summary: "" }];
+					return [];
 				case "tool_start":
 					return [{ type: "tool.started", callId: ev.toolCallId, toolName: ev.toolName }];
 				case "tool_end":

--- a/packages/desktop-tag/src/worker.ts
+++ b/packages/desktop-tag/src/worker.ts
@@ -5,8 +5,11 @@ import {
 	createAgentSession,
 } from "@pk-nerdsaver-ai/pi-coding-agent";
 import { AgentSessionGateway } from "@pk-nerdsaver-ai/pi-coding-agent/gateway/agent-session-gateway";
-import type { GatewayEvent } from "@pk-nerdsaver-ai/pi-coding-agent/gateway/types";
-import type { AgentSession } from "@pk-nerdsaver-ai/pi-coding-agent/session/agent-session";
+import type {
+	GatewayCommand,
+	GatewayEvent,
+	GatewayEventListener,
+} from "@pk-nerdsaver-ai/pi-coding-agent/gateway/types";
 import type {
 	ClientBridge,
 	ClientBridgePermissionOption,
@@ -28,9 +31,23 @@ import type {
 	TaskInput,
 } from "./types";
 
-interface ActiveSession {
-	session: AgentSession;
-	gateway: AgentSessionGateway;
+interface WorkerSession {
+	setClientBridge(bridge: ClientBridge): void;
+	dispose(): Promise<void>;
+}
+
+interface WorkerGateway {
+	dispatch(command: GatewayCommand): Promise<void>;
+	subscribe(listener: GatewayEventListener): () => void;
+	dispose(): void;
+}
+
+interface WorkerRuntime {
+	session: WorkerSession;
+	gateway: WorkerGateway;
+}
+
+interface ActiveSession extends WorkerRuntime {
 	channel: AgentEventChannel;
 	bridge: DesktopTagClientBridge;
 	controller: AbortController;
@@ -42,6 +59,8 @@ interface ActiveSession {
 }
 
 type AgentSessionFactory = (options: CreateAgentSessionOptions) => Promise<CreateAgentSessionResult>;
+type AgentRuntimeFactory = (options: CreateAgentSessionOptions) => Promise<WorkerRuntime>;
+type WorkerFactory = AgentSessionFactory | AgentRuntimeFactory;
 
 /** Bridges permission requests from the agent into the overlay approval flow. */
 class DesktopTagClientBridge implements ClientBridge {
@@ -65,14 +84,19 @@ class DesktopTagClientBridge implements ClientBridge {
 		this.#pending.set(toolCall.toolCallId, resolve);
 
 		const allowedOptions = options.map(o => o.optionId).filter(id => id.startsWith("allow"));
-		const scope: ApprovalRequest["scope"] = allowedOptions.includes("allow_always") ? "session" : "once";
+		const scope: ApprovalRequest["scope"] = allowedOptions.includes("allow_once") ? "once" : "session";
 		const level: ActionLevel = scope === "session" ? 2 : 1;
+		const rawInput = toolCall.rawInput;
+		const requestArguments: Record<string, unknown> =
+			typeof rawInput === "object" && rawInput !== null && !Array.isArray(rawInput)
+				? Object.fromEntries(Object.entries(rawInput))
+				: {};
 
 		const request: ApprovalRequest = {
 			actionId: toolCall.toolCallId,
 			stepId: toolCall.toolCallId,
 			toolName: toolCall.toolName,
-			arguments: (toolCall.rawInput as Record<string, unknown>) ?? {},
+			arguments: requestArguments,
 			effects: toolCall.title,
 			level,
 			scope,
@@ -106,13 +130,13 @@ class DesktopTagClientBridge implements ClientBridge {
 	}
 }
 
-/** A worker that delegates tasks to a local {@link AgentSession} through the gateway. */
+/** A worker that delegates tasks to a local agent session through the gateway. */
 export class PiWorker implements AgentWorker {
 	readonly #sessions = new Map<string, ActiveSession>();
-	readonly #sessionFactory: AgentSessionFactory;
+	readonly #factory: WorkerFactory;
 
-	constructor(sessionFactory: AgentSessionFactory = createAgentSession) {
-		this.#sessionFactory = sessionFactory;
+	constructor(factory: WorkerFactory = createAgentSession) {
+		this.#factory = factory;
 	}
 
 	async createSession(taskId: string, input: TaskInput): Promise<SessionHandle> {
@@ -138,14 +162,12 @@ export class PiWorker implements AgentWorker {
 		const message = buildInitialMessage(contextPacket, routing);
 		const images = contextPacket.visual.screenshotPath ? [await loadImage(contextPacket.visual.screenshotPath)] : [];
 
-		const { session } = await this.#sessionFactory(options);
+		const { session, gateway } = await this.#createRuntime(options);
 
 		const channel = new AgentEventChannel();
 		const controller = new AbortController();
 		const bridge = new DesktopTagClientBridge(channel, controller.signal);
 		session.setClientBridge(bridge);
-
-		const gateway = new AgentSessionGateway(session);
 		const active: ActiveSession = {
 			session,
 			gateway,
@@ -160,17 +182,32 @@ export class PiWorker implements AgentWorker {
 		this.#attachListener(active);
 
 		// Let the caller attach its replaying subscription before a fast session can settle and leave the active registry.
-		void Bun.sleep(0).then(() =>
-			gateway.dispatch({
-				id: crypto.randomUUID(),
-				type: "prompt",
-				identity: { channelId: "desktop-tag", sessionKey: taskId },
-				message,
-				images,
-			}),
-		);
+		void Bun.sleep(0)
+			.then(async () => {
+				if (active.settled || active.cancelling || controller.signal.aborted) return;
+				await gateway.dispatch({
+					id: crypto.randomUUID(),
+					type: "prompt",
+					identity: { channelId: "desktop-tag", sessionKey: taskId },
+					message,
+					images,
+				});
+			})
+			.catch(error =>
+				this.#settle(active, {
+					type: "task.failed",
+					taskId,
+					error: `Failed to start task: ${error instanceof Error ? error.message : String(error)}`,
+				}),
+			);
 
 		return { sessionId: taskId };
+	}
+
+	async #createRuntime(options: CreateAgentSessionOptions): Promise<WorkerRuntime> {
+		const created = await this.#factory(options);
+		if ("gateway" in created) return created;
+		return { session: created.session, gateway: new AgentSessionGateway(created.session) };
 	}
 
 	async sendMessage(sessionId: string, message: string, images?: ImageContent[]): Promise<void> {
@@ -188,9 +225,14 @@ export class PiWorker implements AgentWorker {
 	async approve(sessionId: string, actionId: string, decision: ApprovalDecision): Promise<void> {
 		const active = this.#sessions.get(sessionId);
 		if (!active) throw new Error(`Session ${sessionId} not found`);
+		if (decision.editedArguments !== undefined) {
+			throw new Error("Edited approval arguments are not supported by the desktop-tag worker.");
+		}
+		if (decision.scope === "group" || decision.scope === "application") {
+			throw new Error(`Approval scope "${decision.scope}" is not supported by the desktop-tag worker.`);
+		}
 		if (decision.allowed) {
-			const optionId =
-				decision.scope === "session" || decision.scope === "application" ? "allow_always" : "allow_once";
+			const optionId = decision.scope === "session" ? "allow_always" : "allow_once";
 			active.bridge.resolve(actionId, { outcome: "selected", optionId });
 		} else {
 			active.bridge.resolve(actionId, { outcome: "cancelled" });

--- a/packages/desktop-tag/src/worker.ts
+++ b/packages/desktop-tag/src/worker.ts
@@ -1,0 +1,263 @@
+import * as fs from "node:fs/promises";
+
+import type { ImageContent } from "@pk-nerdsaver-ai/pi-ai";
+import { createAgentSession, type CreateAgentSessionOptions } from "@pk-nerdsaver-ai/pi-coding-agent";
+import { AgentSessionGateway } from "@pk-nerdsaver-ai/pi-coding-agent/gateway/agent-session-gateway";
+import type { GatewayEvent } from "@pk-nerdsaver-ai/pi-coding-agent/gateway/types";
+import type { AgentSession } from "@pk-nerdsaver-ai/pi-coding-agent/session/agent-session";
+import type {
+	ClientBridge,
+	ClientBridgePermissionOption,
+	ClientBridgePermissionOutcome,
+	ClientBridgePermissionToolCall,
+} from "@pk-nerdsaver-ai/pi-coding-agent/session/client-bridge";
+import { getProjectDir, logger } from "@pk-nerdsaver-ai/pi-utils";
+
+import { AgentEventChannel } from "./events";
+import type {
+	ActionLevel,
+	AgentEvent,
+	AgentWorker,
+	ApprovalDecision,
+	ApprovalRequest,
+	ContextPacket,
+	RoutingDecision,
+	SessionHandle,
+	TaskInput,
+} from "./types";
+
+interface ActiveSession {
+	gateway: AgentSessionGateway;
+	channel: AgentEventChannel;
+	bridge: DesktopTagClientBridge;
+	taskId: string;
+}
+
+/** Bridges permission requests from the agent into the overlay approval flow. */
+class DesktopTagClientBridge implements ClientBridge {
+	readonly capabilities = { requestPermission: true };
+	readonly #channel: AgentEventChannel;
+	readonly #pending = new Map<string, (outcome: ClientBridgePermissionOutcome) => void>();
+	readonly #taskId: string;
+
+	constructor(taskId: string, channel: AgentEventChannel) {
+		this.#taskId = taskId;
+		this.#channel = channel;
+	}
+
+	async requestPermission(
+		toolCall: ClientBridgePermissionToolCall,
+		options: ClientBridgePermissionOption[],
+		signal?: AbortSignal,
+	): Promise<ClientBridgePermissionOutcome> {
+		const { promise, resolve } = Promise.withResolvers<ClientBridgePermissionOutcome>();
+		this.#pending.set(toolCall.toolCallId, resolve);
+
+		const allowedOptions = options.map(o => o.optionId).filter(id => id.startsWith("allow"));
+		const scope: ApprovalRequest["scope"] = allowedOptions.includes("allow_always") ? "session" : "once";
+		const level: ActionLevel = scope === "session" ? 2 : 1;
+
+		const request: ApprovalRequest = {
+			actionId: toolCall.toolCallId,
+			stepId: toolCall.toolCallId,
+			toolName: toolCall.toolName,
+			arguments: (toolCall.rawInput as Record<string, unknown>) ?? {},
+			effects: toolCall.title,
+			level,
+			scope,
+		};
+
+		this.#channel.push({
+			type: "approval.requested",
+			request,
+		});
+
+		if (signal) {
+			signal.addEventListener("abort", () => this.resolve(toolCall.toolCallId, { outcome: "cancelled" }), { once: true });
+		}
+
+		try {
+			return await promise;
+		} finally {
+			this.#pending.delete(toolCall.toolCallId);
+		}
+	}
+
+	resolve(toolCallId: string, outcome: ClientBridgePermissionOutcome): void {
+		const resolver = this.#pending.get(toolCallId);
+		if (resolver) resolver(outcome);
+	}
+
+	get actionIds(): string[] {
+		return [...this.#pending.keys()];
+	}
+}
+
+/** A worker that delegates tasks to a local {@link AgentSession} through the gateway. */
+export class PiWorker implements AgentWorker {
+	readonly #sessions = new Map<string, ActiveSession>();
+
+	async createSession(taskId: string, input: TaskInput): Promise<SessionHandle> {
+		const { contextPacket, preferredExecutor } = input;
+		const routing = input.routing;
+
+		const promptLines = [
+			"You are operating in desktop-tag mode.",
+			"A screenshot or selected context has been captured from the user's desktop.",
+			"Use the provided context to answer or act. Prefer non-destructive, reversible actions.",
+		];
+		if (preferredExecutor) {
+			promptLines.push(`Preferred executor for this task: ${preferredExecutor}.`);
+		}
+
+		const options: CreateAgentSessionOptions = {
+			cwd: getProjectDir(),
+			hasUI: true,
+			toolNames: routing.tools,
+			appendSystemPrompt: promptLines.join("\n"),
+		};
+
+		const { session } = await createAgentSession(options);
+
+		const channel = new AgentEventChannel();
+		const bridge = new DesktopTagClientBridge(taskId, channel);
+		session.setClientBridge(bridge);
+
+		const gateway = new AgentSessionGateway(session as AgentSession);
+		const active: ActiveSession = { gateway, channel, bridge, taskId };
+		this.#sessions.set(taskId, active);
+
+		this.#attachListener(active, gateway);
+
+		const message = buildInitialMessage(contextPacket, routing);
+		const images = contextPacket.visual.screenshotPath ? [await loadImage(contextPacket.visual.screenshotPath)] : [];
+
+		await gateway.dispatch({
+			id: crypto.randomUUID(),
+			type: "prompt",
+			identity: { channelId: "desktop-tag", sessionKey: taskId },
+			message,
+			images,
+		});
+
+		return { sessionId: taskId };
+	}
+
+	async sendMessage(sessionId: string, message: string, images?: ImageContent[]): Promise<void> {
+		const active = this.#sessions.get(sessionId);
+		if (!active) throw new Error(`Session ${sessionId} not found`);
+		await active.gateway.dispatch({
+			id: crypto.randomUUID(),
+			type: "prompt",
+			identity: { channelId: "desktop-tag", sessionKey: sessionId },
+			message,
+			images,
+		});
+	}
+
+	async approve(sessionId: string, actionId: string, decision: ApprovalDecision): Promise<void> {
+		const active = this.#sessions.get(sessionId);
+		if (!active) throw new Error(`Session ${sessionId} not found`);
+		if (decision.allowed) {
+			const optionId = decision.scope === "session" || decision.scope === "application" ? "allow_always" : "allow_once";
+			active.bridge.resolve(actionId, { outcome: "selected", optionId });
+		} else {
+			active.bridge.resolve(actionId, { outcome: "cancelled" });
+		}
+	}
+
+	async cancel(sessionId: string): Promise<void> {
+		const active = this.#sessions.get(sessionId);
+		if (!active) return;
+		await active.gateway.dispatch({
+			id: crypto.randomUUID(),
+			type: "abort",
+			identity: { channelId: "desktop-tag", sessionKey: sessionId },
+		});
+	}
+
+	subscribe(sessionId: string): AsyncIterable<AgentEvent> {
+		const active = this.#sessions.get(sessionId);
+		if (!active) throw new Error(`Session ${sessionId} not found`);
+		return active.channel.subscribe();
+	}
+
+	#attachListener(active: ActiveSession, gateway: AgentSessionGateway): void {
+		gateway.subscribe(event => {
+			const translated = translateGatewayEvent(active.taskId, event);
+			for (const e of translated) {
+				active.channel.push(e);
+			}
+		});
+	}
+}
+
+async function loadImage(path: string): Promise<ImageContent> {
+	const bytes = await fs.readFile(path);
+	return {
+		type: "image",
+		data: bytes.toString("base64"),
+		mimeType: "image/png",
+		detail: "high",
+	};
+}
+
+function buildInitialMessage(packet: ContextPacket, routing: RoutingDecision): string {
+	const lines = [
+		`The user asked: ${packet.userRequest}`,
+		`Capture mode: ${packet.captureMode}`,
+		`Routing: ${routing.message}`,
+	];
+	if (packet.foregroundApp.processName) {
+		lines.push(`Foreground app: ${packet.foregroundApp.processName} - ${packet.foregroundApp.windowTitle ?? "unknown window"}`);
+	}
+	if (packet.browser.url) {
+		lines.push(`Active browser tab: ${packet.browser.title ?? ""} (${packet.browser.url})`);
+	}
+	if (packet.selection.clipboardText) {
+		lines.push(`Clipboard/selection text: ${packet.selection.clipboardText}`);
+	}
+	lines.push("Use the attached screenshot and context to answer or act.");
+	return lines.join("\n");
+}
+
+function translateGatewayEvent(taskId: string, event: GatewayEvent): AgentEvent[] {
+	switch (event.type) {
+		case "ready":
+			return [];
+		case "session_event": {
+			const ev = event.event;
+			switch (ev.type) {
+				case "agent_start":
+					return [{ type: "task.started", taskId }];
+				case "agent_end":
+					return [];
+				case "assistant_text_delta":
+					return [{ type: "agent.message.delta", text: ev.text }];
+				case "assistant_end":
+					return ev.hasError
+						? [{ type: "task.failed", taskId, error: "Assistant turn ended with an error." }]
+						: [{ type: "task.completed", taskId, summary: "" }];
+				case "tool_start":
+					return [{ type: "tool.started", callId: ev.toolCallId, toolName: ev.toolName }];
+				case "tool_end":
+					return [{ type: "tool.completed", callId: ev.toolCallId, result: null, isError: ev.isError }];
+				case "notice":
+					return [{ type: "agent.message.delta", text: `[${ev.level}] ${ev.message}` }];
+				case "thinking_level_changed":
+					return [];
+				default:
+					return [];
+			}
+		}
+		case "response": {
+			if (event.success) return [];
+			return [{ type: "task.failed", taskId, error: event.error }];
+		}
+		case "protocol_error":
+			return [{ type: "task.failed", taskId, error: event.error }];
+		default:
+			logger.debug("Unhandled gateway event", { type: (event as { type: string }).type });
+			return [];
+	}
+}

--- a/packages/desktop-tag/test/context.test.ts
+++ b/packages/desktop-tag/test/context.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+
+import { assertCaptureOptions, captureScreenshot } from "../src/context";
+import type { CaptureRegion } from "../src/types";
+
+const invalidRegions: Array<[keyof CaptureRegion, CaptureRegion]> = [
+	["x", { x: 0, y: 1, width: 10, height: 10 }],
+	["y", { x: 1, y: Number.NaN, width: 10, height: 10 }],
+	["width", { x: 1, y: 1, width: -1, height: 10 }],
+	["height", { x: 1, y: 1, width: 10, height: Number.POSITIVE_INFINITY }],
+];
+
+describe("capture validation", () => {
+	it("requires a region for region captures", () => {
+		expect(() => assertCaptureOptions({ mode: "region", userRequest: "inspect this" })).toThrow(
+			"Region capture requires a region",
+		);
+	});
+
+	it("rejects unknown capture modes", () => {
+		expect(() => assertCaptureOptions({ mode: "desktop", userRequest: "inspect this" })).toThrow(
+			"Unsupported capture mode",
+		);
+	});
+
+	it.each(invalidRegions)("rejects an invalid %s before screenshot capture", async (field, region) => {
+		await expect(captureScreenshot("unused.png", region)).rejects.toThrow(
+			`Capture region ${field} must be a finite positive number`,
+		);
+	});
+
+	it("rejects a malformed region supplied for a non-region mode", () => {
+		expect(() =>
+			assertCaptureOptions({
+				mode: "screen",
+				userRequest: "inspect this",
+				region: { x: 1, y: 1, width: 0, height: 10 },
+			}),
+		).toThrow("Capture region width must be a finite positive number");
+	});
+});

--- a/packages/desktop-tag/test/context.test.ts
+++ b/packages/desktop-tag/test/context.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, it } from "bun:test";
 
-import { assertCaptureOptions, captureScreenshot } from "../src/context";
+import {
+	assertCaptureOptions,
+	buildScreenshotScript,
+	buildWindowScreenshotScript,
+	captureScreenshot,
+	requestIxBridgeCommand,
+} from "../src/context";
 import type { CaptureRegion } from "../src/types";
 
-const invalidRegions: Array<[keyof CaptureRegion, CaptureRegion]> = [
-	["x", { x: 0, y: 1, width: 10, height: 10 }],
-	["y", { x: 1, y: Number.NaN, width: 10, height: 10 }],
-	["width", { x: 1, y: 1, width: -1, height: 10 }],
-	["height", { x: 1, y: 1, width: 10, height: Number.POSITIVE_INFINITY }],
+const invalidRegions: Array<[keyof CaptureRegion, CaptureRegion, string]> = [
+	["x", { x: Number.NEGATIVE_INFINITY, y: 1, width: 10, height: 10 }, "finite number"],
+	["y", { x: 1, y: Number.NaN, width: 10, height: 10 }, "finite number"],
+	["width", { x: 1, y: 1, width: 0, height: 10 }, "finite positive number"],
+	["width", { x: 1, y: 1, width: -1, height: 10 }, "finite positive number"],
+	["height", { x: 1, y: 1, width: 10, height: Number.POSITIVE_INFINITY }, "finite positive number"],
 ];
 
 describe("capture validation", () => {
@@ -17,15 +24,22 @@ describe("capture validation", () => {
 		);
 	});
 
+	it.each([
+		["zero", { x: 0, y: 0, width: 10, height: 10 }],
+		["negative", { x: -1920, y: -240, width: 1920, height: 1080 }],
+	] as const)("accepts %s desktop origins", (_name, region) => {
+		expect(() => assertCaptureOptions({ mode: "region", userRequest: "inspect this", region })).not.toThrow();
+	});
+
 	it("rejects unknown capture modes", () => {
 		expect(() => assertCaptureOptions({ mode: "desktop", userRequest: "inspect this" })).toThrow(
 			"Unsupported capture mode",
 		);
 	});
 
-	it.each(invalidRegions)("rejects an invalid %s before screenshot capture", async (field, region) => {
+	it.each(invalidRegions)("rejects an invalid %s before screenshot capture", async (field, region, requirement) => {
 		await expect(captureScreenshot("unused.png", region)).rejects.toThrow(
-			`Capture region ${field} must be a finite positive number`,
+			`Capture region ${field} must be a ${requirement}`,
 		);
 	});
 
@@ -37,5 +51,55 @@ describe("capture validation", () => {
 				region: { x: 1, y: 1, width: 0, height: 10 },
 			}),
 		).toThrow("Capture region width must be a finite positive number");
+	});
+});
+
+describe("screenshot modes", () => {
+	it("uses foreground HWND bounds for window capture, not primary-screen bounds", () => {
+		const script = buildWindowScreenshotScript("C:\\temp\\window.png");
+
+		expect(script).toContain("GetForegroundWindow");
+		expect(script).toContain("GetWindowRect");
+		expect(script).toContain("$bounds.Left, $bounds.Top");
+		expect(script).not.toContain("PrimaryScreen");
+	});
+
+	it("keeps full-screen and explicit-region capture paths distinct", () => {
+		const screenScript = buildScreenshotScript("screen.png");
+		const regionScript = buildScreenshotScript("region.png", { x: -100, y: 20, width: 300, height: 200 });
+
+		expect(screenScript).toContain("PrimaryScreen.Bounds");
+		expect(regionScript).toContain("CopyFromScreen(-100, 20, 0, 0");
+		expect(regionScript).not.toContain("GetForegroundWindow");
+	});
+});
+
+describe("IX Bridge command timeout", () => {
+	it("gives each browser command a fresh bounded abort signal", async () => {
+		const originalFetch = globalThis.fetch;
+		const signals: AbortSignal[] = [];
+		const bodies: string[] = [];
+		globalThis.fetch = ((_input: string | URL | Request, init?: RequestInit) => {
+			if (!init?.signal) throw new Error("missing abort signal");
+			signals.push(init.signal);
+			bodies.push(String(init.body));
+			return new Promise<Response>((_resolve, reject) => {
+				init.signal?.addEventListener("abort", () => reject(new Error("request aborted")), { once: true });
+			});
+		}) as typeof fetch;
+
+		try {
+			const results = await Promise.allSettled([
+				requestIxBridgeCommand("get_url", 5),
+				requestIxBridgeCommand("get_title", 5),
+			]);
+			expect(results.map(result => result.status)).toEqual(["rejected", "rejected"]);
+			expect(signals).toHaveLength(2);
+			expect(signals[0]).not.toBe(signals[1]);
+			expect(signals.every(signal => signal.aborted)).toBe(true);
+			expect(bodies.map(body => JSON.parse(body).action)).toEqual(["get_url", "get_title"]);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
 	});
 });

--- a/packages/desktop-tag/test/events.test.ts
+++ b/packages/desktop-tag/test/events.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+
+import { AgentEventChannel, parseAgentEvent, serializeAgentEvent } from "../src/events";
+import type { AgentEvent } from "../src/types";
+
+describe("AgentEventChannel", () => {
+	it("pushes events to an async iterator", async () => {
+		const channel = new AgentEventChannel();
+		const event: AgentEvent = { type: "task.started", taskId: "t1" };
+		channel.push(event);
+
+		const iterator = channel.subscribe()[Symbol.asyncIterator]();
+		const next = await iterator.next();
+		expect(next.value).toEqual(event);
+	});
+
+	it("waits for new events when the buffer is empty", async () => {
+		const channel = new AgentEventChannel();
+		const iterator = channel.subscribe()[Symbol.asyncIterator]();
+
+		const nextPromise = iterator.next();
+		channel.push({ type: "agent.message.delta", text: "hello" });
+
+		const next = await nextPromise;
+		expect(next.value).toEqual({ type: "agent.message.delta", text: "hello" });
+	});
+
+	it("ends iteration after close", async () => {
+		const channel = new AgentEventChannel();
+		const iterator = channel.subscribe()[Symbol.asyncIterator]();
+		channel.close();
+
+		const next = await iterator.next();
+		expect(next.done).toBe(true);
+	});
+});
+
+describe("serializeAgentEvent / parseAgentEvent", () => {
+	it("round-trips events", () => {
+		const event: AgentEvent = { type: "task.completed", taskId: "t1", summary: "done" };
+		const serialized = serializeAgentEvent(event);
+		const parsed = parseAgentEvent(serialized);
+
+		expect(parsed).toEqual(event);
+	});
+
+	it("returns undefined for malformed JSON", () => {
+		expect(parseAgentEvent("not json")).toBeUndefined();
+	});
+
+	it("returns undefined for objects without a type", () => {
+		expect(parseAgentEvent(JSON.stringify({ foo: "bar" }))).toBeUndefined();
+	});
+});

--- a/packages/desktop-tag/test/events.test.ts
+++ b/packages/desktop-tag/test/events.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import { parseAgentEvent, serializeAgentEvent, TaskEventChannel } from "../src/events";
-import type { AgentEvent } from "../src/types";
+import type { AgentEvent, ContextPacket } from "../src/types";
 
 describe("TaskEventChannel", () => {
 	it("replays events published before subscription in order", async () => {
@@ -68,19 +68,235 @@ describe("TaskEventChannel", () => {
 });
 
 describe("serializeAgentEvent / parseAgentEvent", () => {
-	it("round-trips events", () => {
-		const event: AgentEvent = { type: "task.completed", taskId: "t1", summary: "done" };
-		const serialized = serializeAgentEvent(event);
-		const parsed = parseAgentEvent(serialized);
+	const contextPacket: ContextPacket = {
+		captureId: "capture-1",
+		timestamp: "2026-07-10T12:00:00.000Z",
+		userRequest: "Explain this window",
+		captureMode: "region",
+		visual: {
+			screenshotPath: "C:/tmp/capture.png",
+			screenshotImage: { type: "image", data: "aW1hZ2U=", mimeType: "image/png", detail: "high" },
+			selectedRegion: { x: -10, y: 20, width: 640, height: 480 },
+			displayScale: 1.25,
+			annotations: [{ id: "annotation-1", type: "rectangle", bounds: [1, 2, 3, 4], label: "target" }],
+		},
+		foregroundApp: {
+			processName: "example.exe",
+			windowTitle: "Example",
+			executablePath: "C:/Example/example.exe",
+		},
+		browser: {
+			url: "https://example.com",
+			title: "Example",
+			tabId: "tab-1",
+			domSnapshotRef: "dom-1",
+			accessibilityTreeRef: "a11y-1",
+		},
+		selection: { text: "selected", clipboardText: "copied" },
+		availableCapabilities: ["capture", "browser"],
+	};
 
-		expect(parsed).toEqual(event);
+	const validEvents: AgentEvent[] = [
+		{ type: "task.started", taskId: "task-1" },
+		{ type: "agent.message.delta", text: "hello" },
+		{
+			type: "plan.updated",
+			steps: [
+				{
+					id: "step-1",
+					executorId: "executor-1",
+					capability: "capture",
+					arguments: { target: "window", retries: 2 },
+					level: 2,
+					description: "Capture the active window",
+					requiresApproval: true,
+				},
+			],
+		},
+		{ type: "tool.requested", callId: "call-1", toolName: "capture", arguments: { mode: "window" } },
+		{
+			type: "approval.requested",
+			request: {
+				actionId: "action-1",
+				stepId: "step-1",
+				level: 3,
+				toolName: "shell",
+				arguments: { command: "example" },
+				effects: "Runs a command",
+				scope: "once",
+			},
+		},
+		{ type: "tool.started", callId: "call-1", toolName: "capture" },
+		{ type: "tool.completed", callId: "call-1", result: { path: "capture.png" }, isError: false },
+		{ type: "observation.updated", screenshotRef: "capture.png", contextPacket },
+		{ type: "task.blocked", taskId: "task-1", reason: "Approval required" },
+		{ type: "task.completed", taskId: "task-1", summary: "Done" },
+		{ type: "task.failed", taskId: "task-1", error: "Failed" },
+	];
+
+	it.each(validEvents.map(event => [event.type, event] as const))("round-trips valid %s events", (_type, event) => {
+		expect(parseAgentEvent(serializeAgentEvent(event))).toEqual(event);
+	});
+
+	const malformedEvents: ReadonlyArray<readonly [string, unknown]> = [
+		["null payloads", null],
+		["array payloads", []],
+		["primitive payloads", "task.started"],
+		["objects without a type", { taskId: "task-1" }],
+		["unknown discriminants", { type: "task.paused", taskId: "task-1" }],
+		["task.started without a task id", { type: "task.started" }],
+		["agent.message.delta with non-string text", { type: "agent.message.delta", text: 1 }],
+		["plan.updated with non-array steps", { type: "plan.updated", steps: {} }],
+		[
+			"plan.updated with malformed step arguments",
+			{
+				type: "plan.updated",
+				steps: [
+					{
+						id: "step-1",
+						executorId: "executor-1",
+						capability: "capture",
+						arguments: [],
+						level: 2,
+						description: "Capture",
+						requiresApproval: true,
+					},
+				],
+			},
+		],
+		[
+			"plan.updated with an invalid action level",
+			{
+				type: "plan.updated",
+				steps: [
+					{
+						id: "step-1",
+						executorId: "executor-1",
+						capability: "capture",
+						arguments: {},
+						level: 4,
+						description: "Capture",
+						requiresApproval: true,
+					},
+				],
+			},
+		],
+		[
+			"plan.updated with a non-boolean approval flag",
+			{
+				type: "plan.updated",
+				steps: [
+					{
+						id: "step-1",
+						executorId: "executor-1",
+						capability: "capture",
+						arguments: {},
+						level: 1,
+						description: "Capture",
+						requiresApproval: "true",
+					},
+				],
+			},
+		],
+		[
+			"tool.requested with non-record arguments",
+			{ type: "tool.requested", callId: "call-1", toolName: "capture", arguments: [] },
+		],
+		[
+			"approval.requested with malformed nested fields",
+			{
+				type: "approval.requested",
+				request: {
+					actionId: "action-1",
+					stepId: "step-1",
+					level: "3",
+					toolName: "shell",
+					arguments: {},
+					effects: "Runs a command",
+					scope: "forever",
+				},
+			},
+		],
+		[
+			"approval.requested with non-record arguments",
+			{
+				type: "approval.requested",
+				request: {
+					actionId: "action-1",
+					stepId: "step-1",
+					level: 2,
+					toolName: "shell",
+					arguments: [],
+					effects: "Runs a command",
+				},
+			},
+		],
+		["tool.started with a missing tool name", { type: "tool.started", callId: "call-1" }],
+		["tool.completed with a missing result", { type: "tool.completed", callId: "call-1", isError: false }],
+		[
+			"tool.completed with a non-boolean error flag",
+			{ type: "tool.completed", callId: "call-1", result: null, isError: "false" },
+		],
+		[
+			"observation.updated with a malformed visual context",
+			{
+				type: "observation.updated",
+				contextPacket: {
+					...contextPacket,
+					visual: {
+						...contextPacket.visual,
+						annotations: [{ id: "annotation-1", type: "rectangle", bounds: [1, 2, 3] }],
+					},
+				},
+			},
+		],
+		[
+			"observation.updated with a malformed image",
+			{
+				type: "observation.updated",
+				contextPacket: {
+					...contextPacket,
+					visual: {
+						...contextPacket.visual,
+						screenshotImage: { type: "image", data: 42, mimeType: "image/png" },
+					},
+				},
+			},
+		],
+		[
+			"observation.updated with a malformed capture mode",
+			{ type: "observation.updated", contextPacket: { ...contextPacket, captureMode: "application" } },
+		],
+		[
+			"observation.updated with malformed capabilities",
+			{
+				type: "observation.updated",
+				contextPacket: { ...contextPacket, availableCapabilities: ["capture", false] },
+			},
+		],
+		[
+			"observation.updated with a malformed selected region",
+			{
+				type: "observation.updated",
+				contextPacket: {
+					...contextPacket,
+					visual: {
+						...contextPacket.visual,
+						selectedRegion: { x: 0, y: 0, width: "640", height: 480 },
+					},
+				},
+			},
+		],
+		["task.blocked without a reason", { type: "task.blocked", taskId: "task-1" }],
+		["task.completed with a non-string summary", { type: "task.completed", taskId: "task-1", summary: true }],
+		["task.failed with a non-string error", { type: "task.failed", taskId: "task-1", error: {} }],
+	];
+
+	it.each(malformedEvents)("rejects %s", (_name, event) => {
+		expect(parseAgentEvent(JSON.stringify(event))).toBeUndefined();
 	});
 
 	it("returns undefined for malformed JSON", () => {
 		expect(parseAgentEvent("not json")).toBeUndefined();
-	});
-
-	it("returns undefined for objects without a type", () => {
-		expect(parseAgentEvent(JSON.stringify({ foo: "bar" }))).toBeUndefined();
 	});
 });

--- a/packages/desktop-tag/test/events.test.ts
+++ b/packages/desktop-tag/test/events.test.ts
@@ -1,37 +1,69 @@
 import { describe, expect, it } from "bun:test";
 
-import { AgentEventChannel, parseAgentEvent, serializeAgentEvent } from "../src/events";
+import { parseAgentEvent, serializeAgentEvent, TaskEventChannel } from "../src/events";
 import type { AgentEvent } from "../src/types";
 
-describe("AgentEventChannel", () => {
-	it("pushes events to an async iterator", async () => {
-		const channel = new AgentEventChannel();
-		const event: AgentEvent = { type: "task.started", taskId: "t1" };
-		channel.push(event);
-
-		const iterator = channel.subscribe()[Symbol.asyncIterator]();
-		const next = await iterator.next();
-		expect(next.value).toEqual(event);
-	});
-
-	it("waits for new events when the buffer is empty", async () => {
-		const channel = new AgentEventChannel();
-		const iterator = channel.subscribe()[Symbol.asyncIterator]();
-
-		const nextPromise = iterator.next();
-		channel.push({ type: "agent.message.delta", text: "hello" });
-
-		const next = await nextPromise;
-		expect(next.value).toEqual({ type: "agent.message.delta", text: "hello" });
-	});
-
-	it("ends iteration after close", async () => {
-		const channel = new AgentEventChannel();
-		const iterator = channel.subscribe()[Symbol.asyncIterator]();
+describe("TaskEventChannel", () => {
+	it("replays events published before subscription in order", async () => {
+		const channel = new TaskEventChannel();
+		const events: AgentEvent[] = [
+			{ type: "task.started", taskId: "t1" },
+			{ type: "agent.message.delta", text: "hello" },
+		];
+		for (const event of events) channel.push(event);
 		channel.close();
 
-		const next = await iterator.next();
-		expect(next.done).toBe(true);
+		const received = await Array.fromAsync(channel.subscribe());
+		expect(received).toEqual(events);
+	});
+
+	it("multicasts the full ordered stream to simultaneous subscribers", async () => {
+		const channel = new TaskEventChannel();
+		const first = Array.fromAsync(channel.subscribe());
+		const second = Array.fromAsync(channel.subscribe());
+		const events: AgentEvent[] = [
+			{ type: "task.started", taskId: "t1" },
+			{ type: "agent.message.delta", text: "one" },
+			{ type: "agent.message.delta", text: "two" },
+		];
+
+		for (const event of events) channel.push(event);
+		channel.close();
+
+		expect(await first).toEqual(events);
+		expect(await second).toEqual(events);
+	});
+
+	it("closes a waiting iterator without fabricating an event", async () => {
+		const channel = new TaskEventChannel();
+		const iterator = channel.subscribe()[Symbol.asyncIterator]();
+		const next = iterator.next();
+
+		channel.close();
+
+		expect(await next).toEqual({ done: true, value: undefined });
+		expect(await iterator.next()).toEqual({ done: true, value: undefined });
+	});
+
+	it("aborts one subscriber without interfering with another", async () => {
+		const channel = new TaskEventChannel();
+		const controller = new AbortController();
+		const aborted = channel.subscribe(controller.signal)[Symbol.asyncIterator]();
+		const active = channel.subscribe()[Symbol.asyncIterator]();
+		const abortedNext = aborted.next();
+		const activeNext = active.next();
+
+		controller.abort();
+		channel.push({ type: "agent.message.delta", text: "still active" });
+
+		expect(await abortedNext).toEqual({ done: true, value: undefined });
+		expect(await activeNext).toEqual({
+			done: false,
+			value: { type: "agent.message.delta", text: "still active" },
+		});
+
+		channel.close();
+		expect(await active.next()).toEqual({ done: true, value: undefined });
 	});
 });
 

--- a/packages/desktop-tag/test/extension.test.ts
+++ b/packages/desktop-tag/test/extension.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, mock } from "bun:test";
-
-import desktopTagExtension from "../src/extension";
 import type { ExtensionAPI } from "@pk-nerdsaver-ai/pi-coding-agent/extensibility/extensions";
+import desktopTagExtension from "../src/extension";
 
 function createFakeApi(): ExtensionAPI {
 	return {

--- a/packages/desktop-tag/test/extension.test.ts
+++ b/packages/desktop-tag/test/extension.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, mock } from "bun:test";
+
+import desktopTagExtension from "../src/extension";
+import type { ExtensionAPI } from "@pk-nerdsaver-ai/pi-coding-agent/extensibility/extensions";
+
+function createFakeApi(): ExtensionAPI {
+	return {
+		setLabel: mock(() => {}),
+		registerCommand: mock(() => {}),
+		registerShortcut: mock(() => {}),
+		registerTool: mock(() => {}),
+		registerFlag: mock(() => {}),
+		getFlag: mock(() => undefined),
+		on: mock(() => {}),
+		sendMessage: mock(() => {}),
+		sendUserMessage: mock(() => {}),
+		appendEntry: mock(() => {}),
+		getActiveTools: mock(() => []),
+		setActiveTools: mock(() => {}),
+	} as unknown as ExtensionAPI;
+}
+
+describe("desktopTagExtension", () => {
+	it("registers command and shortcut", () => {
+		const api = createFakeApi();
+		desktopTagExtension(api);
+
+		expect(api.setLabel).toHaveBeenCalledWith("Desktop Tag");
+		expect(api.registerCommand).toHaveBeenCalled();
+		expect(api.registerShortcut).toHaveBeenCalled();
+	});
+});

--- a/packages/desktop-tag/test/extension.test.ts
+++ b/packages/desktop-tag/test/extension.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, mock } from "bun:test";
 import type { ExtensionAPI } from "@pk-nerdsaver-ai/pi-coding-agent/extensibility/extensions";
-import desktopTagExtension from "../src/extension";
+import desktopTagExtension, { parseCommandArgs } from "../src/extension";
 
 function createFakeApi(): ExtensionAPI {
 	return {
@@ -27,5 +27,64 @@ describe("desktopTagExtension", () => {
 		expect(api.setLabel).toHaveBeenCalledWith("Desktop Tag");
 		expect(api.registerCommand).toHaveBeenCalled();
 		expect(api.registerShortcut).toHaveBeenCalled();
+	});
+});
+
+describe("tag command arguments", () => {
+	it("uses a useful screen request when /tag has no arguments", () => {
+		expect(parseCommandArgs("   ")).toEqual({
+			mode: "screen",
+			request: "Describe what is on my screen.",
+		});
+	});
+
+	it("preserves an explicit mode while defaulting an omitted request", () => {
+		expect(parseCommandArgs("window")).toEqual({
+			mode: "window",
+			request: "Describe what is on my screen.",
+		});
+	});
+
+	it("parses signed region coordinates and a trailing request", () => {
+		expect(parseCommandArgs("region -1920 -240 1920 1080 inspect this monitor")).toEqual({
+			mode: "region",
+			region: { x: -1920, y: -240, width: 1920, height: 1080 },
+			request: "inspect this monitor",
+		});
+	});
+
+	it("defaults the request after valid region coordinates", () => {
+		expect(parseCommandArgs("region 10 20 300 200")).toEqual({
+			mode: "region",
+			region: { x: 10, y: 20, width: 300, height: 200 },
+			request: "Describe what is on my screen.",
+		});
+	});
+
+	it.each([
+		"region",
+		"region 1 2 3",
+		"region nope 2 300 200",
+		"region 1 Infinity 300 200",
+		"region 1 2 0 200",
+		"region 1 2 300 -1",
+	])("rejects invalid region coordinates with usage guidance: %s", args => {
+		expect(() => parseCommandArgs(args)).toThrow("Usage: /tag region <x> <y> <width> <height> [request]");
+	});
+});
+
+describe("region overlay", () => {
+	it("provides four numeric fields and includes the region in capture payloads", async () => {
+		const html = await Bun.file(new URL("../src/overlay.html", import.meta.url)).text();
+
+		expect(html).toContain('id="region-inputs" class="region-inputs hidden" disabled');
+		for (const field of ["x", "y", "width", "height"]) {
+			expect(html).toContain(`type="number" id="region-${field}"`);
+		}
+		expect(html).toContain("regionInputsEl.disabled = !regionMode");
+		expect(html).toContain("request: requestEl.value.trim()");
+		expect(html).not.toContain("userRequest: requestEl.value.trim()");
+		expect(html).toContain("payload.region = region");
+		expect(html).toContain("valueAsNumber");
 	});
 });

--- a/packages/desktop-tag/test/gateway.test.ts
+++ b/packages/desktop-tag/test/gateway.test.ts
@@ -19,14 +19,37 @@ class FixedCaptureService extends CaptureService {
 		};
 	}
 }
+class BlockingCaptureService extends FixedCaptureService {
+	readonly started = Promise.withResolvers<void>();
+	readonly release = Promise.withResolvers<void>();
+	readonly completed = Promise.withResolvers<void>();
+	calls = 0;
+
+	override async capture(options: CaptureOptions): Promise<ContextPacket> {
+		this.calls += 1;
+		this.started.resolve();
+		await this.release.promise;
+		try {
+			return await super.capture(options);
+		} finally {
+			this.completed.resolve();
+		}
+	}
+}
 
 class RecordingWorker implements AgentWorker {
 	readonly sessions: string[] = [];
 	readonly cancellations: string[] = [];
+	readonly approvals: Array<{ sessionId: string; actionId: string; decision: ApprovalDecision }> = [];
 	readonly #subscriptionClosers = new Map<string, () => void>();
 	readonly #cancelled = new Set<string>();
 	readonly #sessionWaiters: Array<(sessionId: string) => void> = [];
 	readonly #cancellationWaiters: Array<(sessionId: string) => void> = [];
+	readonly #cancelBlock?: Promise<void>;
+
+	constructor(cancelBlock?: Promise<void>) {
+		this.#cancelBlock = cancelBlock;
+	}
 
 	async createSession(taskId: string, _input: TaskInput): Promise<SessionHandle> {
 		this.sessions.push(taskId);
@@ -48,13 +71,16 @@ class RecordingWorker implements AgentWorker {
 
 	async sendMessage(_sessionId: string, _message: string): Promise<void> {}
 
-	async approve(_sessionId: string, _actionId: string, _decision: ApprovalDecision): Promise<void> {}
+	async approve(sessionId: string, actionId: string, decision: ApprovalDecision): Promise<void> {
+		this.approvals.push({ sessionId, actionId, decision });
+	}
 
 	async cancel(sessionId: string): Promise<void> {
 		if (this.#cancelled.has(sessionId)) return;
 		this.#cancelled.add(sessionId);
 		this.cancellations.push(sessionId);
 		this.#cancellationWaiters.shift()?.(sessionId);
+		await this.#cancelBlock;
 		this.#subscriptionClosers.get(sessionId)?.();
 		this.#subscriptionClosers.delete(sessionId);
 	}
@@ -84,6 +110,28 @@ async function connect(url: string): Promise<WebSocket> {
 	return ws;
 }
 
+function nextSocketMessageOfType(ws: WebSocket, type: string): Promise<Record<string, unknown>> {
+	const received = Promise.withResolvers<Record<string, unknown>>();
+	const onMessage = (event: MessageEvent): void => {
+		try {
+			const message = JSON.parse(String(event.data)) as Record<string, unknown>;
+			if (message.type !== type) return;
+			ws.removeEventListener("message", onMessage);
+			received.resolve(message);
+		} catch (error) {
+			ws.removeEventListener("message", onMessage);
+			received.reject(error);
+		}
+	};
+	ws.addEventListener("message", onMessage);
+	return received.promise;
+}
+
+async function stopGateway(gateway: TagGatewayServer, ws: WebSocket): Promise<void> {
+	await gateway.stop();
+	if (ws.readyState !== WebSocket.CLOSED) ws.close();
+}
+
 describe("gateway network security", () => {
 	it("accepts only explicit loopback bind hosts", () => {
 		expect(isLoopbackHostname("127.0.0.1")).toBe(true);
@@ -97,39 +145,42 @@ describe("gateway network security", () => {
 		expect(() => gateway.start()).toThrow("must bind to a loopback host");
 	});
 
-	it("allows native clients and only the gateway's HTTP loopback origin", () => {
-		expect(isAllowedWebSocketOrigin(null, 18087)).toBe(true);
-		expect(isAllowedWebSocketOrigin("http://localhost:18087", 18087)).toBe(true);
-		expect(isAllowedWebSocketOrigin("http://127.0.0.1:18087", 18087)).toBe(true);
-		expect(isAllowedWebSocketOrigin("http://[::1]:18087", 18087)).toBe(true);
-		expect(isAllowedWebSocketOrigin("https://localhost:18087", 18087)).toBe(false);
-		expect(isAllowedWebSocketOrigin("http://localhost:18088", 18087)).toBe(false);
-		expect(isAllowedWebSocketOrigin("http://localhost:18087/not-an-origin", 18087)).toBe(false);
-		expect(isAllowedWebSocketOrigin("https://attacker.example", 18087)).toBe(false);
-		expect(isAllowedWebSocketOrigin("not an origin", 18087)).toBe(false);
+	it("allows native clients only on loopback URLs and requires exact browser same-origin", () => {
+		const localhostUrl = "http://localhost:18087/ws";
+		expect(isAllowedWebSocketOrigin(null, localhostUrl)).toBe(true);
+		expect(isAllowedWebSocketOrigin("http://localhost:18087", localhostUrl)).toBe(true);
+		expect(isAllowedWebSocketOrigin("http://127.0.0.1:18087", localhostUrl)).toBe(false);
+		expect(isAllowedWebSocketOrigin("http://[::1]:18087", localhostUrl)).toBe(false);
+		expect(isAllowedWebSocketOrigin("https://localhost:18087", localhostUrl)).toBe(false);
+		expect(isAllowedWebSocketOrigin("http://localhost:18088", localhostUrl)).toBe(false);
+		expect(isAllowedWebSocketOrigin("http://localhost:18087/not-an-origin", localhostUrl)).toBe(false);
+		expect(isAllowedWebSocketOrigin(null, "http://192.168.1.10:18087/ws")).toBe(false);
+		expect(isAllowedWebSocketOrigin("https://attacker.example", localhostUrl)).toBe(false);
+		expect(isAllowedWebSocketOrigin("not an origin", localhostUrl)).toBe(false);
 	});
 
-	it("rejects cross-site WebSocket and capture requests", async () => {
+	it("rejects cross-site and cross-host-alias requests", async () => {
 		const gateway = new TagGatewayServer({ port: 0 });
 		gateway.start();
 		try {
-			const headers = { Origin: "https://attacker.example" };
-			const websocketResponse = await fetch(`${gateway.url}/ws`, { headers });
+			const attackerHeaders = { Origin: "https://attacker.example" };
+			const websocketResponse = await fetch(`${gateway.url}/ws`, { headers: attackerHeaders });
 			expect(websocketResponse.status).toBe(403);
-			const captureResponse = await fetch(`${gateway.url}/api/capture`, {
+			const aliasOrigin = gateway.url.replace("127.0.0.1", "localhost");
+			const aliasResponse = await fetch(`${gateway.url}/api/capture`, {
 				method: "POST",
-				headers,
-				body: JSON.stringify({ mode: "screen", userRequest: "capture the victim's screen" }),
+				headers: { Origin: aliasOrigin },
+				body: JSON.stringify({ mode: "screen", request: "capture the victim's screen" }),
 			});
-			expect(captureResponse.status).toBe(403);
+			expect(aliasResponse.status).toBe(403);
 		} finally {
-			gateway.stop();
+			await gateway.stop();
 		}
 	});
 });
 
 describe("gateway task lifecycle", () => {
-	it("cancels replaced and disconnected tasks", async () => {
+	it("cancels replaced and explicitly cancelled tasks", async () => {
 		const worker = new RecordingWorker();
 		const gateway = new TagGatewayServer({ port: 0, captureService: new FixedCaptureService(), worker });
 		gateway.start();
@@ -137,24 +188,143 @@ describe("gateway task lifecycle", () => {
 
 		try {
 			const firstSession = worker.nextSession();
-			ws.send(JSON.stringify({ type: "capture", mode: "screen", userRequest: "explain first" }));
+			ws.send(JSON.stringify({ type: "capture", mode: "screen", request: "explain first" }));
 			const firstTaskId = await firstSession;
 
 			const replacedTask = worker.nextCancellation();
 			const secondSession = worker.nextSession();
-			ws.send(JSON.stringify({ type: "capture", mode: "screen", userRequest: "explain second" }));
+			ws.send(JSON.stringify({ type: "capture", mode: "screen", request: "explain second" }));
 			const [replacedTaskId, secondTaskId] = await Promise.all([replacedTask, secondSession]);
 			expect(replacedTaskId).toBe(firstTaskId);
 
-			const disconnectedTask = worker.nextCancellation();
-			ws.close();
-			expect(await disconnectedTask).toBe(secondTaskId);
+			const cancelledTask = worker.nextCancellation();
+			ws.send(JSON.stringify({ type: "cancel" }));
+			expect(await cancelledTask).toBe(secondTaskId);
 			expect(worker.cancellations.filter(taskId => taskId === firstTaskId)).toHaveLength(1);
 			expect(worker.cancellations.filter(taskId => taskId === secondTaskId)).toHaveLength(1);
 		} finally {
-			ws.close();
-			gateway.stop();
+			await stopGateway(gateway, ws);
 		}
+	});
+
+	it("rejects malformed approval fields without dispatching", async () => {
+		const worker = new RecordingWorker();
+		const gateway = new TagGatewayServer({ port: 0, captureService: new FixedCaptureService(), worker });
+		gateway.start();
+		const ws = await connect(gateway.url);
+		try {
+			const session = worker.nextSession();
+			ws.send(JSON.stringify({ type: "capture", mode: "screen", request: "inspect this" }));
+			await session;
+
+			const protocolError = nextSocketMessageOfType(ws, "protocol_error");
+			ws.send(JSON.stringify({ type: "approve", actionId: "dangerous", allowed: "false" }));
+			expect(await protocolError).toMatchObject({ type: "protocol_error", error: "allowed must be a boolean" });
+
+			const editedArgumentsError = nextSocketMessageOfType(ws, "protocol_error");
+			ws.send(
+				JSON.stringify({
+					type: "approve",
+					actionId: "dangerous",
+					allowed: true,
+					editedArguments: { command: "safe-command" },
+				}),
+			);
+			expect(await editedArgumentsError).toMatchObject({
+				type: "protocol_error",
+				error: "editedArguments are not supported by the desktop-tag worker",
+			});
+
+			const scopeError = nextSocketMessageOfType(ws, "protocol_error");
+			ws.send(JSON.stringify({ type: "approve", actionId: "dangerous", allowed: true, scope: "group" }));
+			expect(await scopeError).toMatchObject({ type: "protocol_error", error: "scope must be once or session" });
+			expect(worker.approvals).toEqual([]);
+		} finally {
+			await stopGateway(gateway, ws);
+		}
+	});
+
+	it("detaches a cancelled task before capture can create a session", async () => {
+		const captureService = new BlockingCaptureService();
+		const worker = new RecordingWorker();
+		const gateway = new TagGatewayServer({ port: 0, captureService, worker });
+		gateway.start();
+		const ws = await connect(gateway.url);
+		try {
+			ws.send(JSON.stringify({ type: "capture", mode: "screen", request: "wait for capture" }));
+			await captureService.started.promise;
+			const cancelled = worker.nextCancellation();
+			ws.send(JSON.stringify({ type: "cancel" }));
+			await cancelled;
+			captureService.release.resolve();
+			await captureService.completed.promise;
+			await gateway.stop();
+			expect(worker.sessions).toEqual([]);
+		} finally {
+			captureService.release.resolve();
+			ws.close();
+			await gateway.stop();
+		}
+	});
+
+	it("waits for blocked capture startup before shutdown completes", async () => {
+		const captureService = new BlockingCaptureService();
+		const worker = new RecordingWorker();
+		const gateway = new TagGatewayServer({ port: 0, captureService, worker });
+		gateway.start();
+		const ws = await connect(gateway.url);
+		const gatewayUrl = gateway.url;
+		ws.send(JSON.stringify({ type: "capture", mode: "screen", request: "block during shutdown" }));
+		await captureService.started.promise;
+
+		const cancellation = worker.nextCancellation();
+		let stopped = false;
+		const stopping = gateway.stop().then(() => {
+			stopped = true;
+		});
+		try {
+			await cancellation;
+			expect(stopped).toBe(false);
+			const captureResponse = await fetch(`${gatewayUrl}/api/capture`, {
+				method: "POST",
+				headers: { Origin: gatewayUrl },
+				body: JSON.stringify({ mode: "screen", request: "must not start" }),
+			});
+			expect(captureResponse.status).toBe(503);
+			expect(captureService.calls).toBe(1);
+			captureService.release.resolve();
+			await captureService.completed.promise;
+			await stopping;
+			expect(stopped).toBe(true);
+			expect(worker.sessions).toEqual([]);
+		} finally {
+			captureService.release.resolve();
+			await stopping;
+			ws.close();
+		}
+	});
+
+	it("awaits active task cancellation before shutdown completes", async () => {
+		const cancelRelease = Promise.withResolvers<void>();
+		const worker = new RecordingWorker(cancelRelease.promise);
+		const gateway = new TagGatewayServer({ port: 0, captureService: new FixedCaptureService(), worker });
+		gateway.start();
+		const ws = await connect(gateway.url);
+		const session = worker.nextSession();
+		ws.send(JSON.stringify({ type: "capture", mode: "screen", request: "stay active" }));
+		await session;
+
+		const cancellation = worker.nextCancellation();
+		let stopped = false;
+		const stopping = gateway.stop().then(() => {
+			stopped = true;
+		});
+		await cancellation;
+		expect(stopped).toBe(false);
+		cancelRelease.resolve();
+		await stopping;
+		expect(stopped).toBe(true);
+		ws.close();
 	});
 
 	it("renders approval content only through text nodes", async () => {

--- a/packages/desktop-tag/test/gateway.test.ts
+++ b/packages/desktop-tag/test/gateway.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "bun:test";
+
+import { type CaptureOptions, CaptureService } from "../src/context";
+import { isAllowedWebSocketOrigin, isLoopbackHostname, TagGatewayServer } from "../src/gateway";
+import type { AgentEvent, AgentWorker, ApprovalDecision, ContextPacket, SessionHandle, TaskInput } from "../src/types";
+
+class FixedCaptureService extends CaptureService {
+	override async capture(options: CaptureOptions): Promise<ContextPacket> {
+		return {
+			captureId: crypto.randomUUID(),
+			timestamp: new Date().toISOString(),
+			userRequest: options.userRequest,
+			captureMode: options.mode,
+			visual: { displayScale: 1, annotations: [] },
+			foregroundApp: {},
+			browser: {},
+			selection: {},
+			availableCapabilities: [],
+		};
+	}
+}
+
+class RecordingWorker implements AgentWorker {
+	readonly sessions: string[] = [];
+	readonly cancellations: string[] = [];
+	readonly #subscriptionClosers = new Map<string, () => void>();
+	readonly #cancelled = new Set<string>();
+	readonly #sessionWaiters: Array<(sessionId: string) => void> = [];
+	readonly #cancellationWaiters: Array<(sessionId: string) => void> = [];
+
+	async createSession(taskId: string, _input: TaskInput): Promise<SessionHandle> {
+		this.sessions.push(taskId);
+		this.#sessionWaiters.shift()?.(taskId);
+		return { sessionId: taskId };
+	}
+
+	nextSession(): Promise<string> {
+		const next = Promise.withResolvers<string>();
+		this.#sessionWaiters.push(next.resolve);
+		return next.promise;
+	}
+
+	nextCancellation(): Promise<string> {
+		const next = Promise.withResolvers<string>();
+		this.#cancellationWaiters.push(next.resolve);
+		return next.promise;
+	}
+
+	async sendMessage(_sessionId: string, _message: string): Promise<void> {}
+
+	async approve(_sessionId: string, _actionId: string, _decision: ApprovalDecision): Promise<void> {}
+
+	async cancel(sessionId: string): Promise<void> {
+		if (this.#cancelled.has(sessionId)) return;
+		this.#cancelled.add(sessionId);
+		this.cancellations.push(sessionId);
+		this.#cancellationWaiters.shift()?.(sessionId);
+		this.#subscriptionClosers.get(sessionId)?.();
+		this.#subscriptionClosers.delete(sessionId);
+	}
+
+	subscribe(sessionId: string): AsyncIterable<AgentEvent> {
+		const closed = Promise.withResolvers<void>();
+		this.#subscriptionClosers.set(sessionId, closed.resolve);
+		return {
+			[Symbol.asyncIterator]() {
+				return {
+					async next(): Promise<IteratorResult<AgentEvent>> {
+						await closed.promise;
+						return { done: true, value: undefined };
+					},
+				};
+			},
+		};
+	}
+}
+
+async function connect(url: string): Promise<WebSocket> {
+	const opened = Promise.withResolvers<void>();
+	const ws = new WebSocket(`${url.replace("http:", "ws:")}/ws`);
+	ws.addEventListener("open", () => opened.resolve(), { once: true });
+	ws.addEventListener("error", () => opened.reject(new Error("WebSocket connection failed")), { once: true });
+	await opened.promise;
+	return ws;
+}
+
+describe("gateway network security", () => {
+	it("accepts only explicit loopback bind hosts", () => {
+		expect(isLoopbackHostname("127.0.0.1")).toBe(true);
+		expect(isLoopbackHostname("LOCALHOST")).toBe(true);
+		expect(isLoopbackHostname("::1")).toBe(true);
+		expect(isLoopbackHostname("[::1]")).toBe(true);
+		expect(isLoopbackHostname("0.0.0.0")).toBe(false);
+		expect(isLoopbackHostname("192.168.1.10")).toBe(false);
+
+		const gateway = new TagGatewayServer({ port: 0, hostname: "0.0.0.0" });
+		expect(() => gateway.start()).toThrow("must bind to a loopback host");
+	});
+
+	it("allows native clients and only the gateway's HTTP loopback origin", () => {
+		expect(isAllowedWebSocketOrigin(null, 18087)).toBe(true);
+		expect(isAllowedWebSocketOrigin("http://localhost:18087", 18087)).toBe(true);
+		expect(isAllowedWebSocketOrigin("http://127.0.0.1:18087", 18087)).toBe(true);
+		expect(isAllowedWebSocketOrigin("http://[::1]:18087", 18087)).toBe(true);
+		expect(isAllowedWebSocketOrigin("https://localhost:18087", 18087)).toBe(false);
+		expect(isAllowedWebSocketOrigin("http://localhost:18088", 18087)).toBe(false);
+		expect(isAllowedWebSocketOrigin("http://localhost:18087/not-an-origin", 18087)).toBe(false);
+		expect(isAllowedWebSocketOrigin("https://attacker.example", 18087)).toBe(false);
+		expect(isAllowedWebSocketOrigin("not an origin", 18087)).toBe(false);
+	});
+
+	it("rejects cross-site WebSocket and capture requests", async () => {
+		const gateway = new TagGatewayServer({ port: 0 });
+		gateway.start();
+		try {
+			const headers = { Origin: "https://attacker.example" };
+			const websocketResponse = await fetch(`${gateway.url}/ws`, { headers });
+			expect(websocketResponse.status).toBe(403);
+			const captureResponse = await fetch(`${gateway.url}/api/capture`, {
+				method: "POST",
+				headers,
+				body: JSON.stringify({ mode: "screen", userRequest: "capture the victim's screen" }),
+			});
+			expect(captureResponse.status).toBe(403);
+		} finally {
+			gateway.stop();
+		}
+	});
+});
+
+describe("gateway task lifecycle", () => {
+	it("cancels replaced and disconnected tasks", async () => {
+		const worker = new RecordingWorker();
+		const gateway = new TagGatewayServer({ port: 0, captureService: new FixedCaptureService(), worker });
+		gateway.start();
+		const ws = await connect(gateway.url);
+
+		try {
+			const firstSession = worker.nextSession();
+			ws.send(JSON.stringify({ type: "capture", mode: "screen", userRequest: "explain first" }));
+			const firstTaskId = await firstSession;
+
+			const replacedTask = worker.nextCancellation();
+			const secondSession = worker.nextSession();
+			ws.send(JSON.stringify({ type: "capture", mode: "screen", userRequest: "explain second" }));
+			const [replacedTaskId, secondTaskId] = await Promise.all([replacedTask, secondSession]);
+			expect(replacedTaskId).toBe(firstTaskId);
+
+			const disconnectedTask = worker.nextCancellation();
+			ws.close();
+			expect(await disconnectedTask).toBe(secondTaskId);
+			expect(worker.cancellations.filter(taskId => taskId === firstTaskId)).toHaveLength(1);
+			expect(worker.cancellations.filter(taskId => taskId === secondTaskId)).toHaveLength(1);
+		} finally {
+			ws.close();
+			gateway.stop();
+		}
+	});
+
+	it("renders approval content only through text nodes", async () => {
+		const html = await Bun.file(new URL("../src/overlay.html", import.meta.url)).text();
+		expect(html).not.toContain("innerHTML");
+		expect(html).toContain("tool.textContent = String(req.toolName");
+		expect(html).toContain("effects.textContent = String(req.effects");
+		expect(html).toContain("argumentsEl.textContent = JSON.stringify(req.arguments");
+	});
+});

--- a/packages/desktop-tag/test/router.test.ts
+++ b/packages/desktop-tag/test/router.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 
-import { assertContextPacket, CapabilityRegistry, createDefaultRegistry, routeContext } from "../src/router";
+import {
+	assertContextPacket,
+	CapabilityRegistry,
+	createDefaultRegistry,
+	routeContext,
+	updateAvailability,
+} from "../src/router";
 import type { ContextPacket } from "../src/types";
 
 function makePacket(overrides: Partial<ContextPacket> = {}): ContextPacket {
@@ -127,5 +133,23 @@ describe("routeContext", () => {
 		const malformed = { ...makePacket(), foregroundApp: { windowTitle: "   " } };
 
 		expect(() => assertContextPacket(malformed)).toThrow("windowTitle must be a nonblank string");
+	});
+});
+
+describe("updateAvailability", () => {
+	it("requires an attached IX Bridge browser extension", async () => {
+		const fetchSpy = spyOn(globalThis, "fetch");
+		try {
+			const registry = createDefaultRegistry();
+			fetchSpy.mockResolvedValueOnce(Response.json({ running: true, extension_connected: false }));
+			await updateAvailability(registry);
+			expect(registry.getExecutor("ix-bridge")?.available).toBe(false);
+
+			fetchSpy.mockResolvedValueOnce(Response.json({ running: true, extension_connected: true }));
+			await updateAvailability(registry);
+			expect(registry.getExecutor("ix-bridge")?.available).toBe(true);
+		} finally {
+			fetchSpy.mockRestore();
+		}
 	});
 });

--- a/packages/desktop-tag/test/router.test.ts
+++ b/packages/desktop-tag/test/router.test.ts
@@ -1,17 +1,18 @@
 import { describe, expect, it } from "bun:test";
 
-import { CapabilityRegistry, createDefaultRegistry, routeContext } from "../src/router";
+import { assertContextPacket, CapabilityRegistry, createDefaultRegistry, routeContext } from "../src/router";
 import type { ContextPacket } from "../src/types";
 
 function makePacket(overrides: Partial<ContextPacket> = {}): ContextPacket {
 	return {
-		timestamp: Date.now(),
+		captureId: "capture-1",
+		timestamp: new Date().toISOString(),
 		captureMode: "screen",
 		userRequest: "explain this",
-		visual: { screenshotPath: undefined },
-		foregroundApp: { processName: undefined, windowTitle: undefined, bounds: undefined },
-		browser: { url: undefined, title: undefined, domSnapshot: undefined, activeElement: undefined },
-		selection: { clipboardText: undefined, selectedText: undefined, region: undefined },
+		visual: { displayScale: 1, annotations: [] },
+		foregroundApp: {},
+		browser: {},
+		selection: {},
 		availableCapabilities: [],
 		...overrides,
 	};
@@ -79,27 +80,52 @@ describe("routeContext", () => {
 		expect(decision.tools).toContain("edit");
 	});
 
-	it("routes email requests to gmail-mcp", () => {
+	it("falls back rather than routing email to an unavailable executor", () => {
 		const registry = createDefaultRegistry();
 		const decision = routeContext(registry, makePacket({ userRequest: "email this to the team" }));
 
-		expect(decision.executorId).toBe("gmail-mcp");
-		expect(decision.tools).toContain("email.draft");
+		expect(registry.getExecutor("gmail-mcp")?.available).toBe(false);
+		expect(decision.executorId).toBe("answer-only");
 	});
 
-	it("routes screen control to computer-use", () => {
+	it("falls back rather than routing screen control to an unavailable executor", () => {
 		const registry = createDefaultRegistry();
 		const decision = routeContext(registry, makePacket({ userRequest: "click the submit button" }));
 
-		expect(decision.executorId).toBe("computer-use");
-		expect(decision.tools).toContain("screen.click");
+		expect(registry.getExecutor("computer-use")?.available).toBe(false);
+		expect(decision.executorId).toBe("answer-only");
 	});
 
 	it("uses browser URL/title to detect Salesforce", () => {
 		const registry = createDefaultRegistry();
-		const decision = routeContext(registry, makePacket({ userRequest: "look at this", browser: { url: "https://myorg.lightning.force.com/", title: "Salesforce" } }));
+		const decision = routeContext(
+			registry,
+			makePacket({
+				userRequest: "look at this",
+				browser: { url: "https://myorg.lightning.force.com/", title: "Salesforce" },
+			}),
+		);
 
 		expect(decision.executorId).toBe("ix-bridge");
 		expect(decision.tools).toContain("ix_bridge");
+	});
+
+	it("throws clearly when no executors are available", () => {
+		const registry = createDefaultRegistry();
+		for (const executor of registry.listExecutors()) executor.available = false;
+
+		expect(() => routeContext(registry, makePacket())).toThrow("No available executors are registered");
+	});
+
+	it("rejects malformed context packets", () => {
+		const malformed = { ...makePacket(), captureMode: "desktop" };
+
+		expect(() => assertContextPacket(malformed)).toThrow("Unsupported context capture mode");
+	});
+
+	it("rejects blank foreground window titles", () => {
+		const malformed = { ...makePacket(), foregroundApp: { windowTitle: "   " } };
+
+		expect(() => assertContextPacket(malformed)).toThrow("windowTitle must be a nonblank string");
 	});
 });

--- a/packages/desktop-tag/test/router.test.ts
+++ b/packages/desktop-tag/test/router.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "bun:test";
+
+import { CapabilityRegistry, createDefaultRegistry, routeContext } from "../src/router";
+import type { ContextPacket } from "../src/types";
+
+function makePacket(overrides: Partial<ContextPacket> = {}): ContextPacket {
+	return {
+		timestamp: Date.now(),
+		captureMode: "screen",
+		userRequest: "explain this",
+		visual: { screenshotPath: undefined },
+		foregroundApp: { processName: undefined, windowTitle: undefined, bounds: undefined },
+		browser: { url: undefined, title: undefined, domSnapshot: undefined, activeElement: undefined },
+		selection: { clipboardText: undefined, selectedText: undefined, region: undefined },
+		availableCapabilities: [],
+		...overrides,
+	};
+}
+
+describe("CapabilityRegistry", () => {
+	it("registers and queries executors", () => {
+		const registry = new CapabilityRegistry();
+		registry.register({
+			id: "test",
+			name: "Test executor",
+			location: "local",
+			riskLevel: "low",
+			available: true,
+			capabilities: [{ name: "greet", approval: "none" }],
+		});
+
+		expect(registry.getExecutor("test")?.name).toBe("Test executor");
+		expect(registry.listExecutors()).toHaveLength(1);
+		expect(registry.findMatching("greet")?.id).toBe("test");
+	});
+
+	it("respects application filters", () => {
+		const registry = new CapabilityRegistry();
+		registry.register({
+			id: "app-a",
+			name: "App A executor",
+			location: "local",
+			riskLevel: "low",
+			available: true,
+			applications: ["a"],
+			capabilities: [{ name: "save" }],
+		});
+		registry.register({
+			id: "app-b",
+			name: "App B executor",
+			location: "local",
+			riskLevel: "low",
+			available: true,
+			applications: ["b"],
+			capabilities: [{ name: "save" }],
+		});
+
+		expect(registry.findMatching("save", "a")?.id).toBe("app-a");
+		expect(registry.findMatching("save", "b")?.id).toBe("app-b");
+	});
+});
+
+describe("routeContext", () => {
+	it("routes general questions to answer-only", () => {
+		const registry = createDefaultRegistry();
+		const decision = routeContext(registry, makePacket({ userRequest: "what does this error mean?" }));
+
+		expect(decision.executorId).toBe("answer-only");
+		expect(decision.tools).toContain("inspect_image");
+		expect(decision.level).toBe(0);
+	});
+
+	it("routes code tasks to local-pi", () => {
+		const registry = createDefaultRegistry();
+		const decision = routeContext(registry, makePacket({ userRequest: "fix this test" }));
+
+		expect(decision.executorId).toBe("local-pi");
+		expect(decision.tools).toContain("bash");
+		expect(decision.tools).toContain("edit");
+	});
+
+	it("routes email requests to gmail-mcp", () => {
+		const registry = createDefaultRegistry();
+		const decision = routeContext(registry, makePacket({ userRequest: "email this to the team" }));
+
+		expect(decision.executorId).toBe("gmail-mcp");
+		expect(decision.tools).toContain("email.draft");
+	});
+
+	it("routes screen control to computer-use", () => {
+		const registry = createDefaultRegistry();
+		const decision = routeContext(registry, makePacket({ userRequest: "click the submit button" }));
+
+		expect(decision.executorId).toBe("computer-use");
+		expect(decision.tools).toContain("screen.click");
+	});
+
+	it("uses browser URL/title to detect Salesforce", () => {
+		const registry = createDefaultRegistry();
+		const decision = routeContext(registry, makePacket({ userRequest: "look at this", browser: { url: "https://myorg.lightning.force.com/", title: "Salesforce" } }));
+
+		expect(decision.executorId).toBe("ix-bridge");
+		expect(decision.tools).toContain("ix_bridge");
+	});
+});

--- a/packages/desktop-tag/test/worker.test.ts
+++ b/packages/desktop-tag/test/worker.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, mock } from "bun:test";
+
+import type { CreateAgentSessionResult } from "@pk-nerdsaver-ai/pi-coding-agent";
+import type {
+	AgentSessionEvent,
+	AgentSessionEventListener,
+} from "@pk-nerdsaver-ai/pi-coding-agent/session/agent-session";
+import type { ClientBridge } from "@pk-nerdsaver-ai/pi-coding-agent/session/client-bridge";
+
+import type { TaskInput } from "../src/types";
+import { PiWorker } from "../src/worker";
+
+class FakeAgentSession {
+	readonly promptResult = Promise.withResolvers<boolean>();
+	readonly abort = mock(async () => {
+		this.emit({ type: "agent_end", messages: [] } as AgentSessionEvent);
+	});
+	readonly dispose = mock(async () => {
+		this.promptResult.resolve(false);
+	});
+	readonly steer = mock(async () => {});
+	readonly followUp = mock(async () => {});
+	readonly newSession = mock(async () => true);
+	readonly sessionManager = { getCwd: () => "/test" };
+	readonly sessionFile = undefined;
+	readonly sessionId = "fake-session";
+	readonly thinkingLevel = undefined;
+	readonly model = undefined;
+	isStreaming = true;
+	bridge: ClientBridge | undefined;
+	readonly #listeners: AgentSessionEventListener[] = [];
+
+	prompt(): Promise<boolean> {
+		return this.promptResult.promise;
+	}
+
+	subscribe(listener: AgentSessionEventListener): () => void {
+		this.#listeners.push(listener);
+		return () => {
+			const index = this.#listeners.indexOf(listener);
+			if (index >= 0) this.#listeners.splice(index, 1);
+		};
+	}
+
+	setClientBridge(bridge: ClientBridge): void {
+		this.bridge = bridge;
+	}
+
+	emit(event: AgentSessionEvent): void {
+		for (const listener of [...this.#listeners]) listener(event);
+	}
+}
+
+const taskInput: TaskInput = {
+	contextPacket: {
+		captureId: "capture-1",
+		timestamp: "2026-07-10T00:00:00.000Z",
+		userRequest: "Inspect the screen",
+		captureMode: "screen",
+		visual: { displayScale: 1, annotations: [] },
+		foregroundApp: {},
+		browser: {},
+		selection: {},
+		availableCapabilities: [],
+	},
+	routing: {
+		executorId: "pi-agent",
+		tools: [],
+		requiredApprovalLevel: 0,
+		message: "Use pi-agent",
+	},
+};
+
+function createWorker(): { worker: PiWorker; session: FakeAgentSession } {
+	const session = new FakeAgentSession();
+	const worker = new PiWorker(async () => ({ session }) as unknown as CreateAgentSessionResult);
+	return { worker, session };
+}
+
+describe("PiWorker lifecycle", () => {
+	it("waits for agent_end instead of completing on an assistant message", async () => {
+		const { worker, session } = createWorker();
+		const handle = await worker.createSession("task-final", taskInput);
+		const events = worker.subscribe(handle.sessionId)[Symbol.asyncIterator]();
+
+		session.emit({ type: "agent_start" } as AgentSessionEvent);
+		expect(await events.next()).toEqual({ done: false, value: { type: "task.started", taskId: "task-final" } });
+
+		session.emit({
+			type: "message_end",
+			message: { role: "assistant", stopReason: "toolUse" },
+		} as unknown as AgentSessionEvent);
+		session.emit({
+			type: "tool_execution_start",
+			toolCallId: "call-1",
+			toolName: "read",
+			args: {},
+		} as unknown as AgentSessionEvent);
+		expect(await events.next()).toEqual({
+			done: false,
+			value: { type: "tool.started", callId: "call-1", toolName: "read" },
+		});
+
+		session.emit({
+			type: "tool_execution_end",
+			toolCallId: "call-1",
+			toolName: "read",
+			result: undefined,
+			isError: false,
+		} as unknown as AgentSessionEvent);
+		expect(await events.next()).toEqual({
+			done: false,
+			value: { type: "tool.completed", callId: "call-1", result: null, isError: false },
+		});
+
+		session.isStreaming = false;
+		session.emit({ type: "agent_end", messages: [] } as AgentSessionEvent);
+		expect(await events.next()).toEqual({
+			done: false,
+			value: { type: "task.completed", taskId: "task-final", summary: "" },
+		});
+		expect(await events.next()).toEqual({ done: true, value: undefined });
+		expect(() => worker.subscribe(handle.sessionId)).toThrow("Session task-final not found");
+	});
+
+	it("keeps approval replies available until final agent settlement", async () => {
+		const { worker, session } = createWorker();
+		const handle = await worker.createSession("task-approval", taskInput);
+		const events = worker.subscribe(handle.sessionId)[Symbol.asyncIterator]();
+		const approval = session.bridge?.requestPermission?.(
+			{ toolCallId: "approval-live", toolName: "write", title: "Write file", rawInput: { path: "result.txt" } },
+			[{ optionId: "allow_once", name: "Allow once", kind: "allow_once" }],
+		);
+		if (!approval) throw new Error("Permission bridge was not installed");
+		expect(await events.next()).toMatchObject({ done: false, value: { type: "approval.requested" } });
+
+		await worker.approve(handle.sessionId, "approval-live", { allowed: true, scope: "once" });
+		expect(await approval).toEqual({ outcome: "selected", optionId: "allow_once" });
+		expect(worker.subscribe(handle.sessionId)).toBeDefined();
+
+		session.emit({ type: "agent_end", messages: [] } as AgentSessionEvent);
+		expect(await events.next()).toEqual({
+			done: false,
+			value: { type: "task.completed", taskId: "task-approval", summary: "" },
+		});
+	});
+
+	it("cancels active execution, settles once, and releases the session", async () => {
+		const { worker, session } = createWorker();
+		const handle = await worker.createSession("task-cancel", taskInput);
+		const events = worker.subscribe(handle.sessionId)[Symbol.asyncIterator]();
+		const approval = session.bridge?.requestPermission?.(
+			{ toolCallId: "approval-1", toolName: "bash", title: "Run command", rawInput: { command: "sleep" } },
+			[{ optionId: "allow_once", name: "Allow once", kind: "allow_once" }],
+		);
+		if (!approval) throw new Error("Permission bridge was not installed");
+		expect(await events.next()).toEqual({
+			done: false,
+			value: {
+				type: "approval.requested",
+				request: {
+					actionId: "approval-1",
+					stepId: "approval-1",
+					toolName: "bash",
+					arguments: { command: "sleep" },
+					effects: "Run command",
+					level: 1,
+					scope: "once",
+				},
+			},
+		});
+
+		await worker.cancel(handle.sessionId);
+		expect(await approval).toEqual({ outcome: "cancelled" });
+		expect(session.abort).toHaveBeenCalledTimes(1);
+		expect(session.dispose).toHaveBeenCalledTimes(1);
+		expect(await events.next()).toEqual({
+			done: false,
+			value: { type: "task.failed", taskId: "task-cancel", error: "Task cancelled." },
+		});
+		expect(await events.next()).toEqual({ done: true, value: undefined });
+
+		await worker.cancel(handle.sessionId);
+		expect(session.abort).toHaveBeenCalledTimes(1);
+		expect(session.dispose).toHaveBeenCalledTimes(1);
+		expect(() => worker.subscribe(handle.sessionId)).toThrow("Session task-cancel not found");
+	});
+});

--- a/packages/desktop-tag/test/worker.test.ts
+++ b/packages/desktop-tag/test/worker.test.ts
@@ -1,40 +1,50 @@
 import { describe, expect, it, mock } from "bun:test";
 
-import type { CreateAgentSessionResult } from "@pk-nerdsaver-ai/pi-coding-agent";
 import type {
-	AgentSessionEvent,
-	AgentSessionEventListener,
-} from "@pk-nerdsaver-ai/pi-coding-agent/session/agent-session";
+	GatewayCommand,
+	GatewayEvent,
+	GatewayEventListener,
+	GatewaySessionEvent,
+} from "@pk-nerdsaver-ai/pi-coding-agent/gateway/types";
 import type { ClientBridge } from "@pk-nerdsaver-ai/pi-coding-agent/session/client-bridge";
 
 import type { TaskInput } from "../src/types";
 import { PiWorker } from "../src/worker";
 
 class FakeAgentSession {
-	readonly promptResult = Promise.withResolvers<boolean>();
-	readonly abort = mock(async () => {
-		this.emit({ type: "agent_end", messages: [] } as AgentSessionEvent);
-	});
-	readonly dispose = mock(async () => {
-		this.promptResult.resolve(false);
-	});
-	readonly steer = mock(async () => {});
-	readonly followUp = mock(async () => {});
-	readonly newSession = mock(async () => true);
-	readonly sessionManager = { getCwd: () => "/test" };
-	readonly sessionFile = undefined;
-	readonly sessionId = "fake-session";
-	readonly thinkingLevel = undefined;
-	readonly model = undefined;
-	isStreaming = true;
+	readonly abort = mock(async () => {});
+	readonly dispose = mock(async () => {});
 	bridge: ClientBridge | undefined;
-	readonly #listeners: AgentSessionEventListener[] = [];
 
-	prompt(): Promise<boolean> {
-		return this.promptResult.promise;
+	setClientBridge(bridge: ClientBridge): void {
+		this.bridge = bridge;
+	}
+}
+
+class FakeGateway {
+	readonly dispose = mock(() => {});
+	readonly commands: GatewayCommand[] = [];
+	readonly #listeners: GatewayEventListener[] = [];
+	#dispatchError: Error | undefined;
+
+	constructor(
+		readonly session: FakeAgentSession,
+		dispatchError?: Error,
+	) {
+		this.#dispatchError = dispatchError;
 	}
 
-	subscribe(listener: AgentSessionEventListener): () => void {
+	async dispatch(command: GatewayCommand): Promise<void> {
+		this.commands.push(command);
+		const dispatchError = this.#dispatchError;
+		if (dispatchError) {
+			this.#dispatchError = undefined;
+			throw dispatchError;
+		}
+		if (command.type === "abort") await this.session.abort();
+	}
+
+	subscribe(listener: GatewayEventListener): () => void {
 		this.#listeners.push(listener);
 		return () => {
 			const index = this.#listeners.indexOf(listener);
@@ -42,12 +52,9 @@ class FakeAgentSession {
 		};
 	}
 
-	setClientBridge(bridge: ClientBridge): void {
-		this.bridge = bridge;
-	}
-
-	emit(event: AgentSessionEvent): void {
-		for (const listener of [...this.#listeners]) listener(event);
+	emitSession(event: GatewaySessionEvent): void {
+		const gatewayEvent: GatewayEvent = { type: "session_event", event };
+		for (const listener of [...this.#listeners]) listener(gatewayEvent);
 	}
 }
 
@@ -66,55 +73,41 @@ const taskInput: TaskInput = {
 	routing: {
 		executorId: "pi-agent",
 		tools: [],
-		requiredApprovalLevel: 0,
+		level: 0,
 		message: "Use pi-agent",
 	},
 };
 
-function createWorker(): { worker: PiWorker; session: FakeAgentSession } {
+function createWorker(dispatchError?: Error): { worker: PiWorker; session: FakeAgentSession; gateway: FakeGateway } {
 	const session = new FakeAgentSession();
-	const worker = new PiWorker(async () => ({ session }) as unknown as CreateAgentSessionResult);
-	return { worker, session };
+	const gateway = new FakeGateway(session, dispatchError);
+	const worker = new PiWorker(async () => ({ session, gateway }));
+	return { worker, session, gateway };
 }
 
 describe("PiWorker lifecycle", () => {
 	it("waits for agent_end instead of completing on an assistant message", async () => {
-		const { worker, session } = createWorker();
+		const { worker, gateway } = createWorker();
 		const handle = await worker.createSession("task-final", taskInput);
 		const events = worker.subscribe(handle.sessionId)[Symbol.asyncIterator]();
 
-		session.emit({ type: "agent_start" } as AgentSessionEvent);
+		gateway.emitSession({ type: "agent_start" });
 		expect(await events.next()).toEqual({ done: false, value: { type: "task.started", taskId: "task-final" } });
 
-		session.emit({
-			type: "message_end",
-			message: { role: "assistant", stopReason: "toolUse" },
-		} as unknown as AgentSessionEvent);
-		session.emit({
-			type: "tool_execution_start",
-			toolCallId: "call-1",
-			toolName: "read",
-			args: {},
-		} as unknown as AgentSessionEvent);
+		gateway.emitSession({ type: "assistant_end", stopReason: "toolUse", hasError: false });
+		gateway.emitSession({ type: "tool_start", toolCallId: "call-1", toolName: "read" });
 		expect(await events.next()).toEqual({
 			done: false,
 			value: { type: "tool.started", callId: "call-1", toolName: "read" },
 		});
 
-		session.emit({
-			type: "tool_execution_end",
-			toolCallId: "call-1",
-			toolName: "read",
-			result: undefined,
-			isError: false,
-		} as unknown as AgentSessionEvent);
+		gateway.emitSession({ type: "tool_end", toolCallId: "call-1", toolName: "read", isError: false });
 		expect(await events.next()).toEqual({
 			done: false,
 			value: { type: "tool.completed", callId: "call-1", result: null, isError: false },
 		});
 
-		session.isStreaming = false;
-		session.emit({ type: "agent_end", messages: [] } as AgentSessionEvent);
+		gateway.emitSession({ type: "agent_end" });
 		expect(await events.next()).toEqual({
 			done: false,
 			value: { type: "task.completed", taskId: "task-final", summary: "" },
@@ -123,26 +116,89 @@ describe("PiWorker lifecycle", () => {
 		expect(() => worker.subscribe(handle.sessionId)).toThrow("Session task-final not found");
 	});
 
+	it("settles and disposes once when initial dispatch rejects", async () => {
+		const { worker, session, gateway } = createWorker(new Error("dispatch failed"));
+		const handle = await worker.createSession("task-dispatch-rejection", taskInput);
+		const events = worker.subscribe(handle.sessionId)[Symbol.asyncIterator]();
+
+		expect(await events.next()).toEqual({
+			done: false,
+			value: {
+				type: "task.failed",
+				taskId: "task-dispatch-rejection",
+				error: "Failed to start task: dispatch failed",
+			},
+		});
+		expect(await events.next()).toEqual({ done: true, value: undefined });
+		expect(session.dispose).toHaveBeenCalledTimes(1);
+		expect(gateway.dispose).toHaveBeenCalledTimes(1);
+
+		gateway.emitSession({ type: "agent_end" });
+		await worker.cancel(handle.sessionId);
+		expect(session.dispose).toHaveBeenCalledTimes(1);
+		expect(gateway.dispose).toHaveBeenCalledTimes(1);
+		expect(() => worker.subscribe(handle.sessionId)).toThrow("Session task-dispatch-rejection not found");
+	});
+
 	it("keeps approval replies available until final agent settlement", async () => {
-		const { worker, session } = createWorker();
+		const { worker, session, gateway } = createWorker();
 		const handle = await worker.createSession("task-approval", taskInput);
 		const events = worker.subscribe(handle.sessionId)[Symbol.asyncIterator]();
 		const approval = session.bridge?.requestPermission?.(
 			{ toolCallId: "approval-live", toolName: "write", title: "Write file", rawInput: { path: "result.txt" } },
-			[{ optionId: "allow_once", name: "Allow once", kind: "allow_once" }],
+			[
+				{ optionId: "allow_once", name: "Allow once", kind: "allow_once" },
+				{ optionId: "allow_always", name: "Always allow", kind: "allow_always" },
+			],
 		);
 		if (!approval) throw new Error("Permission bridge was not installed");
-		expect(await events.next()).toMatchObject({ done: false, value: { type: "approval.requested" } });
+		expect(await events.next()).toMatchObject({
+			done: false,
+			value: { type: "approval.requested", request: { scope: "once", level: 1 } },
+		});
 
 		await worker.approve(handle.sessionId, "approval-live", { allowed: true, scope: "once" });
 		expect(await approval).toEqual({ outcome: "selected", optionId: "allow_once" });
 		expect(worker.subscribe(handle.sessionId)).toBeDefined();
 
-		session.emit({ type: "agent_end", messages: [] } as AgentSessionEvent);
+		gateway.emitSession({ type: "agent_end" });
 		expect(await events.next()).toEqual({
 			done: false,
 			value: { type: "task.completed", taskId: "task-approval", summary: "" },
 		});
+	});
+
+	it("rejects approval edits and unsupported scopes instead of executing original arguments", async () => {
+		const { worker } = createWorker();
+		const handle = await worker.createSession("task-edited-approval", taskInput);
+
+		await expect(
+			worker.approve(handle.sessionId, "approval-edited", {
+				allowed: true,
+				scope: "once",
+				editedArguments: { command: "safe-command" },
+			}),
+		).rejects.toThrow("Edited approval arguments are not supported");
+		await expect(
+			worker.approve(handle.sessionId, "approval-group", { allowed: true, scope: "group" }),
+		).rejects.toThrow('Approval scope "group" is not supported');
+		await worker.cancel(handle.sessionId);
+	});
+
+	it("does not dispatch the deferred prompt after immediate cancellation", async () => {
+		const { worker, gateway } = createWorker();
+		const handle = await worker.createSession("task-immediate-cancel", taskInput);
+		const events = worker.subscribe(handle.sessionId)[Symbol.asyncIterator]();
+
+		await worker.cancel(handle.sessionId);
+		await Bun.sleep(0);
+
+		expect(gateway.commands.filter(command => command.type === "prompt")).toHaveLength(0);
+		expect(await events.next()).toEqual({
+			done: false,
+			value: { type: "task.failed", taskId: "task-immediate-cancel", error: "Task cancelled." },
+		});
+		expect(await events.next()).toEqual({ done: true, value: undefined });
 	});
 
 	it("cancels active execution, settles once, and releases the session", async () => {

--- a/packages/desktop-tag/tsconfig.json
+++ b/packages/desktop-tag/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../tsconfig.workspace.json",
+	"include": ["src"]
+}

--- a/packages/desktop-tag/tsconfig.json
+++ b/packages/desktop-tag/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"extends": "../tsconfig.workspace.json",
-	"include": ["src"]
+	"include": ["src", "test"]
 }


### PR DESCRIPTION
## Summary
- add the `@pk-nerdsaver-ai/pi-desktop-tag` workspace package with extension, CLI, loopback overlay gateway, routing, capture, and worker integration
- enforce exact same-origin browser access, strict wire validation, safe approval handling, and awaited cancellation/shutdown
- support screen, foreground-window, signed-coordinate region, browser context, replaying event streams, and exhaustive wire validation

## Verification
- `bunx biome check packages/desktop-tag --no-errors-on-unmatched`
- `bun --cwd=packages/desktop-tag run check:types`
- `bun --cwd=packages/desktop-tag test --timeout 15000` (92 passed, 182 assertions)
- `bun packages/coding-agent/src/cli.ts --smoke-test`
- `git diff --check`

## Review
Adversarial correctness, security, API, testing, and maintainability passes completed. Final code and package closure gates passed with no remaining blockers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a desktop tagging extension with Screen, Window, Region, and Browser capture modes.
  * Added an overlay for capturing context, submitting requests, viewing progress, and approving actions.
  * Added a standalone local gateway and command-line launcher.
  * Added context-aware routing to available capabilities, including browser and clipboard context.
  * Added secure loopback-only HTTP and WebSocket access.

* **Documentation**
  * Added usage, command syntax, security, task lifecycle, and capability documentation.

* **Tests**
  * Added comprehensive coverage for capture, routing, gateway security, event handling, extension commands, and task execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->