### PR TITLE
fix(collab): open browser sessions on product host

### DIFF
--- a/docs/collab.md
+++ b/docs/collab.md
@@ -15,7 +15,7 @@ prints
 ```
 Collab session started!
  • Join from another terminal: oh-my-pk join "mgAYTZwEnpRQtca0CTgn-Q.gdJUbTovD94ofDaa8YvhY0-ty16w4fn8PgB6PLnoA30"
- • or any web browser: collab.pkking.computer/#mgAYTZwEnpRQtca0CTgn-Q.gdJUbTovD94ofDaa8YvhY0-ty16w4fn8PgB6PLnoA30
+ • or any web browser: oh-my-pk.pkking.computer/collab/#mgAYTZwEnpRQtca0CTgn-Q.gdJUbTovD94ofDaa8YvhY0-ty16w4fn8PgB6PLnoA30
 ```
 
 The browser line is click-to-join (an OSC 8 hyperlink to the full `https://` deep link): the relay serves the web guest client at `/`, and the room id + key ride in the URL fragment. From another omp (any directory, any machine), either form works:
@@ -25,7 +25,7 @@ Running `/collab`, `/remote-control`, `/collab view`, or `/remote-control view` 
 `/remote-control` uses the same encrypted transport as `/collab` (ephemeral session sharing). It is distinct from `/remote`, which is owned by the pk-speak extension and provides a persistent operator gateway (voice, routing, sessions, workspace). If pk-speak is loaded, `/remote` controls the gateway; `/remote-control` controls collab sharing.
 
 ```
-/join collab.pkking.computer/#mgAYTZwEnpRQtca0CTgn-Q.gdJU…
+/join oh-my-pk.pkking.computer/collab/#mgAYTZwEnpRQtca0CTgn-Q.gdJU…
 ```
 
 The guest's previous session is restored on `/leave` (or when the host stops).
@@ -111,14 +111,14 @@ Set `collab.webUrl` when the browser UI is hosted separately from the websocket 
 | Setting | Default | Meaning |
 |---|---|---|
 | `collab.relayUrl` | `wss://collab.pkking.computer` | Relay used by `/collab` when no relay is passed inline |
-| `collab.webUrl` | empty | Browser UI URL for `/collab` links; empty derives from relay; explicit `http://` is allowed only for localhost |
+| `collab.webUrl` | empty | Browser UI URL for `/collab` links; empty uses `https://oh-my-pk.pkking.computer/collab/` for the owned relay and derives from custom relays; explicit `http://` is allowed only for localhost |
 | `collab.displayName` | OS username | Name shown to other participants |
 | `share.serverUrl` | `https://collab.pkking.computer/s` | Share viewer/upload base used by `/share` (links are `<base>/<id>#<key>`) |
 | `share.redactSecrets` | `true` | Run the secret obfuscator over `/share` snapshots before upload |
 
 ## Self-hosting the relay
 
-The owned collaboration service is deployed as the `ompk-collab` Cloudflare Worker at `collab.pkking.computer`. It keeps live room coordination in one Durable Object per room and stores sealed share blobs in the configured R2 bucket. The relay never decrypts session content. Share uploads are capped at 1 MB and rate-limited to 12 per Cloudflare client IP per hour.
+The browser client is exposed at `oh-my-pk.pkking.computer/collab/` through the product-host Worker. Its relay, share, and hub service remains the `ompk-collab` Cloudflare Worker at `collab.pkking.computer`. The relay keeps live room coordination in one Durable Object per room and stores sealed share blobs in the configured R2 bucket; it never decrypts session content. Share uploads are capped at 1 MB and rate-limited to 12 per Cloudflare client IP per hour.
 
 A host disconnect does not end the room immediately: guests receive a `host-away` control message and the relay holds the room open for a ~45 s grace window. If the host reconnects in time, guests get `host-back` and the session resumes; otherwise the room closes as before (`room-closed`, close code 4001). A new host connection replaces a lingering half-open host socket (closed with 4010) so a host that lost its network can always re-claim its room. The guest client page is served with a strict build-generated Content-Security-Policy (inline scripts allowed by hash only), `Referrer-Policy: no-referrer`, and `X-Content-Type-Options: nosniff`.
 

--- a/docs/fork-boundaries.md
+++ b/docs/fork-boundaries.md
@@ -6,7 +6,7 @@ These boundaries keep the fork's built-in collaboration feature, extension-owned
 |---|---|
 | **1. Command namespace** | Built-in reserved names must not claim short generic verbs that extensions own. `/collab` is the primary sharing command; `/remote-control` is a compatibility alias; `/remote` belongs to the pk-speak extension. |
 | **2. Product identity** | Fork-owned user-facing outbound identifiers use `oh-my-pk` through `APP_NAME` from `@pk-nerdsaver-ai/pi-utils`, not `Oh-My-Pi` or `omp.sh`. Upstream issue and pull-request links remain as factual attribution. |
-| **3. Hosting domains** | `oh-my-pk.pkking.computer` hosts the CLI/install landing and may host a future remote client; `collab.pkking.computer` hosts the collab relay and web client; `pkking.computer` is the apex landing. |
+| **3. Hosting domains** | `oh-my-pk.pkking.computer` hosts the CLI/install landing and the `/collab/` browser client; `collab.pkking.computer` hosts the collab relay, share storage, and hub APIs; `pkking.computer` is the apex landing. |
 | **4. Surface capability** | `/collab` provides ephemeral end-to-end encrypted session sharing for browser and TUI guests. `/remote` provides the pk-speak extension's persistent paired operator gateway for voice, routing, sessions, workspace access, and approvals. |
 
 ## Command ownership
@@ -19,8 +19,8 @@ These boundaries keep the fork's built-in collaboration feature, extension-owned
 
 ## Domain map
 
-- `oh-my-pk.pkking.computer`: CLI/install landing and possible future hosted remote client.
-- `collab.pkking.computer`: collab relay and zero-install web client.
+- `oh-my-pk.pkking.computer`: CLI/install landing and the zero-install browser client at `/collab/`.
+- `collab.pkking.computer`: collab WebSocket relay, encrypted share storage/viewer backend, and hub APIs.
 - `pkking.computer`: apex landing.
 
 ## Why these boundaries exist
@@ -29,7 +29,7 @@ These boundaries keep the fork's built-in collaboration feature, extension-owned
 
 **Product identity:** Consistent outbound names and links make it clear which product is making a request and prevent fork-owned traffic from presenting itself as upstream. Historical upstream links remain unchanged because they identify the source of an issue, pull request, schema, or documentation reference.
 
-**Hosting domains:** Separating the product landing, collab relay/client, and apex landing keeps deployment ownership and trust surfaces understandable. A link's hostname should accurately identify the service receiving traffic.
+**Hosting domains:** Keeping the product-facing browser client under `oh-my-pk.pkking.computer/collab/` makes outbound links match the product identity, while the separate `collab.pkking.computer` service hostname clearly identifies relay, share, and hub traffic.
 
 **Surface capability:** Ephemeral sharing and a persistent operator gateway have different lifetimes, permissions, and user expectations. Keeping them distinct avoids implying that a temporary browser/TUI share includes pk-speak's paired voice, routing, session, workspace, or approval capabilities.
 

--- a/infra/install-redirect/README.md
+++ b/infra/install-redirect/README.md
@@ -4,7 +4,8 @@ The install scripts use binaries from a **private Hugging Face repo** (free
 storage + egress), independently of the GitHub Release assets built by Actions.
 A **Cloudflare Worker** at `oh-my-pk.pkking.computer` holds the HF token as a
 secret and proxies downloads, so the repo stays private and the installer never
-sees a token.
+sees a token. It also proxies `/collab/*` through the `ompk-collab` Worker service
+binding, keeping browser collaboration links on the product hostname.
 
 ```
 build host(s) ── publish-binaries-hf.ts ──▶ private HF repo ──▶ CF Worker ──▶ install.sh / install.ps1 ──▶ user
@@ -23,8 +24,10 @@ build host(s) ── publish-binaries-hf.ts ──▶ private HF repo ──▶ 
    wrangler secret put HF_TOKEN      # paste the READ token
    wrangler deploy
    ```
-   `wrangler.toml` already sets `HF_REPO` / `HF_REPO_TYPE` and the custom-domain route.
-   (Requires a Cloudflare account on the **free** Workers plan — no paid features used.)
+   `wrangler.toml` already sets `HF_REPO` / `HF_REPO_TYPE`, the custom-domain route,
+   and the `COLLAB` service binding to the separately deployed `ompk-collab` Worker.
+   Deploy `packages/collab-relay` first. (Requires a Cloudflare account on the
+   **free** Workers plan — no paid features used.)
 
 ## Each release
 

--- a/infra/install-redirect/worker.js
+++ b/infra/install-redirect/worker.js
@@ -7,6 +7,7 @@
 //   /install.ps1                          -> proxy scripts/install.ps1  (GitHub raw)
 //   /version                              -> latest tag, from the private HF repo
 //   /bin/<path>                           -> binary, from the private HF repo
+//   /collab/*                             -> product-hosted collab browser client
 //
 // Binaries live in a PRIVATE Hugging Face repo (free storage, free egress). The
 // repo stays private: this Worker holds the HF token as a secret and proxies
@@ -14,6 +15,7 @@
 //   vars:    HF_REPO     e.g. "pkkidking/oh-my-pi-binaries"
 //   secret:  HF_TOKEN    a read-scoped HF access token (wrangler secret put HF_TOKEN)
 //   var (optional): HF_REPO_TYPE "models" (default) | "datasets"
+//   service: COLLAB      ompk-collab Worker binding
 
 const GITHUB_RAW_BASE = "https://raw.githubusercontent.com/kingkillery/oh-my-pi/main/scripts";
 
@@ -154,6 +156,12 @@ function escapeHtml(value) {
 	return value.replace(/[&<>"']/g, char => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[char]);
 }
 
+async function proxyCollabClient(request, env) {
+	if (!env.COLLAB) return new Response("Collab client unavailable", { status: 503 });
+	const upstreamUrl = new URL(request.url);
+	upstreamUrl.pathname = upstreamUrl.pathname.slice("/collab".length) || "/";
+	return env.COLLAB.fetch(new Request(upstreamUrl, request));
+}
 
 export default {
 	async fetch(request, env, ctx) {
@@ -162,6 +170,11 @@ export default {
 		}
 		const url = new URL(request.url);
 		const pathname = url.pathname;
+		if (pathname === "/collab") {
+			url.pathname = "/collab/";
+			return Response.redirect(url, 308);
+		}
+		if (pathname.startsWith("/collab/")) return proxyCollabClient(request, env);
 
 		switch (pathname) {
 			case "/":

--- a/infra/install-redirect/worker.test.js
+++ b/infra/install-redirect/worker.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import worker from "./worker.js";
+
+function collabBinding(calls) {
+	return {
+		fetch(request) {
+			calls.push(request.url);
+			return Promise.resolve(new Response("collab client", { status: 200 }));
+		},
+	};
+}
+
+describe("oh-my-pk product host collab route", () => {
+	it("proxies the collab app root and assets through the collab Worker binding", async () => {
+		const calls = [];
+		const env = { COLLAB: collabBinding(calls) };
+
+		const rootResponse = await worker.fetch(new Request("https://oh-my-pk.pkking.computer/collab/"), env, {});
+		const assetResponse = await worker.fetch(
+			new Request("https://oh-my-pk.pkking.computer/collab/client.js?v=1"),
+			env,
+			{},
+		);
+
+		expect(await rootResponse.text()).toBe("collab client");
+		expect(await assetResponse.text()).toBe("collab client");
+		expect(calls).toEqual([
+			"https://oh-my-pk.pkking.computer/",
+			"https://oh-my-pk.pkking.computer/client.js?v=1",
+		]);
+	});
+
+	it("redirects the slashless collab path so relative client assets stay under /collab/", async () => {
+		const response = await worker.fetch(
+			new Request("https://oh-my-pk.pkking.computer/collab?source=cli"),
+			{ COLLAB: collabBinding([]) },
+			{},
+		);
+
+		expect(response.status).toBe(308);
+		expect(response.headers.get("Location")).toBe("https://oh-my-pk.pkking.computer/collab/?source=cli");
+	});
+
+	it("returns a service error when the collab Worker binding is unavailable", async () => {
+		const response = await worker.fetch(new Request("https://oh-my-pk.pkking.computer/collab/"), {}, {});
+
+		expect(response.status).toBe(503);
+		expect(await response.text()).toBe("Collab client unavailable");
+	});
+});

--- a/infra/install-redirect/wrangler.toml
+++ b/infra/install-redirect/wrangler.toml
@@ -12,6 +12,10 @@ routes = [
 	{ pattern = "oh-my-pi.pkking.computer", custom_domain = true },
 ]
 
+[[services]]
+binding = "COLLAB"
+service = "ompk-collab"
+
 [vars]
 # Private Hugging Face repo that stores the release binaries (free storage + egress).
 HF_REPO = "pkkidking/oh-my-pi-binaries"

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Fixed `fork` parameter being silently dropped in batch task submissions: `taskItemSchema` and `taskItemSchemaIsolated` both had `"+": "delete"` but omitted `"fork?": "boolean"`, so a batch item with `fork: true` was stripped before `spawnParamsFor` could see it, falling back to a fresh context with no error.
-- Fixed OMPK `/collab` browser links to stay on `*.pkking.computer`: persisted legacy `*.omp.sh` web origins now normalize to `collab.pkking.computer`, and non-local hosted overrides outside the owned domain are rejected.
+- Fixed OMPK `/collab` browser links to open the product-hosted client at `oh-my-pk.pkking.computer/collab/`: persisted legacy `*.omp.sh` and previous `collab.pkking.computer` web origins now normalize there, while non-local hosted overrides outside the owned domain remain rejected.
 
 ### Added
 - Added opt-in `tools.xdev` virtual tool devices (`xd://`) for progressive MCP/custom/extension tool docs and execution, leaving essential builtins and BM25 discovery unchanged.

--- a/packages/coding-agent/scripts/generate-share-viewer.ts
+++ b/packages/coding-agent/scripts/generate-share-viewer.ts
@@ -32,7 +32,7 @@ if (!outPath) {
 
 const loaderJs = await Bun.file(new URL("../src/export/html/share-loader.js", import.meta.url)).text();
 // Pin the omp brand palette (collab-web pink/purple identity) — the viewer is
-// a public artifact matching the live collab.pkking.computer client, not a per-user export
+// a public artifact matching the live oh-my-pk.pkking.computer/collab/ client, not a per-user export
 // that should mirror the host's terminal theme.
 const themeVars = await generateThemeVars("web");
 

--- a/packages/coding-agent/src/collab/protocol.ts
+++ b/packages/coding-agent/src/collab/protocol.ts
@@ -136,7 +136,9 @@ const B64URL_RE = /^[A-Za-z0-9_-]+$/;
 const LOCAL_HOSTNAMES: Record<string, true> = { localhost: true, "127.0.0.1": true, "::1": true, "[::1]": true };
 const PKKING_WEB_HOST_RE = /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+pkking\.computer$/i;
 const LEGACY_UPSTREAM_WEB_HOST_RE = /^(?:[a-z0-9-]+\.)*omp\.sh$/i;
-const DEFAULT_COLLAB_WEB_ORIGIN = DEFAULT_RELAY_URL.replace(/^wss:/, "https:");
+const LEGACY_OMPK_WEB_HOST = "collab.pkking.computer";
+const OMPK_PRODUCT_WEB_ORIGIN = "https://oh-my-pk.pkking.computer";
+const DEFAULT_COLLAB_WEB_BASE_URL = `${OMPK_PRODUCT_WEB_ORIGIN}/collab`;
 
 function isLocalHostname(hostname: string): boolean {
 	return LOCAL_HOSTNAMES[hostname] === true;
@@ -209,6 +211,7 @@ function normalizeCollabWebBaseUrl(relayUrl: string, webUrl?: string): string {
 	if (!explicitWebUrl) {
 		const normalized = normalizeRelayOrigin(relayUrl);
 		if ("error" in normalized) throw new Error(normalized.error);
+		if (normalized.origin === DEFAULT_RELAY_URL) return DEFAULT_COLLAB_WEB_BASE_URL;
 		return normalized.origin.startsWith("wss://")
 			? `https://${normalized.origin.slice("wss://".length)}`
 			: `http://${normalized.origin.slice("ws://".length)}`;
@@ -224,8 +227,11 @@ function normalizeCollabWebBaseUrl(relayUrl: string, webUrl?: string): string {
 		throw new Error("collab.webUrl must start with http:// or https://");
 	}
 	// OMPK and upstream Oh My Pi are independent products. Migrate every
-	// persisted upstream origin before applying current hosted-URL policy.
-	if (LEGACY_UPSTREAM_WEB_HOST_RE.test(url.hostname)) return DEFAULT_COLLAB_WEB_ORIGIN;
+	// persisted upstream origin and the previous fork web host before applying
+	// current hosted-URL policy.
+	if (LEGACY_UPSTREAM_WEB_HOST_RE.test(url.hostname) || url.hostname === LEGACY_OMPK_WEB_HOST) {
+		return DEFAULT_COLLAB_WEB_BASE_URL;
+	}
 	if (url.protocol === "http:" && !isLocalHostname(url.hostname)) {
 		throw new Error("collab.webUrl must use https:// unless it targets localhost");
 	}
@@ -234,6 +240,9 @@ function normalizeCollabWebBaseUrl(relayUrl: string, webUrl?: string): string {
 	}
 	if (!isLocalHostname(url.hostname) && !PKKING_WEB_HOST_RE.test(url.hostname)) {
 		throw new Error("collab.webUrl host must match <subdomain>.pkking.computer (or localhost for development)");
+	}
+	if (url.origin === OMPK_PRODUCT_WEB_ORIGIN && /^\/*$/.test(url.pathname)) {
+		return DEFAULT_COLLAB_WEB_BASE_URL;
 	}
 	const path = url.pathname.replace(/\/+$/, "");
 	return `${url.origin}${path}`;

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1887,7 +1887,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Collab",
 			label: "Web UI URL",
 			description:
-				"Browser UI used by /collab links; empty derives from collab.relayUrl; hosted overrides must match https://<subdomain>.pkking.computer (localhost HTTP is development-only)",
+				"Browser UI used by /collab links; empty uses oh-my-pk.pkking.computer/collab for the owned relay and derives from custom relays; hosted overrides must match https://<subdomain>.pkking.computer (localhost HTTP is development-only)",
 		},
 	},
 

--- a/packages/coding-agent/src/export/html/index.ts
+++ b/packages/coding-agent/src/export/html/index.ts
@@ -41,7 +41,7 @@ export interface ExportOptions {
 	 * Which color palette the export ships with.
 	 * - `"web"` (default) — the omp brand identity (collab-web pink/purple),
 	 *   so public HTML exports and the `/s/<id>` share viewer match the owned
-	 *   `collab.pkking.computer` client. See `web-palette.ts`.
+	 *   `oh-my-pk.pkking.computer/collab/` client. See `web-palette.ts`.
 	 * - `"theme"` — derive from `themeName` (or the active TUI theme), preserving
 	 *   the pre-15.12 behavior where an export mirrored the user's terminal.
 	 */
@@ -122,7 +122,7 @@ function deriveExportColors(baseColor: string): { pageBg: string; cardBg: string
  *   • `generateThemeVars("web" | "theme", themeName?)` — explicit palette.
  *     `"web"` (the default for public artifacts) returns the fixed omp brand
  *     palette from `web-palette.ts` — collab-web pink/purple identity, shared
- *     with the live `collab.pkking.computer` client, so exports and the share viewer render
+ *     with the live `oh-my-pk.pkking.computer/collab/` client, so exports and the share viewer render
  *     identically to it. `"theme"` derives from the TUI theme via
  *     `getResolvedThemeColors(themeName)` plus the three
  *     `export.{pageBg,cardBg,infoBg}` surface overrides.

--- a/packages/coding-agent/src/export/html/web-palette.ts
+++ b/packages/coding-agent/src/export/html/web-palette.ts
@@ -1,6 +1,6 @@
 /**
  * Web/export palette — the omp brand identity shared by the collab-web live
- * client (`collab.pkking.computer/`) and every public HTML export / share viewer (`/s/<id>`).
+ * client (`oh-my-pk.pkking.computer/collab/`) and every public HTML export / share viewer (`/s/<id>`).
  *
  * Why this exists separately from `modes/theme/dark.json`: the `dark` theme is
  * the **default TUI theme** — its amber accent (`#febc38`) drives the terminal

--- a/packages/coding-agent/test/collab/crypto.test.ts
+++ b/packages/coding-agent/test/collab/crypto.test.ts
@@ -164,8 +164,10 @@ describe("collab link format", () => {
 		expect(parsed.wsUrl).toBe(`wss://relay.example.com/r/${roomId}`);
 	});
 
-	it("parses the scheme-less display form of web deep links", () => {
-		const parsed = parseCollabLink(`collab.pkking.computer/#${formatCollabLink(DEFAULT_RELAY_URL, roomId, key)}`);
+	it("parses the scheme-less display form of product-hosted web deep links", () => {
+		const parsed = parseCollabLink(
+			`oh-my-pk.pkking.computer/collab/#${formatCollabLink(DEFAULT_RELAY_URL, roomId, key)}`,
+		);
 		if ("error" in parsed) throw new Error(parsed.error);
 		expect(parsed.wsUrl).toBe(`${DEFAULT_RELAY_URL}/r/${roomId}`);
 		expect(Buffer.from(parsed.key)).toEqual(Buffer.from(key));
@@ -200,8 +202,8 @@ describe("collab link format", () => {
 	it("keeps the key out of web-link path and query", () => {
 		const webLink = formatCollabWebLink(DEFAULT_RELAY_URL, roomId, key);
 		const url = new URL(webLink);
-		expect(url.origin).toBe("https://collab.pkking.computer");
-		expect(url.pathname).toBe("/");
+		expect(url.origin).toBe("https://oh-my-pk.pkking.computer");
+		expect(url.pathname).toBe("/collab/");
 		expect(url.search).toBe("");
 		expect(url.hash).toBe(`#${roomId}.${Buffer.from(key).toString("base64url")}`);
 	});
@@ -209,6 +211,15 @@ describe("collab link format", () => {
 	it("normalizes explicit web UI roots, paths, trailing slashes, and ports", () => {
 		const rootLink = formatCollabWebLink(DEFAULT_RELAY_URL, roomId, key, undefined, " https://web.pkking.computer/ ");
 		expect(rootLink.startsWith("https://web.pkking.computer/#")).toBe(true);
+
+		const productRootLink = formatCollabWebLink(
+			DEFAULT_RELAY_URL,
+			roomId,
+			key,
+			undefined,
+			"https://oh-my-pk.pkking.computer/",
+		);
+		expect(productRootLink.startsWith("https://oh-my-pk.pkking.computer/collab/#")).toBe(true);
 
 		const pathLink = formatCollabWebLink(
 			DEFAULT_RELAY_URL,
@@ -229,9 +240,9 @@ describe("collab link format", () => {
 		expect(localHttpLink.startsWith("http://localhost:5173/app/#")).toBe(true);
 	});
 
-	it("replaces persisted upstream web origins with the OMPK-owned collab origin", () => {
+	it("replaces persisted upstream web origins with the OMPK product collab URL", () => {
 		const webLink = formatCollabWebLink(DEFAULT_RELAY_URL, roomId, key, undefined, "https://my.omp.sh/");
-		expect(webLink.startsWith("https://collab.pkking.computer/#")).toBe(true);
+		expect(webLink.startsWith("https://oh-my-pk.pkking.computer/collab/#")).toBe(true);
 		expect(webLink).not.toContain("omp.sh");
 	});
 
@@ -243,8 +254,13 @@ describe("collab link format", () => {
 			undefined,
 			"http://legacy.omp.sh/stale?theme=dark#old",
 		);
-		expect(webLink.startsWith("https://collab.pkking.computer/#")).toBe(true);
+		expect(webLink.startsWith("https://oh-my-pk.pkking.computer/collab/#")).toBe(true);
 		expect(webLink).not.toContain("omp.sh");
+	});
+
+	it("migrates the previous fork collab web host to the product host", () => {
+		const webLink = formatCollabWebLink(DEFAULT_RELAY_URL, roomId, key, undefined, "https://collab.pkking.computer/");
+		expect(webLink.startsWith("https://oh-my-pk.pkking.computer/collab/#")).toBe(true);
 	});
 
 	it("rejects hosted web origins outside the pkking.computer domain", () => {

--- a/packages/coding-agent/test/slash-commands/collab-qrcode.test.ts
+++ b/packages/coding-agent/test/slash-commands/collab-qrcode.test.ts
@@ -31,8 +31,8 @@ function fakeHost(options?: {
 	return {
 		link: "relay.example.com/r/full-control",
 		viewLink: "relay.example.com/r/read-only",
-		webLink: options?.webLink ?? "https://collab.pkking.computer/#full-control",
-		webViewLink: options?.webViewLink ?? "https://collab.pkking.computer/#read-only",
+		webLink: options?.webLink ?? "https://oh-my-pk.pkking.computer/collab/#full-control",
+		webViewLink: options?.webViewLink ?? "https://oh-my-pk.pkking.computer/collab/#read-only",
 		participants: [{ name: "host", role: "host" }],
 	} as unknown as NonNullable<InteractiveModeContext["collabHost"]>;
 }
@@ -70,8 +70,8 @@ function mockStartedHostLinks() {
 		Object.defineProperties(this, {
 			link: { value: "relay.example.com/r/full-control", configurable: true },
 			viewLink: { value: "relay.example.com/r/read-only", configurable: true },
-			webLink: { value: "https://collab.pkking.computer/#started-full", configurable: true },
-			webViewLink: { value: "https://collab.pkking.computer/#started-view", configurable: true },
+			webLink: { value: "https://oh-my-pk.pkking.computer/collab/#started-full", configurable: true },
+			webViewLink: { value: "https://oh-my-pk.pkking.computer/collab/#started-view", configurable: true },
 			participants: { value: [{ name: "host", role: "host" as const }], configurable: true },
 		});
 		return Promise.resolve();
@@ -90,12 +90,12 @@ describe("/collab slash command QR code rendering", () => {
 		expect(startSpy).toHaveBeenCalledWith("wss://relay.example.com", "");
 		expect(harness.ctx.collabHost).toBeInstanceOf(CollabHost);
 		const statusText = harness.showStatus.mock.calls[0]?.[0] as string;
-		expect(statusText).toContain("collab.pkking.computer/#started-full");
+		expect(statusText).toContain("oh-my-pk.pkking.computer/collab/#started-full");
 		const presented = harness.present.mock.calls[0]?.[0] as readonly unknown[];
 		expect(presented[0]).toBeInstanceOf(Spacer);
 		expect(presented[1]).toBeInstanceOf(CollabQrCodeComponent);
 		const component = presented[1] as CollabQrCodeComponent;
-		expect(component.url).toBe("https://collab.pkking.computer/#started-full");
+		expect(component.url).toBe("https://oh-my-pk.pkking.computer/collab/#started-full");
 		expect(component.render(120).join("\n")).toMatch(/\x1b\[(?:47|40)m/);
 	});
 
@@ -109,13 +109,13 @@ describe("/collab slash command QR code rendering", () => {
 		expect(startSpy).toHaveBeenCalledWith("wss://relay.example.com", "");
 		expect(harness.ctx.collabHost).toBeInstanceOf(CollabHost);
 		const statusText = harness.showStatus.mock.calls[0]?.[0] as string;
-		expect(statusText).toContain("collab.pkking.computer/#started-view");
-		expect(statusText).not.toContain("collab.pkking.computer/#started-full");
+		expect(statusText).toContain("oh-my-pk.pkking.computer/collab/#started-view");
+		expect(statusText).not.toContain("oh-my-pk.pkking.computer/collab/#started-full");
 		const presented = harness.present.mock.calls[0]?.[0] as readonly unknown[];
 		expect(presented[0]).toBeInstanceOf(Spacer);
 		expect(presented[1]).toBeInstanceOf(CollabQrCodeComponent);
 		const component = presented[1] as CollabQrCodeComponent;
-		expect(component.url).toBe("https://collab.pkking.computer/#started-view");
+		expect(component.url).toBe("https://oh-my-pk.pkking.computer/collab/#started-view");
 	});
 
 	it("prints the active full-control browser QR when hosting", async () => {
@@ -125,7 +125,7 @@ describe("/collab slash command QR code rendering", () => {
 
 		expect(handled).toBe(true);
 		const statusText = harness.showStatus.mock.calls[0]?.[0] as string;
-		expect(statusText).toContain("collab.pkking.computer/#full-control");
+		expect(statusText).toContain("oh-my-pk.pkking.computer/collab/#full-control");
 		const presented = harness.present.mock.calls[0]?.[0] as readonly unknown[];
 		expect(presented[0]).toBeInstanceOf(Spacer);
 		expect(presented[1]).toBeInstanceOf(CollabQrCodeComponent);
@@ -134,8 +134,8 @@ describe("/collab slash command QR code rendering", () => {
 	});
 
 	it("prints a one-shot read-only browser QR when hosting", async () => {
-		const webLink = "https://collab.pkking.computer/#full-control";
-		const webViewLink = "https://collab.pkking.computer/#read-only";
+		const webLink = "https://oh-my-pk.pkking.computer/collab/#full-control";
+		const webViewLink = "https://oh-my-pk.pkking.computer/collab/#read-only";
 		const harness = createRuntimeHarness({ collabHost: fakeHost({ webLink, webViewLink }) });
 
 		const handled = await executeBuiltinSlashCommand("/collab view", harness.runtime);

--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added a host-session picker to the browser guest: the header gains a sessions button (writable links only) that lists the host's project/all sessions over the wire `list-sessions`/`load-session` protocol and asks the host TUI to resume one, after which every guest resyncs from the host's fresh welcome. Requests are correlated by `reqId` with timeout, disconnect, host-error, and read-only handling. The mock host now answers both frames so the flow is exercisable offline.
 
 ### Changed
-- Updated deployment metadata and default collaboration links for the owned `collab.pkking.computer` service.
+- Updated deployment metadata and default collaboration links for the product-hosted `oh-my-pk.pkking.computer/collab/` client while retaining `collab.pkking.computer` as the relay service.
 
 - Redesigned the browser collaboration client as a focused coding workspace with a persistent desktop agent sidebar, responsive mobile navigation, a floating composer, and a clearer session join experience inspired by T3 Code.
 

--- a/packages/collab-web/README.md
+++ b/packages/collab-web/README.md
@@ -20,7 +20,7 @@ Host a session from any omp instance (`/collab`, or `/collab ws://localhost:7466
 bun run build   # static site in dist/
 ```
 
-`dist/` is a fully static SPA — host it anywhere. JS/CSS bundles are content-hashed; favicons, `manifest.webmanifest`, `robots.txt`, `sitemap.xml`, and `og-image.png` are emitted at the site root under stable names (canonical URL: `https://collab.pkking.computer/`). Two runtime requirements:
+`dist/` is a fully static SPA — host it anywhere. JS/CSS bundles are content-hashed; favicons, `manifest.webmanifest`, `robots.txt`, `sitemap.xml`, and `og-image.png` are emitted at the site root under stable names (canonical URL: `https://oh-my-pk.pkking.computer/collab/`). Two runtime requirements:
 
 - **Secure context**: room keys are unwrapped with WebCrypto (`crypto.subtle`), which browsers expose only on `https://` or `localhost`.
 - **Relay reachability**: the client connects straight to the relay over WebSocket (`wss://` for anything that isn't localhost). The default owned relay is `wss://collab.pkking.computer`; bare `<roomId>.<key>` links resolve against it (legacy `<roomId>#<key>` and `%23`-mangled links still parse).

--- a/packages/collab-web/index.html
+++ b/packages/collab-web/index.html
@@ -13,7 +13,7 @@
 			content="Guest client for oh-my-pk collab sessions: watch a live coding-agent session — streaming transcript, tool calls, subagents — and prompt the host agent from any browser. End-to-end encrypted; the room key never leaves the URL fragment."
 		/>
 		<meta name="author" content="oh-my-pk" />
-		<link rel="canonical" href="https://collab.pkking.computer/" />
+		<link rel="canonical" href="https://oh-my-pk.pkking.computer/collab/" />
 		<meta name="robots" content="index, follow, max-image-preview:large" />
 
 		<link rel="icon" type="image/svg+xml" href="./public/favicon.svg" />
@@ -27,13 +27,13 @@
 		<!-- Open Graph -->
 		<meta property="og:site_name" content="oh-my-pk" />
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://collab.pkking.computer/" />
+		<meta property="og:url" content="https://oh-my-pk.pkking.computer/collab/" />
 		<meta property="og:title" content="oh-my-pk collab — live agent session in your browser" />
 		<meta
 			property="og:description"
 			content="Watch a live omp session and prompt the host agent from any browser. End-to-end encrypted; the key stays in the URL fragment."
 		/>
-		<meta property="og:image" content="https://collab.pkking.computer/og-image.png" />
+		<meta property="og:image" content="https://oh-my-pk.pkking.computer/collab/og-image.png" />
 		<meta property="og:image:type" content="image/png" />
 		<meta property="og:image:width" content="1200" />
 		<meta property="og:image:height" content="630" />
@@ -42,13 +42,13 @@
 
 		<!-- Twitter / X -->
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:url" content="https://collab.pkking.computer/" />
+		<meta name="twitter:url" content="https://oh-my-pk.pkking.computer/collab/" />
 		<meta name="twitter:title" content="oh-my-pk collab — live agent session in your browser" />
 		<meta
 			name="twitter:description"
 			content="Watch a live omp session and prompt the host agent from any browser. End-to-end encrypted; the key stays in the URL fragment."
 		/>
-		<meta name="twitter:image" content="https://collab.pkking.computer/og-image.png" />
+		<meta name="twitter:image" content="https://oh-my-pk.pkking.computer/collab/og-image.png" />
 		<meta name="twitter:image:alt" content="oh-my-pk collab — your agent, live in any browser" />
 
 		<!-- Structured data: WebApplication -->
@@ -57,7 +57,7 @@
 				"@context": "https://schema.org",
 				"@type": "WebApplication",
 				"name": "oh-my-pk collab",
-				"url": "https://collab.pkking.computer/",
+				"url": "https://oh-my-pk.pkking.computer/collab/",
 				"applicationCategory": "DeveloperApplication",
 				"operatingSystem": "Any",
 				"description": "Browser guest client for oh-my-pk collab live sessions: streaming transcript, tool calls, subagent panel, and a composer that prompts the host agent. End-to-end encrypted.",

--- a/packages/collab-web/package.json
+++ b/packages/collab-web/package.json
@@ -4,7 +4,7 @@
   "version": "15.11.7",
   "private": true,
   "description": "Browser guest client and local relay tools for OMP collaboration",
-  "homepage": "https://collab.pkking.computer",
+  "homepage": "https://oh-my-pk.pkking.computer/collab/",
   "author": "Can Boluk",
   "license": "MIT",
   "repository": {

--- a/packages/collab-web/public/manifest.webmanifest
+++ b/packages/collab-web/public/manifest.webmanifest
@@ -2,15 +2,15 @@
 	"name": "omp collab",
 	"short_name": "omp collab",
 	"description": "Live guest client for omp collab sessions: streaming transcript, tool cards, subagent panel, and a composer that prompts the host agent — end-to-end encrypted.",
-	"start_url": "/",
-	"scope": "/",
+	"start_url": "./",
+	"scope": "./",
 	"display": "standalone",
 	"background_color": "#0f0b14",
 	"theme_color": "#0f0b14",
 	"icons": [
-		{ "src": "/favicon.svg", "type": "image/svg+xml", "sizes": "any", "purpose": "any" },
-		{ "src": "/favicon-192x192.png", "type": "image/png", "sizes": "192x192", "purpose": "any" },
-		{ "src": "/favicon-512x512.png", "type": "image/png", "sizes": "512x512", "purpose": "any" },
-		{ "src": "/favicon-180x180.png", "type": "image/png", "sizes": "180x180", "purpose": "any" }
+		{ "src": "./favicon.svg", "type": "image/svg+xml", "sizes": "any", "purpose": "any" },
+		{ "src": "./favicon-192x192.png", "type": "image/png", "sizes": "192x192", "purpose": "any" },
+		{ "src": "./favicon-512x512.png", "type": "image/png", "sizes": "512x512", "purpose": "any" },
+		{ "src": "./favicon-180x180.png", "type": "image/png", "sizes": "180x180", "purpose": "any" }
 	]
 }

--- a/packages/collab-web/public/robots.txt
+++ b/packages/collab-web/public/robots.txt
@@ -2,4 +2,4 @@ User-agent: *
 Allow: /
 Disallow: /r/
 
-Sitemap: https://collab.pkking.computer/sitemap.xml
+Sitemap: https://oh-my-pk.pkking.computer/collab/sitemap.xml

--- a/packages/collab-web/public/sitemap.xml
+++ b/packages/collab-web/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 	<url>
-		<loc>https://collab.pkking.computer/</loc>
+		<loc>https://oh-my-pk.pkking.computer/collab/</loc>
 		<changefreq>monthly</changefreq>
 		<priority>1.0</priority>
 	</url>


### PR DESCRIPTION
## Summary

Browser collaboration links now open under the product hostname at `https://oh-my-pk.pkking.computer/collab/#…` instead of presenting the relay hostname as the user-facing application. WebSocket relay, encrypted share storage, and hub APIs remain isolated on `collab.pkking.computer`.

The product-host Worker proxies `/collab/*` through a Cloudflare service binding to the existing `ompk-collab` Worker. A slashless `/collab` request redirects to `/collab/` so relative SPA assets resolve correctly, while the web manifest remains deployment-relative for direct relay and custom-host compatibility.

Persisted upstream `*.omp.sh` and previous `collab.pkking.computer` browser origins migrate to the product-hosted client. Custom relay derivation, owned HTTPS overrides, localhost development, and fragment-only room secrets remain supported.

## Test plan

- `bun test test/collab/crypto.test.ts test/slash-commands/collab-qrcode.test.ts` — 37 passed
- `bun test worker.test.js` — 3 passed
- `bun test test/link.test.ts` — 18 passed
- `bun test` in `packages/collab-relay` — 38 passed
- `bun run check:ts`
- `bun run build` in `packages/collab-relay`
- `bunx wrangler deploy --dry-run` in `infra/install-redirect`
- `git diff --check`

The full root `bun run check` still reaches pre-existing Windows Rust/clippy failures unrelated to this TypeScript, web, and Worker change.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5.6_SOL-000000)
