### PR TITLE
feat(collab): host-away grace window, client CSP, relay CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,10 @@ jobs:
            run: bun run ci:check:full
          - name: Build collab web
            run: bun run collab:web:build
+         # Client bundle + CSP generation only: the full relay build's share-viewer
+         # step needs the native addon, which this job intentionally lacks.
+         - name: Build collab relay client assets
+           run: bun --cwd=packages/collab-relay run build:client
 
    # Linux x64 baseline + modern: required by `test`, so it runs on every PR
    # unless native_artifact_lookup found a cached run. Release runs always

--- a/docs/collab.md
+++ b/docs/collab.md
@@ -118,6 +118,8 @@ Set `collab.webUrl` when the browser UI is hosted separately from the websocket 
 
 The owned collaboration service is deployed as the `ompk-collab` Cloudflare Worker at `collab.pkking.computer`. It keeps live room coordination in one Durable Object per room and stores sealed share blobs in the configured R2 bucket. The relay never decrypts session content. Share uploads are capped at 1 MB and rate-limited to 12 per Cloudflare client IP per hour.
 
+A host disconnect does not end the room immediately: guests receive a `host-away` control message and the relay holds the room open for a ~45 s grace window. If the host reconnects in time, guests get `host-back` and the session resumes; otherwise the room closes as before (`room-closed`, close code 4001). A new host connection replaces a lingering half-open host socket (closed with 4010) so a host that lost its network can always re-claim its room. The guest client page is served with a strict build-generated Content-Security-Policy (inline scripts allowed by hash only), `Referrer-Policy: no-referrer`, and `X-Content-Type-Options: nosniff`.
+
 It exposes:
 
 - `GET /` — the static collab-web guest client (target of the `/collab` deep link),

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "collab:relay": "bun --cwd=packages/collab-web run relay",
     "collab:mock-host": "bun --cwd=packages/collab-web run mock-host",
     "collab:web:build": "bun --cwd=packages/collab-web run build",
+    "collab:relay:build": "bun --cwd=packages/collab-relay run build",
     "claude:trace": "bun scripts/claude-trace.ts",
     "build": "bun run --workspaces --if-present build",
     "build:native": "bun --cwd=packages/natives run build",

--- a/packages/coding-agent/src/collab/guest.ts
+++ b/packages/coding-agent/src/collab/guest.ts
@@ -208,6 +208,14 @@ export class CollabGuestLink {
 				})
 				.catch(err => logger.warn("collab guest frame apply failed", { type: frame.t, error: String(err) }));
 		};
+		socket.onControl = msg => {
+			if (this.#left) return;
+			if (msg.t === "host-away") {
+				this.#ctx.showStatus("Collab host connection lost, waiting for it to return…", { dim: true });
+			} else if (msg.t === "host-back") {
+				this.#ctx.showStatus("Collab host reconnected");
+			}
+		};
 		socket.onClose = (reason, willReconnect) => {
 			this.#flushPendingTranscripts();
 			if (this.#left) return;

--- a/packages/coding-agent/src/collab/relay-client.ts
+++ b/packages/coding-agent/src/collab/relay-client.ts
@@ -14,6 +14,7 @@ const FATAL_CLOSE_REASONS: Record<number, string> = {
 	4001: "room closed",
 	4004: "no such room",
 	4009: "a host is already connected for this room",
+	4010: "host connection replaced",
 	4029: "room is full",
 };
 

--- a/packages/coding-agent/test/collab/relay-client-close.test.ts
+++ b/packages/coding-agent/test/collab/relay-client-close.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import { CollabSocket } from "@pk-nerdsaver-ai/pi-coding-agent/collab/relay-client";
+
+class FakeWebSocket {
+	static readonly instances: FakeWebSocket[] = [];
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSED = 3;
+
+	binaryType = "blob";
+	readyState: number = FakeWebSocket.CONNECTING;
+	onopen: (() => void) | null = null;
+	onmessage: ((event: { data: unknown }) => void) | null = null;
+	onerror: (() => void) | null = null;
+	onclose: ((event: { code: number; reason: string }) => void) | null = null;
+
+	constructor() {
+		FakeWebSocket.instances.push(this);
+	}
+
+	send(): void {}
+
+	close(): void {
+		this.readyState = FakeWebSocket.CLOSED;
+	}
+
+	open(): void {
+		this.readyState = FakeWebSocket.OPEN;
+		this.onopen?.();
+	}
+
+	serverClose(code: number, reason: string): void {
+		this.readyState = FakeWebSocket.CLOSED;
+		this.onclose?.({ code, reason });
+	}
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+	FakeWebSocket.instances.length = 0;
+});
+
+describe("CollabSocket close handling", () => {
+	test("a replaced host connection stays closed instead of reconnecting", async () => {
+		const key = await crypto.subtle.importKey("raw", new Uint8Array(32), "AES-GCM", false, ["encrypt", "decrypt"]);
+		vi.useFakeTimers();
+		const realWebSocket = globalThis.WebSocket;
+		globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+		try {
+			const socket = new CollabSocket({ wsUrl: "wss://relay.example/r/roomroomroom", role: "host", key });
+			const onClose = vi.fn();
+			socket.onClose = onClose;
+
+			socket.connect();
+			const first = FakeWebSocket.instances[0];
+			expect(first).toBeDefined();
+			first!.open();
+			first!.serverClose(4010, "replaced by a newer host connection");
+
+			expect(onClose).toHaveBeenCalledWith("host connection replaced", false);
+			vi.advanceTimersByTime(60_000);
+			expect(FakeWebSocket.instances).toHaveLength(1);
+		} finally {
+			globalThis.WebSocket = realWebSocket;
+		}
+	});
+});

--- a/packages/collab-relay/package.json
+++ b/packages/collab-relay/package.json
@@ -5,7 +5,8 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"build": "rm -rf dist && bun build ../collab-web/index.html --outdir=dist --minify --entry-naming=[hash].[ext] --chunk-naming=[hash].[ext] --asset-naming=[hash].[ext] && mv dist/*.html dist/index.html && cp -R ../collab-web/public/* dist/ && mkdir -p dist/share-viewer && bun ../coding-agent/scripts/generate-share-viewer.ts dist/share-viewer/index.html && bun scripts/verify-build.ts dist",
+		"build:client": "rm -rf dist && bun build ../collab-web/index.html --outdir=dist --minify --entry-naming=[hash].[ext] --chunk-naming=[hash].[ext] --asset-naming=[hash].[ext] && mv dist/*.html dist/index.html && cp -R ../collab-web/public/* dist/ && bun scripts/generate-csp.ts dist",
+		"build": "bun run build:client && mkdir -p dist/share-viewer && bun ../coding-agent/scripts/generate-share-viewer.ts dist/share-viewer/index.html && bun scripts/verify-build.ts dist",
 		"dev": "bun run build && wrangler dev",
 		"deploy": "bun run build && wrangler deploy",
 		"check": "biome check src test scripts && bun run check:types",

--- a/packages/collab-relay/scripts/generate-csp.ts
+++ b/packages/collab-relay/scripts/generate-csp.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env bun
+/**
+ * Emit `dist/csp.txt` — the Content-Security-Policy the worker stamps on the
+ * guest client's HTML (see `src/asset-service.ts`). Inline executable scripts
+ * in the BUILT index.html are allowed by sha256 hash, so the policy needs no
+ * 'unsafe-inline' for scripts and stays correct however the bundler rewrites
+ * the page. Regenerate on every build; the worker fails open (no CSP header)
+ * if the file is missing, and verify-build.ts fails the build in that case.
+ */
+import * as path from "node:path";
+
+const ANALYTICS_ORIGIN = "https://um.can.ac";
+const SCRIPT_RE = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+/** Executable inline script types; data blocks like application/ld+json are not governed by script-src. */
+const EXECUTABLE_TYPES = new Set(["module", "text/javascript", "application/javascript"]);
+
+const distRoot = path.resolve(process.argv[2] ?? "dist");
+const html = await Bun.file(path.join(distRoot, "index.html")).text();
+
+const hashes: string[] = [];
+for (const match of html.matchAll(SCRIPT_RE)) {
+	const attrs = match[1] ?? "";
+	const body = match[2] ?? "";
+	if (/\bsrc\s*=/i.test(attrs) || body.length === 0) continue;
+	const type = /\btype\s*=\s*["']?([^"'\s>]+)/i.exec(attrs)?.[1]?.toLowerCase();
+	if (type !== undefined && !EXECUTABLE_TYPES.has(type)) continue;
+	const digest = new Bun.CryptoHasher("sha256").update(body).digest("base64");
+	hashes.push(`'sha256-${digest}'`);
+}
+
+const csp = [
+	"default-src 'self'",
+	`script-src 'self' ${[...hashes, ANALYTICS_ORIGIN].join(" ")}`,
+	// React style attributes need inline styles; CSS injection is a far smaller blast radius than script.
+	"style-src 'self' 'unsafe-inline'",
+	// Session images arrive inline in entry frames and render as data:/blob: URIs.
+	"img-src 'self' data: blob:",
+	// Custom relays from pasted links are arbitrary wss hosts; plain ws is localhost-only by link policy.
+	`connect-src 'self' wss: ws://localhost:* ws://127.0.0.1:* ${ANALYTICS_ORIGIN}`,
+	"font-src 'self' data:",
+	"media-src 'self' data: blob:",
+	"manifest-src 'self'",
+	"worker-src 'self' blob:",
+	"object-src 'none'",
+	"base-uri 'none'",
+	"form-action 'none'",
+	"frame-ancestors 'none'",
+].join("; ");
+
+await Bun.write(path.join(distRoot, "csp.txt"), `${csp}\n`);
+console.log(`Wrote csp.txt (${hashes.length} inline script hash${hashes.length === 1 ? "" : "es"})`);

--- a/packages/collab-relay/scripts/generate-csp.ts
+++ b/packages/collab-relay/scripts/generate-csp.ts
@@ -17,15 +17,16 @@ const EXECUTABLE_TYPES = new Set(["module", "text/javascript", "application/java
 const distRoot = path.resolve(process.argv[2] ?? "dist");
 const html = await Bun.file(path.join(distRoot, "index.html")).text();
 
-const hashes: string[] = [];
+const hashes = new Set<string>();
 for (const match of html.matchAll(SCRIPT_RE)) {
 	const attrs = match[1] ?? "";
 	const body = match[2] ?? "";
-	if (/\bsrc\s*=/i.test(attrs) || body.length === 0) continue;
-	const type = /\btype\s*=\s*["']?([^"'\s>]+)/i.exec(attrs)?.[1]?.toLowerCase();
+	// (?:^|\s) keeps data-src / data-type attributes from masquerading as src / type.
+	if (/(?:^|\s)src\s*=/i.test(attrs) || body.length === 0) continue;
+	const type = /(?:^|\s)type\s*=\s*["']?([^"'\s>]+)/i.exec(attrs)?.[1]?.toLowerCase();
 	if (type !== undefined && !EXECUTABLE_TYPES.has(type)) continue;
 	const digest = new Bun.CryptoHasher("sha256").update(body).digest("base64");
-	hashes.push(`'sha256-${digest}'`);
+	hashes.add(`'sha256-${digest}'`);
 }
 
 const csp = [
@@ -48,4 +49,4 @@ const csp = [
 ].join("; ");
 
 await Bun.write(path.join(distRoot, "csp.txt"), `${csp}\n`);
-console.log(`Wrote csp.txt (${hashes.length} inline script hash${hashes.length === 1 ? "" : "es"})`);
+console.log(`Wrote csp.txt (${hashes.size} inline script hash${hashes.size === 1 ? "" : "es"})`);

--- a/packages/collab-relay/scripts/verify-build.ts
+++ b/packages/collab-relay/scripts/verify-build.ts
@@ -2,13 +2,25 @@
 import * as path from "node:path";
 
 const distRoot = path.resolve(process.argv[2] ?? "dist");
-const requiredAssets = ["index.html", "og-image.png", "robots.txt", "sitemap.xml", "share-viewer/index.html"] as const;
+const requiredAssets = [
+	"index.html",
+	"og-image.png",
+	"robots.txt",
+	"sitemap.xml",
+	"csp.txt",
+	"share-viewer/index.html",
+] as const;
 
 for (const relativePath of requiredAssets) {
 	const assetPath = path.join(distRoot, relativePath);
 	if (!(await Bun.file(assetPath).exists())) {
 		throw new Error(`relay build is missing ${relativePath}`);
 	}
+}
+
+const csp = (await Bun.file(path.join(distRoot, "csp.txt")).text()).trim();
+if (!csp.startsWith("default-src ") || !csp.includes("script-src ")) {
+	throw new Error("csp.txt does not contain a client Content-Security-Policy");
 }
 
 const viewer = await Bun.file(path.join(distRoot, "share-viewer", "index.html")).text();

--- a/packages/collab-relay/src/asset-service.ts
+++ b/packages/collab-relay/src/asset-service.ts
@@ -1,0 +1,47 @@
+/**
+ * Serves the static collab-web guest client with security headers.
+ *
+ * The room key rides in the URL fragment of the client page, so XSS there is
+ * room compromise. HTML responses get the build-generated CSP (`/csp.txt`,
+ * whose inline-script hashes are computed from the built page by
+ * `scripts/generate-csp.ts`) plus no-referrer and nosniff. Non-HTML assets
+ * pass through untouched so hashed js/css keep their asset-layer headers.
+ */
+
+export interface ClientAssets {
+	fetch(request: Request): Promise<Response>;
+}
+
+const CSP_ASSET_PATH = "/csp.txt";
+
+export async function serveClientAsset(request: Request, assets: ClientAssets): Promise<Response> {
+	const asset = await assetOrSpa(request, assets);
+	const contentType = asset.headers.get("Content-Type")?.toLowerCase() ?? "";
+	if (!contentType.startsWith("text/html")) return asset;
+	const headers = new Headers(asset.headers);
+	headers.set("Referrer-Policy", "no-referrer");
+	headers.set("X-Content-Type-Options", "nosniff");
+	const csp = await loadClientCsp(request, assets);
+	if (csp) headers.set("Content-Security-Policy", csp);
+	return new Response(asset.body, { status: asset.status, statusText: asset.statusText, headers });
+}
+
+/** CSP is fail-open: a missing or malformed csp.txt serves the page without one rather than bricking it. */
+async function loadClientCsp(request: Request, assets: ClientAssets): Promise<string | null> {
+	const url = new URL(request.url);
+	url.pathname = CSP_ASSET_PATH;
+	url.search = "";
+	const response = await assets.fetch(new Request(url, { headers: { Accept: "text/plain" } }));
+	if (!response.ok) return null;
+	const csp = (await response.text()).trim();
+	return csp.startsWith("default-src ") ? csp : null;
+}
+
+async function assetOrSpa(request: Request, assets: ClientAssets): Promise<Response> {
+	const asset = await assets.fetch(request);
+	if (asset.status !== 404 || request.method !== "GET") return asset;
+	const rootUrl = new URL(request.url);
+	rootUrl.pathname = "/";
+	rootUrl.search = "";
+	return assets.fetch(new Request(rootUrl, { headers: request.headers }));
+}

--- a/packages/collab-relay/src/index.ts
+++ b/packages/collab-relay/src/index.ts
@@ -1,4 +1,5 @@
 import { DurableObject } from "cloudflare:workers";
+import { serveClientAsset } from "./asset-service";
 import { handleHubRequest, pruneHubs } from "./hub-service";
 import type {
 	HubAccessToken,
@@ -7,14 +8,17 @@ import type {
 	HubStoredValue,
 	HubTokenBinding,
 } from "./hub-types";
+import {
+	parseAttachment,
+	type RoomDeps,
+	type RoomSocket,
+	roomAlarm,
+	roomClose,
+	roomConnect,
+	roomMessage,
+	type SocketAttachment,
+} from "./room-service";
 import { handleShareRequest, pruneShares, type ShareServiceDependencies } from "./share-service";
-
-type RelayRole = "host" | "guest";
-
-interface SocketAttachment {
-	role: RelayRole;
-	peerId: number;
-}
 
 interface Env {
 	ASSETS: Fetcher;
@@ -27,7 +31,6 @@ interface Env {
 }
 
 const ROOM_PATH_RE = /^\/r\/([A-Za-z0-9_-]{10,64})$/;
-const ENVELOPE_HEADER_LENGTH = 4;
 const SHARE_UPLOAD_LIMIT = 12;
 const SHARE_UPLOAD_WINDOW_MS = 60 * 60 * 1_000;
 
@@ -43,25 +46,12 @@ function asBinary(message: ArrayBuffer | string): Uint8Array<ArrayBuffer> | null
 	return new Uint8Array(message);
 }
 
-function readPeerId(bytes: Uint8Array): number | null {
-	if (bytes.byteLength < ENVELOPE_HEADER_LENGTH) return null;
-	return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(0, false);
-}
-
-function rewritePeerId(bytes: Uint8Array, peerId: number): void {
-	new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).setUint32(0, peerId, false);
-}
-
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function attachmentOf(socket: WebSocket): SocketAttachment | null {
-	const value: unknown = socket.deserializeAttachment();
-	if (!isRecord(value)) return null;
-	const record = value;
-	if ((record.role !== "host" && record.role !== "guest") || typeof record.peerId !== "number") return null;
-	return { role: record.role, peerId: record.peerId };
+	return parseAttachment(socket.deserializeAttachment());
 }
 
 function relayResponse(request: Request, env: Env): Promise<Response> {
@@ -97,16 +87,24 @@ function shareDependencies(env: Env): ShareServiceDependencies {
 	};
 }
 
-async function assetOrSpa(request: Request, assets: Fetcher): Promise<Response> {
-	const asset = await assets.fetch(request);
-	if (asset.status !== 404 || request.method !== "GET") return asset;
-	const rootUrl = new URL(request.url);
-	rootUrl.pathname = "/";
-	rootUrl.search = "";
-	return assets.fetch(new Request(rootUrl, { headers: request.headers }));
-}
-
 export class CollabRoom extends DurableObject<Env> {
+	#deps(): RoomDeps {
+		return {
+			sockets: () => this.ctx.getWebSockets().map(socket => this.#roomSocket(socket)),
+			storage: this.ctx.storage,
+			now: () => Date.now(),
+		};
+	}
+
+	#roomSocket(socket: WebSocket): RoomSocket {
+		return {
+			attachment: () => attachmentOf(socket),
+			setAttachment: attachment => socket.serializeAttachment(attachment),
+			send: data => socket.send(data),
+			close: (code, reason) => socket.close(code, reason),
+		};
+	}
+
 	async fetch(request: Request): Promise<Response> {
 		if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
 			return new Response("websocket upgrade required", { status: 426 });
@@ -117,30 +115,8 @@ export class CollabRoom extends DurableObject<Env> {
 		const pair = new WebSocketPair();
 		const client = pair[0];
 		const server = pair[1];
-		const sockets = this.ctx.getWebSockets();
-		const host = sockets.find(socket => attachmentOf(socket)?.role === "host");
-
 		this.ctx.acceptWebSocket(server);
-		if (role === "host" && host) {
-			server.close(4009, "a host is already connected for this room");
-			return new Response(null, { status: 101, webSocket: client });
-		}
-		if (role === "guest" && !host) {
-			server.close(4004, "no such room");
-			return new Response(null, { status: 101, webSocket: client });
-		}
-
-		let peerId = 0;
-		if (role === "guest") {
-			peerId = (await this.ctx.storage.get<number>("nextPeerId")) ?? 1;
-			if (peerId > 0xfffffffe) {
-				server.close(4029, "room is full");
-				return new Response(null, { status: 101, webSocket: client });
-			}
-			await this.ctx.storage.put("nextPeerId", peerId + 1);
-		}
-		server.serializeAttachment({ role, peerId } satisfies SocketAttachment);
-		if (role === "guest") host?.send(JSON.stringify({ t: "peer-joined", peer: peerId }));
+		await roomConnect(this.#deps(), this.#roomSocket(server), role);
 		return new Response(null, { status: 101, webSocket: client });
 	}
 
@@ -148,41 +124,17 @@ export class CollabRoom extends DurableObject<Env> {
 		const attachment = attachmentOf(socket);
 		const bytes = asBinary(message);
 		if (!attachment || !bytes) return;
-		const sockets = this.ctx.getWebSockets();
-		const host = sockets.find(candidate => attachmentOf(candidate)?.role === "host");
-		if (!host) return;
-
-		if (attachment.role === "guest") {
-			if (bytes.byteLength < ENVELOPE_HEADER_LENGTH) return;
-			rewritePeerId(bytes, attachment.peerId);
-			host.send(bytes);
-			return;
-		}
-
-		const targetPeer = readPeerId(bytes);
-		if (targetPeer === null) return;
-		for (const candidate of sockets) {
-			const candidateAttachment = attachmentOf(candidate);
-			if (candidateAttachment?.role !== "guest") continue;
-			if (targetPeer === 0 || targetPeer === candidateAttachment.peerId) candidate.send(bytes);
-		}
+		roomMessage(this.#deps(), attachment, bytes);
 	}
 
-	webSocketClose(socket: WebSocket): void {
+	async webSocketClose(socket: WebSocket): Promise<void> {
 		const attachment = attachmentOf(socket);
 		if (!attachment) return;
-		const sockets = this.ctx.getWebSockets();
-		if (attachment.role === "host") {
-			for (const candidate of sockets) {
-				const candidateAttachment = attachmentOf(candidate);
-				if (candidateAttachment?.role !== "guest") continue;
-				candidate.send(JSON.stringify({ t: "room-closed" }));
-				candidate.close(4001, "room closed");
-			}
-			return;
-		}
-		const host = sockets.find(candidate => attachmentOf(candidate)?.role === "host");
-		if (host) host.send(JSON.stringify({ t: "peer-left", peer: attachment.peerId }));
+		await roomClose(this.#deps(), attachment);
+	}
+
+	async alarm(): Promise<void> {
+		await roomAlarm(this.#deps());
 	}
 }
 
@@ -357,7 +309,7 @@ export default {
 		if (shareResponse) return shareResponse;
 		const hubResponse = await handleHubRequest(request, hubDependencies(env));
 		if (hubResponse) return hubResponse;
-		return assetOrSpa(request, env.ASSETS);
+		return serveClientAsset(request, env.ASSETS);
 	},
 
 	async scheduled(_controller: ScheduledController, env: Env): Promise<void> {

--- a/packages/collab-relay/src/room-service.ts
+++ b/packages/collab-relay/src/room-service.ts
@@ -1,0 +1,185 @@
+/**
+ * Collab room coordination logic, extracted from the `CollabRoom` Durable
+ * Object so it can be unit-tested against fake sockets/storage (same pattern
+ * as `share-service` / `hub-service`).
+ *
+ * Reliability contract:
+ * - A host disconnect does NOT close the room immediately. Guests get a
+ *   `host-away` control message and the room stays open for `HOST_GRACE_MS`;
+ *   if the host reconnects in time guests get `host-back`, otherwise the
+ *   alarm broadcasts `room-closed` and closes every guest (4001) as before.
+ * - A new host connection replaces a lingering half-open host socket (closed
+ *   with 4010) instead of being rejected, so a host that lost its network can
+ *   always re-claim its room. Host attachments carry an epoch so the stale
+ *   socket's close event cannot be mistaken for the live host going away.
+ * - Guests that leave while the host is away are recorded and replayed as
+ *   `peer-left` control messages when the host returns.
+ */
+
+export type RelayRole = "host" | "guest";
+
+export interface SocketAttachment {
+	role: RelayRole;
+	peerId: number;
+	/** Host connection generation; a close event from an older epoch is a replaced socket, not the live host. */
+	epoch?: number;
+}
+
+export interface RoomSocket {
+	attachment(): SocketAttachment | null;
+	setAttachment(attachment: SocketAttachment): void;
+	send(data: Uint8Array | string): void;
+	close(code: number, reason: string): void;
+}
+
+export interface RoomStorage {
+	get<T = unknown>(key: string): Promise<T | undefined>;
+	put(key: string, value: unknown): Promise<void>;
+	delete(keys: string[]): Promise<unknown>;
+	setAlarm(scheduledTime: number): Promise<void>;
+	deleteAlarm(): Promise<void>;
+}
+
+export interface RoomDeps {
+	/** Currently connected sockets (closed sockets excluded). */
+	sockets(): RoomSocket[];
+	storage: RoomStorage;
+	now(): number;
+}
+
+export const ENVELOPE_HEADER_LENGTH = 4;
+/** How long a room survives without its host before guests are closed. */
+export const HOST_GRACE_MS = 45_000;
+const MAX_PEER_ID = 0xfffffffe;
+
+export const CLOSE_ROOM_CLOSED = 4001;
+export const CLOSE_NO_ROOM = 4004;
+export const CLOSE_HOST_REPLACED = 4010;
+export const CLOSE_ROOM_FULL = 4029;
+
+const KEY_NEXT_PEER_ID = "nextPeerId";
+const KEY_HOST_AWAY = "hostAway";
+const KEY_HOST_EPOCH = "hostEpoch";
+const KEY_PENDING_PEER_LEFTS = "pendingPeerLefts";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseAttachment(value: unknown): SocketAttachment | null {
+	if (!isRecord(value)) return null;
+	if ((value.role !== "host" && value.role !== "guest") || typeof value.peerId !== "number") return null;
+	return {
+		role: value.role,
+		peerId: value.peerId,
+		epoch: typeof value.epoch === "number" ? value.epoch : undefined,
+	};
+}
+
+function readPeerId(bytes: Uint8Array): number | null {
+	if (bytes.byteLength < ENVELOPE_HEADER_LENGTH) return null;
+	return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(0, false);
+}
+
+function rewritePeerId(bytes: Uint8Array, peerId: number): void {
+	new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).setUint32(0, peerId, false);
+}
+
+function hostOf(sockets: RoomSocket[]): RoomSocket | undefined {
+	return sockets.find(socket => socket.attachment()?.role === "host");
+}
+
+function guestsOf(sockets: RoomSocket[]): RoomSocket[] {
+	return sockets.filter(socket => socket.attachment()?.role === "guest");
+}
+
+/** Handle a freshly accepted socket. May close it (no room / room full). */
+export async function roomConnect(deps: RoomDeps, socket: RoomSocket, role: RelayRole): Promise<void> {
+	const host = hostOf(deps.sockets());
+	if (role === "host") {
+		// Last-writer-wins: after a network drop the previous host socket can
+		// linger half-open and would otherwise lock the room out (4009 forever).
+		if (host) host.close(CLOSE_HOST_REPLACED, "replaced by a newer host connection");
+		const epoch = ((await deps.storage.get<number>(KEY_HOST_EPOCH)) ?? 0) + 1;
+		await deps.storage.put(KEY_HOST_EPOCH, epoch);
+		socket.setAttachment({ role: "host", peerId: 0, epoch });
+		if ((await deps.storage.get<number>(KEY_HOST_AWAY)) === undefined) return;
+		await deps.storage.delete([KEY_HOST_AWAY]);
+		await deps.storage.deleteAlarm();
+		const pending = (await deps.storage.get<number[]>(KEY_PENDING_PEER_LEFTS)) ?? [];
+		if (pending.length > 0) await deps.storage.delete([KEY_PENDING_PEER_LEFTS]);
+		const back = JSON.stringify({ t: "host-back" });
+		for (const guest of guestsOf(deps.sockets())) guest.send(back);
+		for (const peer of pending) socket.send(JSON.stringify({ t: "peer-left", peer }));
+		return;
+	}
+	if (!host) {
+		socket.close(CLOSE_NO_ROOM, "no such room");
+		return;
+	}
+	const peerId = (await deps.storage.get<number>(KEY_NEXT_PEER_ID)) ?? 1;
+	if (peerId > MAX_PEER_ID) {
+		socket.close(CLOSE_ROOM_FULL, "room is full");
+		return;
+	}
+	await deps.storage.put(KEY_NEXT_PEER_ID, peerId + 1);
+	socket.setAttachment({ role: "guest", peerId });
+	host.send(JSON.stringify({ t: "peer-joined", peer: peerId }));
+}
+
+/** Route a sealed envelope. Guest frames go to the host (peerId stamped); host frames fan out to target guests. */
+export function roomMessage(deps: RoomDeps, sender: SocketAttachment, bytes: Uint8Array): void {
+	if (bytes.byteLength < ENVELOPE_HEADER_LENGTH) return;
+	const sockets = deps.sockets();
+	const host = hostOf(sockets);
+	if (!host) return;
+	if (sender.role === "guest") {
+		rewritePeerId(bytes, sender.peerId);
+		host.send(bytes);
+		return;
+	}
+	const targetPeer = readPeerId(bytes);
+	if (targetPeer === null) return;
+	for (const socket of sockets) {
+		const attachment = socket.attachment();
+		if (attachment?.role !== "guest") continue;
+		if (targetPeer === 0 || targetPeer === attachment.peerId) socket.send(bytes);
+	}
+}
+
+/** Handle a socket close. The closing socket is already gone from `deps.sockets()`. */
+export async function roomClose(deps: RoomDeps, attachment: SocketAttachment): Promise<void> {
+	const sockets = deps.sockets();
+	if (attachment.role === "guest") {
+		const host = hostOf(sockets);
+		if (host) {
+			host.send(JSON.stringify({ t: "peer-left", peer: attachment.peerId }));
+			return;
+		}
+		if ((await deps.storage.get<number>(KEY_HOST_AWAY)) === undefined) return;
+		const pending = (await deps.storage.get<number[]>(KEY_PENDING_PEER_LEFTS)) ?? [];
+		pending.push(attachment.peerId);
+		await deps.storage.put(KEY_PENDING_PEER_LEFTS, pending);
+		return;
+	}
+	const epoch = (await deps.storage.get<number>(KEY_HOST_EPOCH)) ?? 0;
+	if ((attachment.epoch ?? 0) !== epoch) return;
+	const guests = guestsOf(sockets);
+	if (guests.length === 0) return;
+	const now = deps.now();
+	await deps.storage.put(KEY_HOST_AWAY, now);
+	await deps.storage.setAlarm(now + HOST_GRACE_MS);
+	const away = JSON.stringify({ t: "host-away", graceMs: HOST_GRACE_MS });
+	for (const guest of guests) guest.send(away);
+}
+
+/** Grace window expired: close the room unless the host made it back. */
+export async function roomAlarm(deps: RoomDeps): Promise<void> {
+	await deps.storage.delete([KEY_HOST_AWAY, KEY_PENDING_PEER_LEFTS]);
+	const sockets = deps.sockets();
+	if (hostOf(sockets)) return;
+	for (const guest of guestsOf(sockets)) {
+		guest.send(JSON.stringify({ t: "room-closed" }));
+		guest.close(CLOSE_ROOM_CLOSED, "room closed");
+	}
+}

--- a/packages/collab-relay/src/room-service.ts
+++ b/packages/collab-relay/src/room-service.ts
@@ -138,6 +138,8 @@ export function roomMessage(deps: RoomDeps, sender: SocketAttachment, bytes: Uin
 		host.send(bytes);
 		return;
 	}
+	// A frame queued on a replaced host socket must not fan out as the live host's.
+	if ((sender.epoch ?? 0) !== (host.attachment()?.epoch ?? 0)) return;
 	const targetPeer = readPeerId(bytes);
 	if (targetPeer === null) return;
 	for (const socket of sockets) {
@@ -175,9 +177,19 @@ export async function roomClose(deps: RoomDeps, attachment: SocketAttachment): P
 
 /** Grace window expired: close the room unless the host made it back. */
 export async function roomAlarm(deps: RoomDeps): Promise<void> {
-	await deps.storage.delete([KEY_HOST_AWAY, KEY_PENDING_PEER_LEFTS]);
 	const sockets = deps.sockets();
-	if (hostOf(sockets)) return;
+	if (hostOf(sockets)) {
+		await deps.storage.delete([KEY_HOST_AWAY, KEY_PENDING_PEER_LEFTS]);
+		return;
+	}
+	const away = await deps.storage.get<number>(KEY_HOST_AWAY);
+	if (away !== undefined && away + HOST_GRACE_MS > deps.now()) {
+		// A stale alarm (at-least-once delivery racing a newer grace window)
+		// must not cut the current window short: re-arm to its real deadline.
+		await deps.storage.setAlarm(away + HOST_GRACE_MS);
+		return;
+	}
+	await deps.storage.delete([KEY_HOST_AWAY, KEY_PENDING_PEER_LEFTS]);
 	for (const guest of guestsOf(sockets)) {
 		guest.send(JSON.stringify({ t: "room-closed" }));
 		guest.close(CLOSE_ROOM_CLOSED, "room closed");

--- a/packages/collab-relay/test/asset-service.test.ts
+++ b/packages/collab-relay/test/asset-service.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { type ClientAssets, serveClientAsset } from "../src/asset-service";
+
+const CSP = "default-src 'self'; script-src 'self' 'sha256-abc'";
+
+function fakeAssets(files: Record<string, { body: string; type: string }>): ClientAssets {
+	return {
+		fetch(request: Request): Promise<Response> {
+			const pathname = new URL(request.url).pathname;
+			const file = files[pathname];
+			if (!file) return Promise.resolve(new Response("not found", { status: 404 }));
+			return Promise.resolve(new Response(file.body, { headers: { "Content-Type": file.type } }));
+		},
+	};
+}
+
+const clientFiles = {
+	"/": { body: "<!doctype html><title>omp collab</title>", type: "text/html; charset=utf-8" },
+	"/app.js": { body: "console.log(1)", type: "text/javascript" },
+	"/csp.txt": { body: `${CSP}\n`, type: "text/plain" },
+};
+
+describe("serveClientAsset", () => {
+	test("stamps CSP and security headers on HTML", async () => {
+		const response = await serveClientAsset(new Request("https://relay.example/"), fakeAssets(clientFiles));
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Security-Policy")).toBe(CSP);
+		expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+		expect(response.headers.get("Referrer-Policy")).toBe("no-referrer");
+	});
+
+	test("leaves non-HTML assets untouched", async () => {
+		const response = await serveClientAsset(new Request("https://relay.example/app.js"), fakeAssets(clientFiles));
+		expect(response.headers.get("Content-Security-Policy")).toBeNull();
+		expect(response.headers.get("X-Content-Type-Options")).toBeNull();
+	});
+
+	test("fails open without a csp.txt but keeps the other headers", async () => {
+		const { "/csp.txt": _omitted, ...withoutCsp } = clientFiles;
+		const response = await serveClientAsset(new Request("https://relay.example/"), fakeAssets(withoutCsp));
+		expect(response.headers.get("Content-Security-Policy")).toBeNull();
+		expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+	});
+
+	test("rejects a csp.txt that is not a policy", async () => {
+		const files = { ...clientFiles, "/csp.txt": { body: "<html>oops</html>", type: "text/plain" } };
+		const response = await serveClientAsset(new Request("https://relay.example/"), fakeAssets(files));
+		expect(response.headers.get("Content-Security-Policy")).toBeNull();
+	});
+
+	test("GET for an unknown path falls back to the SPA root with headers", async () => {
+		const response = await serveClientAsset(new Request("https://relay.example/join/xyz"), fakeAssets(clientFiles));
+		expect(response.status).toBe(200);
+		expect(await response.text()).toContain("omp collab");
+		expect(response.headers.get("Content-Security-Policy")).toBe(CSP);
+	});
+
+	test("non-GET misses pass through as 404", async () => {
+		const response = await serveClientAsset(
+			new Request("https://relay.example/join/xyz", { method: "POST" }),
+			fakeAssets(clientFiles),
+		);
+		expect(response.status).toBe(404);
+	});
+});

--- a/packages/collab-relay/test/room-service.test.ts
+++ b/packages/collab-relay/test/room-service.test.ts
@@ -170,9 +170,23 @@ describe("host grace window", () => {
 		const host = await room.connect("host");
 		const guest = await room.connect("guest");
 		await room.disconnect(host);
+		room.now += HOST_GRACE_MS;
 		await roomAlarm(room.deps());
 		expect(guest.controls()).toEqual([{ t: "host-away", graceMs: HOST_GRACE_MS }, { t: "room-closed" }]);
 		expect(guest.closed).toEqual({ code: CLOSE_ROOM_CLOSED, reason: "room closed" });
+	});
+
+	test("a stale alarm before the deadline re-arms instead of closing", async () => {
+		const room = new FakeRoom();
+		const host = await room.connect("host");
+		const guest = await room.connect("guest");
+		await room.disconnect(host);
+		const deadline = room.now + HOST_GRACE_MS;
+		room.now += 1_000;
+		room.alarmAt = 0;
+		await roomAlarm(room.deps());
+		expect(guest.closed).toBeNull();
+		expect(room.alarmAt).toBe(deadline);
 	});
 
 	test("alarm racing a returned host closes nothing", async () => {
@@ -183,6 +197,15 @@ describe("host grace window", () => {
 		await room.connect("host");
 		await roomAlarm(room.deps());
 		expect(guest.closed).toBeNull();
+	});
+
+	test("frames from a replaced host socket are not fanned out to guests", async () => {
+		const room = new FakeRoom();
+		const stale = await room.connect("host");
+		const guest = await room.connect("guest");
+		await room.connect("host");
+		roomMessage(room.deps(), stale.attachment()!, envelope(0, [3]));
+		expect(guest.sent.filter(data => typeof data !== "string")).toHaveLength(0);
 	});
 
 	test("a replaced host socket's close does not start the grace window", async () => {

--- a/packages/collab-relay/test/room-service.test.ts
+++ b/packages/collab-relay/test/room-service.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, test } from "bun:test";
+import {
+	CLOSE_HOST_REPLACED,
+	CLOSE_NO_ROOM,
+	CLOSE_ROOM_CLOSED,
+	HOST_GRACE_MS,
+	parseAttachment,
+	type RoomDeps,
+	type RoomSocket,
+	type RoomStorage,
+	roomAlarm,
+	roomClose,
+	roomConnect,
+	roomMessage,
+	type SocketAttachment,
+} from "../src/room-service";
+
+class FakeSocket implements RoomSocket {
+	sent: (string | Uint8Array)[] = [];
+	closed: { code: number; reason: string } | null = null;
+	#attachment: SocketAttachment | null = null;
+
+	attachment(): SocketAttachment | null {
+		return this.#attachment;
+	}
+	setAttachment(attachment: SocketAttachment): void {
+		this.#attachment = attachment;
+	}
+	send(data: Uint8Array | string): void {
+		this.sent.push(data);
+	}
+	close(code: number, reason: string): void {
+		this.closed = { code, reason };
+	}
+
+	controls(): { t: string; peer?: number; graceMs?: number }[] {
+		return this.sent
+			.filter((data): data is string => typeof data === "string")
+			.map(data => JSON.parse(data) as { t: string; peer?: number; graceMs?: number });
+	}
+}
+
+class FakeRoom {
+	sockets: FakeSocket[] = [];
+	now = 1_000_000;
+	alarmAt: number | null = null;
+	#map = new Map<string, unknown>();
+
+	deps(): RoomDeps {
+		const storage: RoomStorage = {
+			get: <T>(key: string) => Promise.resolve(this.#map.get(key) as T | undefined),
+			put: (key, value) => {
+				this.#map.set(key, value);
+				return Promise.resolve();
+			},
+			delete: (keys: string[]) => {
+				for (const key of keys) this.#map.delete(key);
+				return Promise.resolve(keys.length);
+			},
+			setAlarm: scheduledTime => {
+				this.alarmAt = scheduledTime;
+				return Promise.resolve();
+			},
+			deleteAlarm: () => {
+				this.alarmAt = null;
+				return Promise.resolve();
+			},
+		};
+		// Mirrors the DO runtime: closed sockets drop out of getWebSockets().
+		return { sockets: () => this.sockets.filter(socket => !socket.closed), storage, now: () => this.now };
+	}
+
+	async connect(role: "host" | "guest"): Promise<FakeSocket> {
+		const socket = new FakeSocket();
+		this.sockets.push(socket);
+		await roomConnect(this.deps(), socket, role);
+		return socket;
+	}
+
+	async disconnect(socket: FakeSocket): Promise<void> {
+		const attachment = socket.attachment();
+		this.sockets = this.sockets.filter(candidate => candidate !== socket);
+		if (attachment) await roomClose(this.deps(), attachment);
+	}
+}
+
+function envelope(peerId: number, payload: number[]): Uint8Array {
+	const bytes = new Uint8Array(4 + payload.length);
+	new DataView(bytes.buffer).setUint32(0, peerId, false);
+	bytes.set(payload, 4);
+	return bytes;
+}
+
+describe("roomConnect", () => {
+	test("guest without a host is closed with 4004", async () => {
+		const room = new FakeRoom();
+		const guest = await room.connect("guest");
+		expect(guest.closed).toEqual({ code: CLOSE_NO_ROOM, reason: "no such room" });
+	});
+
+	test("guest join assigns a peer id and notifies the host", async () => {
+		const room = new FakeRoom();
+		const host = await room.connect("host");
+		const guest = await room.connect("guest");
+		expect(guest.closed).toBeNull();
+		expect(guest.attachment()).toEqual({ role: "guest", peerId: 1, epoch: undefined });
+		expect(host.controls()).toEqual([{ t: "peer-joined", peer: 1 }]);
+	});
+
+	test("a newer host connection replaces a lingering host socket", async () => {
+		const room = new FakeRoom();
+		const stale = await room.connect("host");
+		const guest = await room.connect("guest");
+		const fresh = await room.connect("host");
+		expect(stale.closed).toEqual({ code: CLOSE_HOST_REPLACED, reason: "replaced by a newer host connection" });
+		expect(fresh.closed).toBeNull();
+		expect((fresh.attachment()?.epoch ?? 0) > (stale.attachment()?.epoch ?? 0)).toBe(true);
+		// Guest frames now route to the fresh host.
+		roomMessage(room.deps(), guest.attachment()!, envelope(0, [7]));
+		expect(fresh.sent).toHaveLength(1);
+	});
+});
+
+describe("host grace window", () => {
+	test("host drop notifies guests and arms the alarm instead of closing them", async () => {
+		const room = new FakeRoom();
+		const host = await room.connect("host");
+		const guest = await room.connect("guest");
+		await room.disconnect(host);
+		expect(guest.closed).toBeNull();
+		expect(guest.controls()).toEqual([{ t: "host-away", graceMs: HOST_GRACE_MS }]);
+		expect(room.alarmAt).toBe(room.now + HOST_GRACE_MS);
+	});
+
+	test("host drop with no guests arms nothing", async () => {
+		const room = new FakeRoom();
+		const host = await room.connect("host");
+		await room.disconnect(host);
+		expect(room.alarmAt).toBeNull();
+	});
+
+	test("host reconnect within the window sends host-back and disarms the alarm", async () => {
+		const room = new FakeRoom();
+		const host = await room.connect("host");
+		const guest = await room.connect("guest");
+		await room.disconnect(host);
+		const returned = await room.connect("host");
+		expect(room.alarmAt).toBeNull();
+		expect(guest.controls()).toEqual([{ t: "host-away", graceMs: HOST_GRACE_MS }, { t: "host-back" }]);
+		expect(returned.controls()).toEqual([]);
+		// The room keeps working after the reconnect.
+		roomMessage(room.deps(), guest.attachment()!, envelope(0, [1]));
+		expect(returned.sent).toHaveLength(1);
+	});
+
+	test("guests leaving while the host is away are replayed as peer-left on reconnect", async () => {
+		const room = new FakeRoom();
+		const host = await room.connect("host");
+		const staying = await room.connect("guest");
+		const leaving = await room.connect("guest");
+		await room.disconnect(host);
+		await room.disconnect(leaving);
+		const returned = await room.connect("host");
+		expect(returned.controls()).toEqual([{ t: "peer-left", peer: leaving.attachment()?.peerId }]);
+		expect(staying.closed).toBeNull();
+	});
+
+	test("expired alarm closes every guest with room-closed", async () => {
+		const room = new FakeRoom();
+		const host = await room.connect("host");
+		const guest = await room.connect("guest");
+		await room.disconnect(host);
+		await roomAlarm(room.deps());
+		expect(guest.controls()).toEqual([{ t: "host-away", graceMs: HOST_GRACE_MS }, { t: "room-closed" }]);
+		expect(guest.closed).toEqual({ code: CLOSE_ROOM_CLOSED, reason: "room closed" });
+	});
+
+	test("alarm racing a returned host closes nothing", async () => {
+		const room = new FakeRoom();
+		const host = await room.connect("host");
+		const guest = await room.connect("guest");
+		await room.disconnect(host);
+		await room.connect("host");
+		await roomAlarm(room.deps());
+		expect(guest.closed).toBeNull();
+	});
+
+	test("a replaced host socket's close does not start the grace window", async () => {
+		const room = new FakeRoom();
+		const stale = await room.connect("host");
+		const guest = await room.connect("guest");
+		await room.connect("host");
+		// The replaced socket's close event arrives late; its epoch is outdated.
+		await roomClose(room.deps(), stale.attachment()!);
+		expect(room.alarmAt).toBeNull();
+		expect(guest.controls()).toEqual([]);
+	});
+});
+
+describe("roomMessage", () => {
+	test("guest envelopes are stamped with the sender peer id", async () => {
+		const room = new FakeRoom();
+		const host = await room.connect("host");
+		const guest = await room.connect("guest");
+		roomMessage(room.deps(), guest.attachment()!, envelope(0, [9]));
+		const [received] = host.sent.filter((data): data is Uint8Array => typeof data !== "string");
+		expect(new DataView(received!.buffer).getUint32(0, false)).toBe(guest.attachment()!.peerId);
+	});
+
+	test("host broadcast (peer 0) reaches all guests, targeted frames only one", async () => {
+		const room = new FakeRoom();
+		const host = await room.connect("host");
+		const first = await room.connect("guest");
+		const second = await room.connect("guest");
+		roomMessage(room.deps(), host.attachment()!, envelope(0, [1]));
+		roomMessage(room.deps(), host.attachment()!, envelope(second.attachment()!.peerId, [2]));
+		expect(first.sent).toHaveLength(1);
+		expect(second.sent).toHaveLength(2);
+	});
+});
+
+describe("parseAttachment", () => {
+	test("accepts pre-epoch attachments from hibernating sockets", () => {
+		expect(parseAttachment({ role: "host", peerId: 0 })).toEqual({ role: "host", peerId: 0, epoch: undefined });
+	});
+
+	test("rejects malformed values", () => {
+		expect(parseAttachment(null)).toBeNull();
+		expect(parseAttachment({ role: "spectator", peerId: 1 })).toBeNull();
+		expect(parseAttachment({ role: "guest" })).toBeNull();
+	});
+});

--- a/packages/collab-relay/wrangler.toml
+++ b/packages/collab-relay/wrangler.toml
@@ -6,11 +6,14 @@ compatibility_date = "2026-07-13"
 pattern = "collab.pkking.computer"
 custom_domain = true
 
+# run_worker_first = true routes every request (including asset hits) through
+# the worker so HTML responses get the client CSP and security headers stamped
+# by src/asset-service.ts; assets previously bypassed the worker entirely.
 [assets]
 directory = "./dist"
 binding = "ASSETS"
 not_found_handling = "none"
-run_worker_first = [ "/healthz", "/r/*", "/s", "/s/*", "/h", "/h/*" ]
+run_worker_first = true
 
 [[durable_objects.bindings]]
 name = "COLLAB_ROOMS"

--- a/packages/collab-web/src/lib/client.ts
+++ b/packages/collab-web/src/lib/client.ts
@@ -115,9 +115,15 @@ export class GuestClient {
 		this.#socket.onOpen = () => this.#handleOpen();
 		this.#socket.onFrame = frame => this.#applyFrameSafe(frame);
 		this.#socket.onControl = msg => {
-			if (msg.t === "room-closed") this.#end("room closed");
-			else if (msg.t === "host-away") this.#pushNotice("warning", "host connection lost — waiting for it to return");
+			if (msg.t === "room-closed") {
+				this.#end("room closed");
+				return;
+			}
+			// No frame follows while the host is away, so commit the notice immediately.
+			if (msg.t === "host-away") this.#pushNotice("warning", "host connection lost — waiting for it to return");
 			else if (msg.t === "host-back") this.#pushNotice("info", "host reconnected");
+			else return;
+			this.#commit();
 		};
 		this.#socket.onClose = (reason, willReconnect) => this.#handleClose(reason, willReconnect);
 		this.#snapshot = this.#buildSnapshot();

--- a/packages/collab-web/src/lib/client.ts
+++ b/packages/collab-web/src/lib/client.ts
@@ -116,6 +116,8 @@ export class GuestClient {
 		this.#socket.onFrame = frame => this.#applyFrameSafe(frame);
 		this.#socket.onControl = msg => {
 			if (msg.t === "room-closed") this.#end("room closed");
+			else if (msg.t === "host-away") this.#pushNotice("warning", "host connection lost — waiting for it to return");
+			else if (msg.t === "host-back") this.#pushNotice("info", "host reconnected");
 		};
 		this.#socket.onClose = (reason, willReconnect) => this.#handleClose(reason, willReconnect);
 		this.#snapshot = this.#buildSnapshot();

--- a/packages/collab-web/src/lib/socket.ts
+++ b/packages/collab-web/src/lib/socket.ts
@@ -16,6 +16,7 @@ const FATAL_CLOSE_REASONS: Record<number, string> = {
 	4001: "room closed",
 	4004: "no such room",
 	4009: "a host is already connected for this room",
+	4010: "host connection replaced",
 	4029: "room is full",
 };
 

--- a/packages/collab-web/test/socket.test.ts
+++ b/packages/collab-web/test/socket.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import { CollabSocket } from "../src/lib/socket";
+
+class FakeWebSocket {
+	static readonly instances: FakeWebSocket[] = [];
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSED = 3;
+
+	binaryType = "blob";
+	readyState: number = FakeWebSocket.CONNECTING;
+	onopen: (() => void) | null = null;
+	onmessage: ((event: { data: unknown }) => void) | null = null;
+	onerror: (() => void) | null = null;
+	onclose: ((event: { code: number; reason: string }) => void) | null = null;
+
+	constructor() {
+		FakeWebSocket.instances.push(this);
+	}
+
+	send(): void {}
+
+	close(): void {
+		this.readyState = FakeWebSocket.CLOSED;
+	}
+
+	open(): void {
+		this.readyState = FakeWebSocket.OPEN;
+		this.onopen?.();
+	}
+
+	serverClose(code: number, reason: string): void {
+		this.readyState = FakeWebSocket.CLOSED;
+		this.onclose?.({ code, reason });
+	}
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+	FakeWebSocket.instances.length = 0;
+});
+
+describe("CollabSocket close handling", () => {
+	test("a replaced host connection stays closed instead of reconnecting", async () => {
+		const key = await crypto.subtle.importKey("raw", new Uint8Array(32), "AES-GCM", false, ["encrypt", "decrypt"]);
+		vi.useFakeTimers();
+		const realWebSocket = globalThis.WebSocket;
+		globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+		try {
+			const socket = new CollabSocket({ wsUrl: "wss://relay.example/r/roomroomroom", role: "host", key });
+			const onClose = vi.fn();
+			socket.onClose = onClose;
+
+			socket.connect();
+			const first = FakeWebSocket.instances[0];
+			expect(first).toBeDefined();
+			first!.open();
+			first!.serverClose(4010, "replaced by a newer host connection");
+
+			expect(onClose).toHaveBeenCalledWith("host connection replaced", false);
+			vi.advanceTimersByTime(60_000);
+			expect(FakeWebSocket.instances).toHaveLength(1);
+		} finally {
+			globalThis.WebSocket = realWebSocket;
+		}
+	});
+});

--- a/packages/wire/CHANGELOG.md
+++ b/packages/wire/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added `host-away` / `host-back` relay→guest control messages: the relay now holds a room open for a grace window when the host socket drops instead of closing guests immediately.
+
 ### Changed
 
 - Changed the default collaboration relay and encrypted share endpoints to the owned `collab.pkking.computer` service.

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -417,5 +417,10 @@ export interface ParsedCollabLink {
 /** Relay → host control message. */
 export type RelayControlToHost = { t: "peer-joined" | "peer-left"; peer: number };
 /** Relay → guest control message. */
-export type RelayControlToGuest = { t: "room-closed" };
+export type RelayControlToGuest =
+	| { t: "room-closed" }
+	/** Host socket dropped; the relay holds the room open for `graceMs` awaiting its return. */
+	| { t: "host-away"; graceMs: number }
+	/** The host reconnected within the grace window; the session resumes. */
+	| { t: "host-back" };
 export type RelayControlMessage = RelayControlToHost | RelayControlToGuest;

--- a/scripts/ci-test-ts.ts
+++ b/scripts/ci-test-ts.ts
@@ -74,6 +74,7 @@ const fastWorkspacePackages = [
 	"packages/agent",
 	"packages/context-policy",
 	"packages/context-storage",
+	"packages/collab-relay",
 ];
 
 // These suites cover the native package, TUI/browser-ish behavior, local servers,


### PR DESCRIPTION
## What

Three reliability/hardening fixes for the `/collab` path to the deployed `ompk-collab` worker:

1. **Host-away grace window** — `CollabRoom` no longer closes every guest the instant the host socket drops. Guests receive a `host-away` control message and the room stays open for a 45 s window (Durable Object alarm). If the host reconnects in time, guests get `host-back` and `peer-left`s recorded during the outage are replayed to the host; otherwise the alarm closes the room with `room-closed`/4001 exactly as before. A newer host connection now **replaces** a lingering half-open host socket (close 4010) instead of being rejected with 4009, so a host that lost its network can always re-claim its room; host attachments carry an epoch so the replaced socket's late close event can't be mistaken for the live host going away. The room logic is extracted into `room-service.ts` with injected sockets/storage (same pattern as `share-service`/`hub-service`) and unit-tested.
2. **Security headers on the guest client** — the page that carries the room key in its URL fragment previously shipped with no CSP. `run_worker_first = true` routes asset requests through the worker, and the new `asset-service.ts` stamps HTML responses with a build-generated Content-Security-Policy (`scripts/generate-csp.ts` hashes the built page's inline scripts, so no `'unsafe-inline'` for scripts), `Referrer-Policy: no-referrer`, and `X-Content-Type-Options: nosniff`. `verify-build.ts` now fails the build if `csp.txt` is missing or malformed. Non-HTML assets pass through untouched.
3. **Relay in CI** — `packages/collab-relay` joins the workspace test bucket in `scripts/ci-test-ts.ts`, and the no-natives `check` job builds the relay client assets via a new `build:client` script (the full `build` keeps the share-viewer step, which needs the native addon, for deploys).

The TUI guest and web client surface `host-away`/`host-back` as a status line / notice. Old clients ignore unknown control messages, so mixed versions keep today's behavior.

## Why

A transient host network blip previously destroyed the room for every guest (fatal 4001, no reconnect), and a half-open stale host socket could permanently lock the host out of its own room (fatal 4009). The client page is the most security-sensitive HTML the worker serves — XSS there equals room-key compromise — but only the share viewer had a CSP. And the relay package, the exact code fronting the cloud environment, ran no tests in CI.

## Testing

- `packages/collab-relay`: `bun test` — 36 pass (18 new across `room-service.test.ts` / `asset-service.test.ts`, covering grace-window arm/disarm, peer-left replay, stale-host replacement epochs, alarm expiry/race, envelope routing, CSP stamping and fail-open) — plus `biome check` and `tsgo` clean.
- `bun run build:client` against the real bundle: generated CSP contains exactly one inline-script hash; hash independently re-computed and matched.
- `wrangler deploy --dry-run`: config and worker bundle validate.
- `packages/collab-web` (42 tests), `packages/wire` tests, and typechecks for all touched packages pass. `packages/coding-agent` `test/collab` shows the same 32 pass / 6 fail as a clean checkout (pre-existing missing-native-addon failures in this environment, unrelated).
- `bun scripts/ci-test-ts.ts workspace --dry-run` confirms the relay package is picked up.

---

- [x] `bun check` passes (touched packages: collab-relay, collab-web, wire, coding-agent typecheck)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing) — `packages/wire/CHANGELOG.md`; `docs/collab.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNCKkJ3xMbbNUCwy3Tzdrr

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNCKkJ3xMbbNUCwy3Tzdrr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collaboration rooms now remain available for approximately 45 seconds after the host disconnects, allowing the host to reconnect without ending the session.
  * Guests receive clear notifications when the host disconnects or reconnects.
  * Reconnecting hosts can reclaim rooms, while lingering connections are safely replaced.

* **Security**
  * Guest pages now use stricter browser security and privacy headers.

* **Documentation**
  * Documented host-disconnect behavior, reconnection grace periods, and room closure conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->