### PR TITLE
feat(gopk-clips): single-writer Activity Memory + read-only `activity` tool

### DIFF
--- a/packages/activity-journal/CHANGELOG.md
+++ b/packages/activity-journal/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `ActivityLedgerReader` and `SqliteActivityLedgerReader`: a query-only view over a ledger owned by another process. It opens the sqlite handle read-only and deliberately skips the `CREATE TABLE IF NOT EXISTS` bootstrap that `SqliteActivityLedger` runs, since that DDL takes a write lock and would contend with the live writer on every open. Adds `listOverlapping(startedAt, endedAt)` for windowed queries.
+
 ## [16.3.0] - 2026-07-23
 
 ### Added

--- a/packages/activity-journal/src/ledger.ts
+++ b/packages/activity-journal/src/ledger.ts
@@ -9,6 +9,18 @@ export interface ActivityLedger {
 	close(): void;
 }
 
+/**
+ * The query-only half of {@link ActivityLedger}. Consumers that only read —
+ * recall, reporting, in-session activity lookup — should depend on this and
+ * open via {@link SqliteActivityLedgerReader}, never on the read-write class.
+ */
+export interface ActivityLedgerReader {
+	list(): readonly ActivityEvidence[];
+	/** Evidence whose window overlaps `[startedAt, endedAt)`; both ISO-8601. */
+	listOverlapping(startedAt: string, endedAt: string): readonly ActivityEvidence[];
+	close(): void;
+}
+
 interface LedgerRow {
 	readonly id: string;
 	readonly payload: string;
@@ -99,6 +111,53 @@ export class SqliteActivityLedger implements ActivityLedger {
 			[JSON.stringify(updated), deletedAt, evidenceId],
 		);
 		return result.changes === 1;
+	}
+
+	close(): void {
+		this.#db.close();
+	}
+}
+
+/**
+ * Read-only view of a ledger someone else owns.
+ *
+ * Deliberately does NOT run the `CREATE TABLE IF NOT EXISTS` bootstrap that
+ * {@link SqliteActivityLedger} does: DDL takes a write lock, so a reader that
+ * bootstraps would contend with the live writer on every open. The sqlite
+ * handle itself is opened read-only, which makes that a structural guarantee
+ * rather than a convention — any stray write throws instead of racing.
+ *
+ * Requires the database to already exist; opening a missing file throws, since
+ * "the ledger has not been created yet" is a caller-visible state, not
+ * something a reader should paper over by creating an empty database.
+ */
+export class SqliteActivityLedgerReader implements ActivityLedgerReader {
+	#db: Database;
+
+	constructor(path: string) {
+		this.#db = new Database(path, { readonly: true, strict: true });
+	}
+
+	list(): readonly ActivityEvidence[] {
+		return this.#db
+			.query<LedgerRow, []>("SELECT id, payload FROM activity_evidence ORDER BY started_at, id")
+			.all()
+			.map(row => parseEvidence(row));
+	}
+
+	listOverlapping(startedAt: string, endedAt: string): readonly ActivityEvidence[] {
+		// Half-open overlap: the row starts before the window ends and ends
+		// after it begins. Both columns hold `Date#toISOString()` output, whose
+		// fixed-width UTC form sorts lexicographically in chronological order,
+		// so string comparison is a correct range test here.
+		return this.#db
+			.query<LedgerRow, [string, string]>(
+				`SELECT id, payload FROM activity_evidence
+				 WHERE started_at < ? AND ended_at > ?
+				 ORDER BY started_at, id`,
+			)
+			.all(endedAt, startedAt)
+			.map(row => parseEvidence(row));
 	}
 
 	close(): void {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the `activity` discoverable tool, gated by `gopkClips.enabled` (default off), which answers "what was I working on this morning?" by reading the local Activity Memory ledger: tracked time, application mix, and sanitized window-title digests bucketed by local hour, for a calendar day (`date`) or a trailing window (`lastHours`). Read-only and local-only — it never records anything itself.
+- Added `SqliteActivityLedgerReader` to `@pk-nerdsaver-ai/pi-activity-journal`: a read-only ledger view that opens the sqlite handle read-only and skips the `CREATE TABLE` bootstrap, so readers cannot take a write lock or contend with the live ingest daemon. Recall and the `activity` tool both use it.
+
+### Changed
+
+- Activity Memory ingestion is now owned exclusively by the always-on `gopk-ingest` daemon. `AgentSession` no longer starts a second ingest host when `gopkClips.enabled` is on: two consumers raced to delete the same journal-handoff files and contended for the ledger's write lock, which could split clips across ledgers. `gopkClips.enabled` now gates in-session *reading* only.
+- Unified gopk-clips path resolution behind a single resolver (explicit override, then the shared `config.json`, then the agent dir), with `~` expansion and absolute resolution applied to both the capture root and the ledger path. Previously the daemon's `ingest.pid` lock could land in a cwd-relative `./~/` directory while its host resolved elsewhere.
+
+### Fixed
+
+- Fixed hour-over-hour activity recall on days that are not 24 hours long: the day window is now derived from local midnight to the next local midnight, so DST transition days correctly span 23 or 25 hours instead of being truncated or overrun.
+- Fixed activity recall bucketing in half-hour-offset timezones (IST, NPT): buckets now start on real local hour marks rather than UTC hour boundaries labelled with the local hour, and are keyed by absolute instant so the repeated hour on a fall-back day stays two distinct buckets.
+
+### Removed
+
+- Removed the `gopkClips.captureRoot`, `gopkClips.pollIntervalMs`, and `gopkClips.cleanupIntervalMs` settings. They configured the in-session ingest host, which no longer exists; the `gopk-ingest` daemon takes its paths from its own `config.json` and hardcodes its intervals, so these could not affect anything. Stale entries in an existing `settings.json` are ignored rather than rejected.
+
 ## [16.3.0] - 2026-07-23
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Removed
 
-- Removed the `gopkClips.captureRoot`, `gopkClips.pollIntervalMs`, and `gopkClips.cleanupIntervalMs` settings. They configured the in-session ingest host, which no longer exists; the `gopk-ingest` daemon takes its paths from its own `config.json` and hardcodes its intervals, so these could not affect anything. Stale entries in an existing `settings.json` are ignored rather than rejected.
+- Removed the `gopkClips.captureRoot`, `gopkClips.pollIntervalMs`, and `gopkClips.cleanupIntervalMs` settings. They configured the in-session ingest host, which no longer exists; the `gopk-ingest` daemon takes its paths from its own `config.json` and hardcodes its intervals, so these could not affect anything. Stale entries left behind in an existing config (`~/.ompk/agent/config.yml`, or a project `.ompk/settings.json`) are ignored rather than rejected, since settings are read by schema path and unknown keys are never validated.
 
 ## [16.3.0] - 2026-07-23
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4595,53 +4595,23 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
-	// Gopk-clips activity handoff — local-only, opt-in. Polls the capture
-	// daemon's journal-handoff drop directory for sanitized activity
-	// derivatives and ingests them into the local activity ledger, running the
-	// raw-clip retention purge on an interval. Nothing leaves the machine;
-	// requires the user to run the gopk-clips Context Mode daemon themselves.
+	// Activity Memory — local-only, opt-in, READ-ONLY from this agent's side.
+	// Recording and ingestion belong entirely to the separate always-on
+	// Activity Memory app and its `gopk-ingest` daemon, which is the sole
+	// writer of the local ledger. This setting gates the `activity` tool, which
+	// only queries that ledger. Capture root, poll interval, and retention
+	// interval are the daemon's own configuration and are deliberately not
+	// settings here — it reads them from its config.json, so exposing them
+	// would have been a knob that changed nothing.
 	"gopkClips.enabled": {
 		type: "boolean",
 		default: false,
 		ui: {
 			tab: "memory",
 			group: "Activity Memory",
-			label: "Remember what I work on",
+			label: "Let me look up what you were working on",
 			description:
-				"Let this agent read your recent activity (which apps/windows, titles only) from the local Activity Memory timeline during sessions. The timeline is recorded by the always-on Activity Memory app; this only controls in-session recall. Local-only.",
-		},
-	},
-	// No default on purpose: unset means <agentDir>/gopk-clips/capture, which
-	// tracks PI_CONFIG_DIR/profile overrides instead of hardcoding a home path.
-	"gopkClips.captureRoot": {
-		type: "string",
-		default: undefined,
-		ui: {
-			tab: "memory",
-			group: "Activity Memory",
-			label: "Capture Root",
-			description:
-				"gopk-clips capture root (default: <agent dir>/gopk-clips/capture); the handoff drop lives at <root>/journal-handoff and derivative pointers must resolve under it",
-		},
-	},
-	"gopkClips.pollIntervalMs": {
-		type: "number",
-		default: 15_000,
-		ui: {
-			tab: "memory",
-			group: "Activity Memory",
-			label: "Poll Interval (ms)",
-			description: "Delay between handoff-directory polls",
-		},
-	},
-	"gopkClips.cleanupIntervalMs": {
-		type: "number",
-		default: 600_000,
-		ui: {
-			tab: "memory",
-			group: "Activity Memory",
-			label: "Retention Interval (ms)",
-			description: "Delay between raw-clip retention purge passes",
+				'Give this agent the `activity` tool, so it can answer questions like "what was I working on this morning?" by reading the local Activity Memory timeline (which apps and window titles had focus, and for how long — no screenshots or page contents). Recording is done by the separate always-on Activity Memory app; this only controls whether the agent may read it. Local-only.',
 		},
 	},
 

--- a/packages/coding-agent/src/gopk-clips/daemon.ts
+++ b/packages/coding-agent/src/gopk-clips/daemon.ts
@@ -23,49 +23,15 @@
  *   --once  run a single poll+cleanup pass and exit (smoke test)
  */
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
-// Subpath imports keep the compiled gopk-ingest.exe free of the pi_natives
+// Subpath import keeps the compiled gopk-ingest.exe free of the pi_natives
 // native addon (which the pi-utils barrel eagerly loads). See session-state.ts.
-import { getAgentDir } from "@pk-nerdsaver-ai/pi-utils/dirs";
 import * as logger from "@pk-nerdsaver-ai/pi-utils/logger";
+import { resolveGopkClipsPaths } from "./paths";
 import { createGopkClipsHost, type GopkClipsHostState } from "./session-state";
 
 const POLL_INTERVAL_MS = 15_000;
 const CLEANUP_INTERVAL_MS = 600_000;
-
-/** Well-known config.json shared with the gopk-clips capture side. */
-function sharedConfigPath(): string {
-	if (process.platform === "win32") {
-		const base = process.env.LOCALAPPDATA || path.join(os.homedir(), "AppData", "Local");
-		return path.join(base, "gopk-clips", "config.json");
-	}
-	const base = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
-	return path.join(base, "gopk-clips", "config.json");
-}
-
-interface ResolvedPaths {
-	captureRoot: string;
-	ledgerPath: string;
-}
-
-/** Prefer setup's config.json; else the same defaults createGopkClipsHost uses. */
-function resolvePaths(): ResolvedPaths {
-	const agentRoot = path.join(getAgentDir(), "gopk-clips");
-	const fallback: ResolvedPaths = {
-		captureRoot: path.join(agentRoot, "capture"),
-		ledgerPath: path.join(agentRoot, "activity-ledger.sqlite"),
-	};
-	try {
-		const parsed = JSON.parse(fs.readFileSync(sharedConfigPath(), "utf8")) as Partial<ResolvedPaths>;
-		return {
-			captureRoot: parsed.captureRoot || fallback.captureRoot,
-			ledgerPath: parsed.ledgerPath || fallback.ledgerPath,
-		};
-	} catch {
-		return fallback;
-	}
-}
 
 function pidFilePath(captureRoot: string): string {
 	return path.join(captureRoot, "ingest.pid");
@@ -112,7 +78,9 @@ async function main(): Promise<void> {
 	const argv = process.argv.slice(2);
 	const stop = argv.includes("--stop");
 	const once = argv.includes("--once");
-	const { captureRoot, ledgerPath } = resolvePaths();
+	// Absolute and `~`-expanded, so the pid lock below can never land somewhere
+	// other than the capture root the host itself resolves.
+	const { captureRoot, ledgerPath } = resolveGopkClipsPaths();
 	fs.mkdirSync(captureRoot, { recursive: true });
 	const pidPath = pidFilePath(captureRoot);
 
@@ -137,7 +105,12 @@ async function main(): Promise<void> {
 
 	let host: GopkClipsHostState;
 	try {
-		host = createGopkClipsHost({ captureRoot, ledgerPath, pollIntervalMs: POLL_INTERVAL_MS, cleanupIntervalMs: CLEANUP_INTERVAL_MS });
+		host = createGopkClipsHost({
+			captureRoot,
+			ledgerPath,
+			pollIntervalMs: POLL_INTERVAL_MS,
+			cleanupIntervalMs: CLEANUP_INTERVAL_MS,
+		});
 	} catch (error) {
 		logger.warn("ingest daemon: failed to start", { error: String(error) });
 		process.exitCode = 1;

--- a/packages/coding-agent/src/gopk-clips/daemon.ts
+++ b/packages/coding-agent/src/gopk-clips/daemon.ts
@@ -8,15 +8,22 @@
  * `gopkClips.enabled`, the sampler wrote handoffs forever and the ledger — and
  * therefore the report and recall — stayed permanently empty.
  *
- * This daemon runs the exact same host (poll handoffs -> sanitizing ingest ->
- * retention purge) as a standalone, lifecycle-independent process that setup
- * autostarts alongside the sampler. No duplicated ingest/retention logic: it
- * reuses `createGopkClipsHost` wholesale. The agent-session host remains as an
- * optional extra consumer for in-session recall.
+ * This daemon runs that same host (poll handoffs -> sanitizing ingest ->
+ * retention purge) as a standalone, lifecycle-independent process, reusing
+ * `createGopkClipsHost` wholesale rather than duplicating the logic.
+ *
+ * It is now the ONLY ingester. The agent-session host was removed: two
+ * consumers raced to unlink the same handoff files and contended for the
+ * ledger's write lock. Sessions read the ledger (see ./read.ts and the
+ * `activity` tool); they never drain the queue. Do not reintroduce a second
+ * caller of `createGopkClipsHost`.
+ *
+ * Nothing autostarts this yet — that gap is tracked separately. If it is not
+ * running, the sampler keeps writing handoffs and the ledger stops growing.
  *
  * Single instance per ledger via an `ingest.pid` lock next to the capture
  * root; graceful shutdown on SIGINT/SIGTERM. Paths come from the shared
- * gopk-clips config.json when present, else the historical agent-dir default.
+ * gopk-clips config.json when present, else the agent-dir default.
  *
  * Usage: bun packages/coding-agent/src/gopk-clips/daemon.ts [--stop] [--once]
  *   --stop  terminate a running daemon via its pid file

--- a/packages/coding-agent/src/gopk-clips/paths.ts
+++ b/packages/coding-agent/src/gopk-clips/paths.ts
@@ -1,0 +1,78 @@
+/**
+ * Single source of truth for gopk-clips filesystem locations. The in-session
+ * ingest host, the standalone daemon, and the recall CLI all resolve through
+ * here so they can never disagree about which capture root is polled or which
+ * ledger is read and written.
+ *
+ * Precedence per path: an explicit override (a setting or a CLI flag) beats the
+ * shared gopk-clips `config.json` the capture-side setup writes, which beats the
+ * agent-dir default. Every result is `~`-expanded and made absolute, so neither
+ * a tilde-prefixed nor a relative config value can resolve differently depending
+ * on a process's working directory — which is what previously let the daemon's
+ * `ingest.pid` lock and its host's capture root drift apart.
+ *
+ * Subpath import (not the pi-utils barrel): the barrel eagerly loads the
+ * pi_natives native addon, which cannot bundle into the compiled
+ * gopk-ingest.exe. See ./session-state.ts.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getAgentDir } from "@pk-nerdsaver-ai/pi-utils/dirs";
+
+export interface GopkClipsPaths {
+	/** Capture daemon root; the handoff drop is `<captureRoot>/journal-handoff`. */
+	readonly captureRoot: string;
+	/** Local SQLite activity ledger. */
+	readonly ledgerPath: string;
+}
+
+/** Any subset of {@link GopkClipsPaths}; empty strings count as unset. */
+export type GopkClipsPathOverrides = Partial<GopkClipsPaths>;
+
+/** Expand a leading `~` so user-supplied paths behave like shell paths. */
+export function expandHomePath(value: string): string {
+	if (value === "~") return os.homedir();
+	if (value.startsWith("~/") || value.startsWith("~\\")) return path.join(os.homedir(), value.slice(2));
+	return value;
+}
+
+/** Well-known config.json shared with the gopk-clips capture side. */
+export function sharedConfigPath(): string {
+	if (process.platform === "win32") {
+		const base = process.env.LOCALAPPDATA || path.join(os.homedir(), "AppData", "Local");
+		return path.join(base, "gopk-clips", "config.json");
+	}
+	const base = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
+	return path.join(base, "gopk-clips", "config.json");
+}
+
+/** Path overrides from the shared config, or none when it is absent or unreadable. */
+function readSharedConfig(): GopkClipsPathOverrides {
+	try {
+		const parsed = JSON.parse(fs.readFileSync(sharedConfigPath(), "utf8")) as GopkClipsPathOverrides;
+		if (typeof parsed !== "object" || parsed === null) return {};
+		return {
+			...(typeof parsed.captureRoot === "string" ? { captureRoot: parsed.captureRoot } : {}),
+			...(typeof parsed.ledgerPath === "string" ? { ledgerPath: parsed.ledgerPath } : {}),
+		};
+	} catch {
+		return {};
+	}
+}
+
+/**
+ * Resolve both gopk-clips paths to absolute, `~`-expanded form. Extra
+ * properties on `overrides` are ignored, so callers can pass a wider config
+ * object straight through.
+ */
+export function resolveGopkClipsPaths(overrides: GopkClipsPathOverrides = {}): GopkClipsPaths {
+	const shared = readSharedConfig();
+	const agentRoot = path.join(getAgentDir(), "gopk-clips");
+	const captureRoot = overrides.captureRoot || shared.captureRoot || path.join(agentRoot, "capture");
+	const ledgerPath = overrides.ledgerPath || shared.ledgerPath || path.join(agentRoot, "activity-ledger.sqlite");
+	return {
+		captureRoot: path.resolve(expandHomePath(captureRoot)),
+		ledgerPath: path.resolve(expandHomePath(ledgerPath)),
+	};
+}

--- a/packages/coding-agent/src/gopk-clips/read.test.ts
+++ b/packages/coding-agent/src/gopk-clips/read.test.ts
@@ -1,0 +1,221 @@
+// TZ is pinned before any Date work so the DST and local-hour assertions are
+// deterministic rather than dependent on the machine running the suite.
+// America/New_York: 2026-03-08 springs forward (23h day), 2026-11-01 falls
+// back (25h day).
+process.env.TZ = "America/New_York";
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type ActivityEvidence, SqliteActivityLedger } from "@pk-nerdsaver-ai/pi-activity-journal";
+import { floorToLocalHour, localDayWindow, localHourStarts, readActivitySummary, summarizeActivity } from "./read";
+
+const HOUR = 3_600_000;
+
+/** Minimal evidence row; only the fields the summarizer reads are meaningful. */
+function evidence(startedAt: number, endedAt: number, appId: string, digest?: string): ActivityEvidence {
+	return {
+		id: `gopk_clips:${appId}:${startedAt}`,
+		source: "gopk_clips",
+		sourceEventId: `${appId}:${startedAt}`,
+		window: { startedAt: new Date(startedAt).toISOString(), endedAt: new Date(endedAt).toISOString() },
+		recordedAt: new Date(endedAt).toISOString(),
+		application: { id: appId, category: "other" },
+		activityCategory: "unknown",
+		strength: "corroborating",
+		signal: "screen_active",
+		confidence: "medium",
+		confidenceReason: "test",
+		...(digest ? { redactedDigest: digest } : {}),
+		evidenceRefs: [],
+	};
+}
+
+describe("localDayWindow", () => {
+	it("spans 24 hours on an ordinary day", () => {
+		const { startedAt, endedAt } = localDayWindow("2026-07-27");
+		expect((endedAt - startedAt) / HOUR).toBe(24);
+		expect(new Date(startedAt).getHours()).toBe(0);
+	});
+
+	it("spans 23 hours across a spring-forward transition", () => {
+		const { startedAt, endedAt } = localDayWindow("2026-03-08");
+		expect((endedAt - startedAt) / HOUR).toBe(23);
+	});
+
+	it("spans 25 hours across a fall-back transition", () => {
+		const { startedAt, endedAt } = localDayWindow("2026-11-01");
+		expect((endedAt - startedAt) / HOUR).toBe(25);
+	});
+
+	it("rejects malformed and non-existent dates", () => {
+		expect(() => localDayWindow("27-07-2026")).toThrow();
+		expect(() => localDayWindow("2026-02-30")).toThrow();
+	});
+});
+
+describe("localHourStarts", () => {
+	it("emits one mark per local hour, all on a local hour boundary", () => {
+		const window = localDayWindow("2026-07-27");
+		const starts = localHourStarts(window);
+		expect(starts.length).toBe(24);
+		for (const start of starts) {
+			expect(new Date(start).getMinutes()).toBe(0);
+			expect(floorToLocalHour(start)).toBe(start);
+		}
+	});
+
+	it("emits 23 marks on the spring-forward day, skipping the lost hour", () => {
+		const starts = localHourStarts(localDayWindow("2026-03-08"));
+		expect(starts.length).toBe(23);
+		expect(starts.map(s => new Date(s).getHours())).not.toContain(2);
+	});
+
+	it("emits 25 marks on the fall-back day, keeping the repeated hour distinct", () => {
+		const starts = localHourStarts(localDayWindow("2026-11-01"));
+		expect(starts.length).toBe(25);
+		const ones = starts.filter(s => new Date(s).getHours() === 1);
+		expect(ones.length).toBe(2);
+		expect(ones[0]).not.toBe(ones[1]);
+	});
+});
+
+describe("summarizeActivity", () => {
+	it("returns an all-zero summary for no evidence", () => {
+		const window = localDayWindow("2026-07-27");
+		const summary = summarizeActivity([], window);
+		expect(summary.clipCount).toBe(0);
+		expect(summary.trackedMs).toBe(0);
+		expect(summary.apps).toEqual([]);
+		expect(summary.hours.length).toBe(24);
+		expect(summary.hours.every(hour => hour.trackedMs === 0)).toBe(true);
+	});
+
+	it("splits a window spanning an hour boundary across both hours", () => {
+		const window = localDayWindow("2026-07-27");
+		const tenAm = new Date(2026, 6, 27, 10).getTime();
+		// 09:58 -> 10:04: two minutes in hour 9, four in hour 10.
+		const summary = summarizeActivity([evidence(tenAm - 2 * 60_000, tenAm + 4 * 60_000, "code")], window);
+
+		expect(summary.clipCount).toBe(1);
+		expect(summary.trackedMs).toBe(6 * 60_000);
+		const nine = summary.hours.find(hour => hour.hourLabel === 9);
+		const ten = summary.hours.find(hour => hour.hourLabel === 10);
+		expect(nine?.trackedMs).toBe(2 * 60_000);
+		expect(ten?.trackedMs).toBe(4 * 60_000);
+		// Counted once overall, not once per bucket it touches.
+		expect(summary.apps).toEqual([["code", 6 * 60_000]]);
+	});
+
+	it("clips evidence to the requested window", () => {
+		const window = localDayWindow("2026-07-27");
+		// Starts 30m before local midnight, ends 30m after.
+		const summary = summarizeActivity(
+			[evidence(window.startedAt - 30 * 60_000, window.startedAt + 30 * 60_000, "code")],
+			window,
+		);
+		expect(summary.trackedMs).toBe(30 * 60_000);
+	});
+
+	it("ignores evidence entirely outside the window", () => {
+		const window = localDayWindow("2026-07-27");
+		const summary = summarizeActivity([evidence(window.endedAt + HOUR, window.endedAt + 2 * HOUR, "code")], window);
+		expect(summary.clipCount).toBe(0);
+		expect(summary.trackedMs).toBe(0);
+	});
+
+	it("keeps the two repeated 1am hours separate on a fall-back day", () => {
+		const window = localDayWindow("2026-11-01");
+		const [firstOne, secondOne] = localHourStarts(window).filter(s => new Date(s).getHours() === 1);
+		const summary = summarizeActivity(
+			[
+				evidence((firstOne as number) + 10 * 60_000, (firstOne as number) + 20 * 60_000, "code"),
+				evidence((secondOne as number) + 10 * 60_000, (secondOne as number) + 40 * 60_000, "comet"),
+			],
+			window,
+		);
+		const ones = summary.hours.filter(hour => hour.hourLabel === 1);
+		expect(ones.length).toBe(2);
+		expect(ones[0]?.trackedMs).toBe(10 * 60_000);
+		expect(ones[1]?.trackedMs).toBe(30 * 60_000);
+	});
+
+	it("dedupes multi-line digests into one collapsed line", () => {
+		const window = localDayWindow("2026-07-27");
+		const tenAm = new Date(2026, 6, 27, 10).getTime();
+		const summary = summarizeActivity(
+			[evidence(tenAm, tenAm + 60_000, "code", "main.rs\n  main.rs  \nlib.rs\n")],
+			window,
+		);
+		expect(summary.hours.find(hour => hour.hourLabel === 10)?.digests).toEqual(["main.rs  ·  lib.rs"]);
+	});
+
+	it("orders apps by tracked time, descending", () => {
+		const window = localDayWindow("2026-07-27");
+		const nineAm = new Date(2026, 6, 27, 9).getTime();
+		const summary = summarizeActivity(
+			[
+				evidence(nineAm, nineAm + 5 * 60_000, "comet"),
+				evidence(nineAm, nineAm + 20 * 60_000, "code"),
+				evidence(nineAm, nineAm + 10 * 60_000, "notion"),
+			],
+			window,
+		);
+		expect(summary.apps.map(([app]) => app)).toEqual(["code", "notion", "comet"]);
+	});
+});
+
+describe("readActivitySummary", () => {
+	let root: string;
+	let ledgerPath: string;
+
+	beforeEach(async () => {
+		root = await fs.mkdtemp(path.join(os.tmpdir(), "gopk-read-"));
+		ledgerPath = path.join(root, "activity-ledger.sqlite");
+	});
+
+	afterEach(async () => {
+		await fs.rm(root, { recursive: true, force: true });
+	});
+
+	it("reports an absent ledger instead of creating one", () => {
+		const summary = readActivitySummary({ window: localDayWindow("2026-07-27"), ledgerPath });
+		expect(summary.ledgerPresent).toBe(false);
+		expect(summary.clipCount).toBe(0);
+		expect(summary.hours.length).toBe(24);
+	});
+
+	it("does not create the ledger file as a side effect of reading", async () => {
+		readActivitySummary({ window: localDayWindow("2026-07-27"), ledgerPath });
+		expect(await fs.exists(ledgerPath)).toBe(false);
+	});
+
+	it("reads an existing ledger without mutating it", async () => {
+		const writer = new SqliteActivityLedger(ledgerPath);
+		const tenAm = new Date(2026, 6, 27, 10).getTime();
+		writer.record(evidence(tenAm, tenAm + 15 * 60_000, "code", "main.rs"));
+		writer.record(evidence(tenAm + HOUR, tenAm + HOUR + 5 * 60_000, "comet"));
+		writer.close();
+		const before = (await fs.stat(ledgerPath)).size;
+
+		const summary = readActivitySummary({ window: localDayWindow("2026-07-27"), ledgerPath });
+		expect(summary.ledgerPresent).toBe(true);
+		expect(summary.clipCount).toBe(2);
+		expect(summary.trackedMs).toBe(20 * 60_000);
+		expect(summary.hours.find(hour => hour.hourLabel === 10)?.digests).toEqual(["main.rs"]);
+		expect((await fs.stat(ledgerPath)).size).toBe(before);
+	});
+
+	it("excludes rows outside the requested day", () => {
+		const writer = new SqliteActivityLedger(ledgerPath);
+		const tenAm = new Date(2026, 6, 27, 10).getTime();
+		writer.record(evidence(tenAm, tenAm + 10 * 60_000, "code"));
+		writer.record(evidence(tenAm - 24 * HOUR, tenAm - 24 * HOUR + 10 * 60_000, "comet"));
+		writer.close();
+
+		const summary = readActivitySummary({ window: localDayWindow("2026-07-27"), ledgerPath });
+		expect(summary.clipCount).toBe(1);
+		expect(summary.apps).toEqual([["code", 10 * 60_000]]);
+	});
+});

--- a/packages/coding-agent/src/gopk-clips/read.test.ts
+++ b/packages/coding-agent/src/gopk-clips/read.test.ts
@@ -1,17 +1,48 @@
-// TZ is pinned before any Date work so the DST and local-hour assertions are
-// deterministic rather than dependent on the machine running the suite.
-// America/New_York: 2026-03-08 springs forward (23h day), 2026-11-01 falls
-// back (25h day).
-process.env.TZ = "America/New_York";
-
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { type ActivityEvidence, SqliteActivityLedger } from "@pk-nerdsaver-ai/pi-activity-journal";
-import { floorToLocalHour, localDayWindow, localHourStarts, readActivitySummary, summarizeActivity } from "./read";
+import {
+	floorToLocalHour,
+	localDateOf,
+	localDayWindow,
+	localHourStarts,
+	readActivitySummary,
+	summarizeActivity,
+} from "./read";
 
 const HOUR = 3_600_000;
+
+// This file never assigns `process.env.TZ`. A process timezone can only be
+// changed once — Bun applies the first assignment and then ignores `delete`
+// and any later re-assignment — so setting it here would irreversibly re-zone
+// every sibling suite sharing this `bun test` process. Zone-dependent
+// assertions run in a child instead (see ./tz-probe-fixture.ts); everything
+// below is written to hold in ANY timezone.
+
+interface ZoneProbe {
+	zone: string;
+	dayHours: number;
+	markCount: number;
+	labels: number[];
+	markMinutes: number[];
+	marksAreFixpoints: boolean;
+	firstMarkCoversStart: boolean;
+}
+
+const FIXTURE = path.join(import.meta.dir, "tz-probe-fixture.ts");
+
+/** Measure one calendar day under `zone`, in a child process. */
+function probeZone(zone: string, date: string): ZoneProbe {
+	const run = Bun.spawnSync(["bun", FIXTURE, date], {
+		env: { ...process.env, TZ: zone },
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	if (run.exitCode !== 0) throw new Error(`probe ${zone} ${date} failed: ${run.stderr.toString()}`);
+	return JSON.parse(run.stdout.toString()) as ZoneProbe;
+}
 
 /** Minimal evidence row; only the fields the summarizer reads are meaningful. */
 function evidence(startedAt: number, endedAt: number, appId: string, digest?: string): ActivityEvidence {
@@ -32,85 +63,104 @@ function evidence(startedAt: number, endedAt: number, appId: string, digest?: st
 	};
 }
 
-describe("localDayWindow", () => {
+/** A six-hour window starting on a local hour mark — six buckets in any zone. */
+function sixHourWindow(): { startedAt: number; endedAt: number } {
+	const startedAt = floorToLocalHour(Date.parse("2026-07-27T12:00:00Z"));
+	return { startedAt, endedAt: startedAt + 6 * HOUR };
+}
+
+describe("localDayWindow / localHourStarts across timezones", () => {
+	// America/New_York: 2026-03-08 springs forward, 2026-11-01 falls back.
 	it("spans 24 hours on an ordinary day", () => {
-		const { startedAt, endedAt } = localDayWindow("2026-07-27");
-		expect((endedAt - startedAt) / HOUR).toBe(24);
-		expect(new Date(startedAt).getHours()).toBe(0);
+		const probe = probeZone("America/New_York", "2026-07-27");
+		expect(probe.dayHours).toBe(24);
+		expect(probe.markCount).toBe(24);
 	});
 
-	it("spans 23 hours across a spring-forward transition", () => {
-		const { startedAt, endedAt } = localDayWindow("2026-03-08");
-		expect((endedAt - startedAt) / HOUR).toBe(23);
+	it("spans 23 hours across a spring-forward transition and skips the lost hour", () => {
+		const probe = probeZone("America/New_York", "2026-03-08");
+		expect(probe.dayHours).toBe(23);
+		expect(probe.markCount).toBe(23);
+		expect(probe.labels).not.toContain(2);
 	});
 
-	it("spans 25 hours across a fall-back transition", () => {
-		const { startedAt, endedAt } = localDayWindow("2026-11-01");
-		expect((endedAt - startedAt) / HOUR).toBe(25);
+	it("spans 25 hours across a fall-back transition and keeps the repeated hour", () => {
+		const probe = probeZone("America/New_York", "2026-11-01");
+		expect(probe.dayHours).toBe(25);
+		expect(probe.markCount).toBe(25);
+		expect(probe.labels.filter(hour => hour === 1).length).toBe(2);
+	});
+
+	it("puts every bucket on a real local hour mark in half-hour-offset zones", () => {
+		// The bug this replaced floored to UTC hour boundaries, which land at
+		// :30 local in Asia/Kolkata (+5:30) and :45 in Asia/Kathmandu (+5:45).
+		for (const zone of ["Asia/Kolkata", "Asia/Kathmandu", "Australia/Adelaide"]) {
+			const probe = probeZone(zone, "2026-07-27");
+			expect({ zone, minutes: probe.markMinutes }).toEqual({ zone, minutes: [0] });
+			expect(probe.markCount).toBe(24);
+			expect(probe.marksAreFixpoints).toBe(true);
+		}
+	});
+
+	it("never emits a first mark that starts after the window it covers", () => {
+		for (const [zone, date] of [
+			["America/New_York", "2026-03-08"],
+			["Asia/Kolkata", "2026-07-27"],
+			["UTC", "2026-07-27"],
+			["Australia/Sydney", "2026-10-04"],
+		] as const) {
+			expect({ zone, ok: probeZone(zone, date).firstMarkCoversStart }).toEqual({ zone, ok: true });
+		}
 	});
 
 	it("rejects malformed and non-existent dates", () => {
 		expect(() => localDayWindow("27-07-2026")).toThrow();
 		expect(() => localDayWindow("2026-02-30")).toThrow();
+		expect(() => localDayWindow("")).toThrow();
 	});
-});
 
-describe("localHourStarts", () => {
-	it("emits one mark per local hour, all on a local hour boundary", () => {
-		const window = localDayWindow("2026-07-27");
-		const starts = localHourStarts(window);
-		expect(starts.length).toBe(24);
-		for (const start of starts) {
-			expect(new Date(start).getMinutes()).toBe(0);
-			expect(floorToLocalHour(start)).toBe(start);
+	it("round-trips localDateOf through localDayWindow", () => {
+		const today = localDateOf();
+		const { startedAt } = localDayWindow(today);
+		expect(localDateOf(startedAt)).toBe(today);
+	});
+
+	it("emits marks one hour apart, each a floorToLocalHour fixpoint", () => {
+		const starts = localHourStarts(sixHourWindow());
+		expect(starts.length).toBe(6);
+		for (let i = 0; i < starts.length; i++) {
+			expect(floorToLocalHour(starts[i] as number)).toBe(starts[i]);
+			if (i > 0) expect((starts[i] as number) - (starts[i - 1] as number)).toBe(HOUR);
 		}
-	});
-
-	it("emits 23 marks on the spring-forward day, skipping the lost hour", () => {
-		const starts = localHourStarts(localDayWindow("2026-03-08"));
-		expect(starts.length).toBe(23);
-		expect(starts.map(s => new Date(s).getHours())).not.toContain(2);
-	});
-
-	it("emits 25 marks on the fall-back day, keeping the repeated hour distinct", () => {
-		const starts = localHourStarts(localDayWindow("2026-11-01"));
-		expect(starts.length).toBe(25);
-		const ones = starts.filter(s => new Date(s).getHours() === 1);
-		expect(ones.length).toBe(2);
-		expect(ones[0]).not.toBe(ones[1]);
 	});
 });
 
 describe("summarizeActivity", () => {
 	it("returns an all-zero summary for no evidence", () => {
-		const window = localDayWindow("2026-07-27");
-		const summary = summarizeActivity([], window);
+		const summary = summarizeActivity([], sixHourWindow());
 		expect(summary.clipCount).toBe(0);
 		expect(summary.trackedMs).toBe(0);
 		expect(summary.apps).toEqual([]);
-		expect(summary.hours.length).toBe(24);
+		expect(summary.hours.length).toBe(6);
 		expect(summary.hours.every(hour => hour.trackedMs === 0)).toBe(true);
 	});
 
 	it("splits a window spanning an hour boundary across both hours", () => {
-		const window = localDayWindow("2026-07-27");
-		const tenAm = new Date(2026, 6, 27, 10).getTime();
-		// 09:58 -> 10:04: two minutes in hour 9, four in hour 10.
-		const summary = summarizeActivity([evidence(tenAm - 2 * 60_000, tenAm + 4 * 60_000, "code")], window);
+		const window = sixHourWindow();
+		const boundary = window.startedAt + 2 * HOUR;
+		// 2 minutes before the boundary, 4 after.
+		const summary = summarizeActivity([evidence(boundary - 2 * 60_000, boundary + 4 * 60_000, "code")], window);
 
 		expect(summary.clipCount).toBe(1);
 		expect(summary.trackedMs).toBe(6 * 60_000);
-		const nine = summary.hours.find(hour => hour.hourLabel === 9);
-		const ten = summary.hours.find(hour => hour.hourLabel === 10);
-		expect(nine?.trackedMs).toBe(2 * 60_000);
-		expect(ten?.trackedMs).toBe(4 * 60_000);
+		expect(summary.hours[1]?.trackedMs).toBe(2 * 60_000);
+		expect(summary.hours[2]?.trackedMs).toBe(4 * 60_000);
 		// Counted once overall, not once per bucket it touches.
 		expect(summary.apps).toEqual([["code", 6 * 60_000]]);
 	});
 
 	it("clips evidence to the requested window", () => {
-		const window = localDayWindow("2026-07-27");
-		// Starts 30m before local midnight, ends 30m after.
+		const window = sixHourWindow();
 		const summary = summarizeActivity(
 			[evidence(window.startedAt - 30 * 60_000, window.startedAt + 30 * 60_000, "code")],
 			window,
@@ -119,46 +169,37 @@ describe("summarizeActivity", () => {
 	});
 
 	it("ignores evidence entirely outside the window", () => {
-		const window = localDayWindow("2026-07-27");
+		const window = sixHourWindow();
 		const summary = summarizeActivity([evidence(window.endedAt + HOUR, window.endedAt + 2 * HOUR, "code")], window);
 		expect(summary.clipCount).toBe(0);
 		expect(summary.trackedMs).toBe(0);
 	});
 
-	it("keeps the two repeated 1am hours separate on a fall-back day", () => {
-		const window = localDayWindow("2026-11-01");
-		const [firstOne, secondOne] = localHourStarts(window).filter(s => new Date(s).getHours() === 1);
-		const summary = summarizeActivity(
-			[
-				evidence((firstOne as number) + 10 * 60_000, (firstOne as number) + 20 * 60_000, "code"),
-				evidence((secondOne as number) + 10 * 60_000, (secondOne as number) + 40 * 60_000, "comet"),
-			],
-			window,
-		);
-		const ones = summary.hours.filter(hour => hour.hourLabel === 1);
-		expect(ones.length).toBe(2);
-		expect(ones[0]?.trackedMs).toBe(10 * 60_000);
-		expect(ones[1]?.trackedMs).toBe(30 * 60_000);
+	it("conserves total time across bucket splits", () => {
+		const window = sixHourWindow();
+		// Spans the whole window and overhangs both ends.
+		const summary = summarizeActivity([evidence(window.startedAt - HOUR, window.endedAt + HOUR, "code")], window);
+		const bucketed = summary.hours.reduce((total, hour) => total + hour.trackedMs, 0);
+		expect(summary.trackedMs).toBe(window.endedAt - window.startedAt);
+		expect(bucketed).toBe(summary.trackedMs);
 	});
 
 	it("dedupes multi-line digests into one collapsed line", () => {
-		const window = localDayWindow("2026-07-27");
-		const tenAm = new Date(2026, 6, 27, 10).getTime();
+		const window = sixHourWindow();
 		const summary = summarizeActivity(
-			[evidence(tenAm, tenAm + 60_000, "code", "main.rs\n  main.rs  \nlib.rs\n")],
+			[evidence(window.startedAt, window.startedAt + 60_000, "code", "main.rs\n  main.rs  \nlib.rs\n")],
 			window,
 		);
-		expect(summary.hours.find(hour => hour.hourLabel === 10)?.digests).toEqual(["main.rs  ·  lib.rs"]);
+		expect(summary.hours[0]?.digests).toEqual(["main.rs  ·  lib.rs"]);
 	});
 
 	it("orders apps by tracked time, descending", () => {
-		const window = localDayWindow("2026-07-27");
-		const nineAm = new Date(2026, 6, 27, 9).getTime();
+		const window = sixHourWindow();
 		const summary = summarizeActivity(
 			[
-				evidence(nineAm, nineAm + 5 * 60_000, "comet"),
-				evidence(nineAm, nineAm + 20 * 60_000, "code"),
-				evidence(nineAm, nineAm + 10 * 60_000, "notion"),
+				evidence(window.startedAt, window.startedAt + 5 * 60_000, "comet"),
+				evidence(window.startedAt, window.startedAt + 20 * 60_000, "code"),
+				evidence(window.startedAt, window.startedAt + 10 * 60_000, "notion"),
 			],
 			window,
 		);
@@ -179,42 +220,38 @@ describe("readActivitySummary", () => {
 		await fs.rm(root, { recursive: true, force: true });
 	});
 
-	it("reports an absent ledger instead of creating one", () => {
-		const summary = readActivitySummary({ window: localDayWindow("2026-07-27"), ledgerPath });
+	it("reports an absent ledger instead of creating one", async () => {
+		const summary = readActivitySummary({ window: sixHourWindow(), ledgerPath });
 		expect(summary.ledgerPresent).toBe(false);
 		expect(summary.clipCount).toBe(0);
-		expect(summary.hours.length).toBe(24);
-	});
-
-	it("does not create the ledger file as a side effect of reading", async () => {
-		readActivitySummary({ window: localDayWindow("2026-07-27"), ledgerPath });
+		expect(summary.hours.length).toBe(6);
 		expect(await fs.exists(ledgerPath)).toBe(false);
 	});
 
 	it("reads an existing ledger without mutating it", async () => {
+		const window = sixHourWindow();
 		const writer = new SqliteActivityLedger(ledgerPath);
-		const tenAm = new Date(2026, 6, 27, 10).getTime();
-		writer.record(evidence(tenAm, tenAm + 15 * 60_000, "code", "main.rs"));
-		writer.record(evidence(tenAm + HOUR, tenAm + HOUR + 5 * 60_000, "comet"));
+		writer.record(evidence(window.startedAt, window.startedAt + 15 * 60_000, "code", "main.rs"));
+		writer.record(evidence(window.startedAt + HOUR, window.startedAt + HOUR + 5 * 60_000, "comet"));
 		writer.close();
 		const before = (await fs.stat(ledgerPath)).size;
 
-		const summary = readActivitySummary({ window: localDayWindow("2026-07-27"), ledgerPath });
+		const summary = readActivitySummary({ window, ledgerPath });
 		expect(summary.ledgerPresent).toBe(true);
 		expect(summary.clipCount).toBe(2);
 		expect(summary.trackedMs).toBe(20 * 60_000);
-		expect(summary.hours.find(hour => hour.hourLabel === 10)?.digests).toEqual(["main.rs"]);
+		expect(summary.hours[0]?.digests).toEqual(["main.rs"]);
 		expect((await fs.stat(ledgerPath)).size).toBe(before);
 	});
 
-	it("excludes rows outside the requested day", () => {
+	it("excludes rows outside the requested window", () => {
+		const window = sixHourWindow();
 		const writer = new SqliteActivityLedger(ledgerPath);
-		const tenAm = new Date(2026, 6, 27, 10).getTime();
-		writer.record(evidence(tenAm, tenAm + 10 * 60_000, "code"));
-		writer.record(evidence(tenAm - 24 * HOUR, tenAm - 24 * HOUR + 10 * 60_000, "comet"));
+		writer.record(evidence(window.startedAt, window.startedAt + 10 * 60_000, "code"));
+		writer.record(evidence(window.startedAt - 24 * HOUR, window.startedAt - 24 * HOUR + 10 * 60_000, "comet"));
 		writer.close();
 
-		const summary = readActivitySummary({ window: localDayWindow("2026-07-27"), ledgerPath });
+		const summary = readActivitySummary({ window, ledgerPath });
 		expect(summary.clipCount).toBe(1);
 		expect(summary.apps).toEqual([["code", 10 * 60_000]]);
 	});

--- a/packages/coding-agent/src/gopk-clips/read.ts
+++ b/packages/coding-agent/src/gopk-clips/read.ts
@@ -1,0 +1,220 @@
+/**
+ * Read side of Activity Memory — job #3 of the gopk-clips pipeline.
+ *
+ * The sampler writes handoff files; the always-on `gopk-ingest` daemon drains
+ * them into `activity-ledger.sqlite` (jobs #1 and #2, see ./daemon.ts). This
+ * module only ever *queries* that ledger, read-only, and never touches the
+ * handoff directory. It is the single implementation behind both the recall
+ * CLI and the in-session `activity` tool, so their numbers cannot diverge.
+ *
+ * Local-time correctness is the whole difficulty here, and both hazards are
+ * handled explicitly rather than by flooring epoch milliseconds:
+ *
+ *  - A calendar day is NOT 24 hours. On DST transition days it is 23 or 25,
+ *    so the day window is derived from local midnight to the *next* local
+ *    midnight via the Date constructor, which normalizes the shift for us.
+ *  - Hour boundaries are NOT UTC hour boundaries. In half-hour-offset zones
+ *    (IST +5:30, NPT +5:45) a UTC-floored bucket straddles two local hours and
+ *    is mislabelled. Buckets here start on a real local hour mark, and a
+ *    bucket is keyed by its absolute start instant — so the repeated hour on a
+ *    fall-back day stays two distinct buckets instead of collapsing into one.
+ *
+ * Nothing leaves the machine; the ledger is a local SQLite file.
+ */
+import * as fs from "node:fs";
+import { type ActivityEvidence, SqliteActivityLedgerReader } from "@pk-nerdsaver-ai/pi-activity-journal";
+import { resolveGopkClipsPaths } from "./paths";
+
+const HOUR_MS = 3_600_000;
+
+/** Half-open instant range `[startedAt, endedAt)`, in epoch milliseconds. */
+export interface ActivityWindowMs {
+	readonly startedAt: number;
+	readonly endedAt: number;
+}
+
+export interface ActivityHourBucket {
+	/** Absolute start of this local hour, epoch ms. Unique per bucket. */
+	readonly hourStartedAt: number;
+	/** Local hour label 0-23. Not unique: a fall-back day repeats one. */
+	readonly hourLabel: number;
+	readonly trackedMs: number;
+	/** Tracked ms per `application.id`, descending by duration. */
+	readonly apps: readonly (readonly [string, number])[];
+	/** Deduped one-line sanitized digests sampled in this hour. */
+	readonly digests: readonly string[];
+}
+
+export interface ActivitySummary {
+	readonly window: ActivityWindowMs;
+	/** False when the ledger file does not exist yet; every total is then zero. */
+	readonly ledgerPresent: boolean;
+	readonly ledgerPath: string;
+	readonly clipCount: number;
+	readonly trackedMs: number;
+	/** Tracked ms per `application.id` across the window, descending. */
+	readonly apps: readonly (readonly [string, number])[];
+	readonly hours: readonly ActivityHourBucket[];
+}
+
+/** Start of the local hour containing `ms`. Correct at any UTC offset. */
+export function floorToLocalHour(ms: number): number {
+	const at = new Date(ms);
+	return new Date(at.getFullYear(), at.getMonth(), at.getDate(), at.getHours()).getTime();
+}
+
+/**
+ * The local calendar day `date` (YYYY-MM-DD) as a half-open instant range.
+ * Length is 23, 24, or 25 hours depending on DST — the Date constructor
+ * normalizes day rollover, so this is correct without a timezone database.
+ * Throws on a date that does not exist.
+ */
+export function localDayWindow(date: string): ActivityWindowMs {
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+	if (!match) throw new Error(`date must be YYYY-MM-DD, got ${JSON.stringify(date)}`);
+	const year = Number(match[1]);
+	const month = Number(match[2]);
+	const day = Number(match[3]);
+	const startedAt = new Date(year, month - 1, day).getTime();
+	const endedAt = new Date(year, month - 1, day + 1).getTime();
+	if (!Number.isFinite(startedAt) || !Number.isFinite(endedAt)) throw new Error(`invalid date: ${date}`);
+	// Reject rollover (2026-02-30 -> Mar 2) rather than silently summarizing
+	// a day the caller did not ask for.
+	const start = new Date(startedAt);
+	if (start.getFullYear() !== year || start.getMonth() !== month - 1 || start.getDate() !== day) {
+		throw new Error(`invalid date: ${date}`);
+	}
+	return { startedAt, endedAt };
+}
+
+/** The local date (YYYY-MM-DD) containing `ms`; defaults to now. */
+export function localDateOf(ms: number = Date.now()): string {
+	const at = new Date(ms);
+	const month = String(at.getMonth() + 1).padStart(2, "0");
+	const day = String(at.getDate()).padStart(2, "0");
+	return `${at.getFullYear()}-${month}-${day}`;
+}
+
+/**
+ * Local hour marks covering `window`, ascending. Steps by one hour from the
+ * first local hour mark: across a DST shift the UTC offset moves by a whole
+ * hour, so the marks stay on local `:00` and the day yields 23 or 25 of them.
+ */
+export function localHourStarts(window: ActivityWindowMs): number[] {
+	const starts: number[] = [];
+	for (let at = floorToLocalHour(window.startedAt); at < window.endedAt; at += HOUR_MS) starts.push(at);
+	return starts;
+}
+
+/** Collapse a multi-line digest (one sampled title per line) to one deduped line. */
+function collapseDigest(digest: string | undefined): string {
+	const lines = (digest ?? "").split("\n").map(line => line.trim());
+	return [...new Set(lines.filter(Boolean))].join("  ·  ");
+}
+
+function descending(totals: ReadonlyMap<string, number>): (readonly [string, number])[] {
+	return [...totals.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+}
+
+/**
+ * Bucket `evidence` into local hours across `window`. Each evidence window is
+ * split across every hour it spans and credited proportionally, so a clip
+ * straddling 09:58-10:04 contributes to both hours rather than to whichever
+ * one happens to hold its start.
+ */
+export function summarizeActivity(
+	evidence: readonly ActivityEvidence[],
+	window: ActivityWindowMs,
+	options: { readonly ledgerPath?: string; readonly ledgerPresent?: boolean } = {},
+): ActivitySummary {
+	interface Bucket {
+		trackedMs: number;
+		readonly apps: Map<string, number>;
+		readonly digests: string[];
+	}
+	const buckets = new Map<number, Bucket>();
+	for (const hourStart of localHourStarts(window)) {
+		buckets.set(hourStart, { trackedMs: 0, apps: new Map(), digests: [] });
+	}
+	const hourStarts = [...buckets.keys()].sort((a, b) => a - b);
+	const apps = new Map<string, number>();
+	let trackedMs = 0;
+	let clipCount = 0;
+
+	for (const item of evidence) {
+		const start = Date.parse(item.window.startedAt);
+		const end = Date.parse(item.window.endedAt);
+		if (!Number.isFinite(start) || !Number.isFinite(end)) continue;
+		if (end <= window.startedAt || start >= window.endedAt) continue;
+		clipCount++;
+		const appId = item.application?.id ?? "unknown";
+		const digest = collapseDigest(item.redactedDigest);
+
+		for (let index = 0; index < hourStarts.length; index++) {
+			const hourStart = hourStarts[index] as number;
+			const hourEnd = index + 1 < hourStarts.length ? (hourStarts[index + 1] as number) : window.endedAt;
+			const overlap = Math.min(end, hourEnd, window.endedAt) - Math.max(start, hourStart, window.startedAt);
+			if (overlap <= 0) continue;
+			const bucket = buckets.get(hourStart);
+			if (!bucket) continue;
+			bucket.trackedMs += overlap;
+			bucket.apps.set(appId, (bucket.apps.get(appId) ?? 0) + overlap);
+			apps.set(appId, (apps.get(appId) ?? 0) + overlap);
+			trackedMs += overlap;
+			if (digest && bucket.digests[bucket.digests.length - 1] !== digest) bucket.digests.push(digest);
+		}
+	}
+
+	return {
+		window,
+		ledgerPresent: options.ledgerPresent ?? true,
+		ledgerPath: options.ledgerPath ?? "",
+		clipCount,
+		trackedMs,
+		apps: descending(apps),
+		hours: hourStarts.map(hourStart => {
+			const bucket = buckets.get(hourStart) as Bucket;
+			return {
+				hourStartedAt: hourStart,
+				hourLabel: new Date(hourStart).getHours(),
+				trackedMs: bucket.trackedMs,
+				apps: descending(bucket.apps),
+				digests: bucket.digests,
+			};
+		}),
+	};
+}
+
+/**
+ * Open the ledger read-only, query the window, and summarize. A ledger that
+ * does not exist yet yields an empty summary with `ledgerPresent: false` —
+ * the normal state before the Activity Memory app has ever run — rather than
+ * an error, and never creates the file.
+ */
+export function readActivitySummary(options: {
+	readonly window: ActivityWindowMs;
+	readonly ledgerPath?: string;
+}): ActivitySummary {
+	const ledgerPath = resolveGopkClipsPaths({ ledgerPath: options.ledgerPath }).ledgerPath;
+	if (!fs.existsSync(ledgerPath)) {
+		return summarizeActivity([], options.window, { ledgerPath, ledgerPresent: false });
+	}
+	const reader = new SqliteActivityLedgerReader(ledgerPath);
+	try {
+		const evidence = reader.listOverlapping(
+			new Date(options.window.startedAt).toISOString(),
+			new Date(options.window.endedAt).toISOString(),
+		);
+		return summarizeActivity(evidence, options.window, { ledgerPath, ledgerPresent: true });
+	} finally {
+		reader.close();
+	}
+}
+
+/** `1.5h` / `12m` / `0m`, for terminal and model-facing output alike. */
+export function formatTrackedMs(ms: number): string {
+	if (ms <= 0) return "0m";
+	const minutes = ms / 60_000;
+	if (minutes >= 60) return `${(minutes / 60).toFixed(1)}h`;
+	return `${Math.max(1, Math.round(minutes))}m`;
+}

--- a/packages/coding-agent/src/gopk-clips/recall-cli.ts
+++ b/packages/coding-agent/src/gopk-clips/recall-cli.ts
@@ -1,79 +1,42 @@
 /**
  * Hour-over-hour recall over the local activity ledger: "what was I working
- * on today?" rendered as a terminal timeline. Reads the SQLite ledger the
- * gopk-clips host feeds (see ./session-state.ts) and prints, per hour, the
- * tracked minutes, the app mix, and (with --digests) sample sanitized
- * digests. Local viewing only — nothing leaves the machine.
+ * on today?" rendered as a terminal timeline. All querying and bucketing
+ * lives in ./read.ts, which the in-session `activity` tool shares — this file
+ * is presentation only, so the CLI and the tool can never report different
+ * numbers. Local viewing only; nothing leaves the machine.
  *
  * Usage:
  *   bun src/gopk-clips/recall-cli.ts [--date YYYY-MM-DD] [--ledger <path>]
  *     [--digests] [--json]
  */
-import * as fs from "node:fs";
-import * as os from "node:os";
-import * as path from "node:path";
-import { type ActivityEvidence, SqliteActivityLedger } from "@pk-nerdsaver-ai/pi-activity-journal";
-import { getAgentDir } from "@pk-nerdsaver-ai/pi-utils";
+import { type ActivitySummary, formatTrackedMs, localDateOf, localDayWindow, readActivitySummary } from "./read";
 
-/**
- * Resolve the ledger path the always-on daemon actually writes: prefer the
- * shared gopk-clips config.json (so a custom captureRoot / profile lines up),
- * fall back to the agent-dir default. Keeps recall pointed at the same ledger
- * as the report and the daemon regardless of PI_CONFIG_DIR/profile.
- */
-function resolveLedgerPath(): string {
-	const fallback = path.join(getAgentDir(), "gopk-clips", "activity-ledger.sqlite");
-	const configPath =
-		process.platform === "win32"
-			? path.join(process.env.LOCALAPPDATA || path.join(os.homedir(), "AppData", "Local"), "gopk-clips", "config.json")
-			: path.join(process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config"), "gopk-clips", "config.json");
-	try {
-		const parsed = JSON.parse(fs.readFileSync(configPath, "utf8")) as { ledgerPath?: string };
-		return parsed.ledgerPath || fallback;
-	} catch {
-		return fallback;
-	}
+interface Options {
+	readonly date: string;
+	readonly ledgerPath: string;
+	readonly digests: boolean;
+	readonly json: boolean;
 }
 
-interface HourBucket {
-	readonly hour: number;
-	trackedMs: number;
-	readonly appMs: Map<string, number>;
-	readonly digests: string[];
-}
-
-function parseArgs(argv: string[]): { date: string; ledgerPath: string; digests: boolean; json: boolean } {
-	const today = new Date();
-	const localDate = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
-	const options = {
-		date: localDate,
-		ledgerPath: resolveLedgerPath(),
-		digests: false,
-		json: false,
-	};
+function parseArgs(argv: string[]): Options {
+	let date = localDateOf();
+	// Empty defers to the shared resolver, so the CLI reads whichever ledger
+	// the daemon writes.
+	let ledgerPath = "";
+	let digests = false;
+	let json = false;
 	for (let i = 0; i < argv.length; i++) {
 		const arg = argv[i];
-		if (arg === "--date") options.date = argv[++i] ?? options.date;
-		else if (arg === "--ledger") options.ledgerPath = argv[++i] ?? options.ledgerPath;
-		else if (arg === "--digests") options.digests = true;
-		else if (arg === "--json") options.json = true;
+		if (arg === "--date") date = argv[++i] ?? date;
+		else if (arg === "--ledger") ledgerPath = argv[++i] ?? ledgerPath;
+		else if (arg === "--digests") digests = true;
+		else if (arg === "--json") json = true;
 		else {
 			console.error(`Unknown argument: ${arg}`);
 			process.exit(1);
 		}
 	}
-	if (!/^\d{4}-\d{2}-\d{2}$/.test(options.date)) {
-		console.error("--date must be YYYY-MM-DD");
-		process.exit(1);
-	}
-	return options;
-}
-
-function formatMinutes(ms: number): string {
-	if (ms <= 0) return "0m";
-	const minutes = ms / 60_000;
-	if (minutes >= 60) return `${(minutes / 60).toFixed(1)}h`;
-	return `${Math.max(1, Math.round(minutes))}m`;
+	return { date, ledgerPath, digests, json };
 }
 
 function bar(ms: number, maxMs: number, width = 20): string {
@@ -81,98 +44,70 @@ function bar(ms: number, maxMs: number, width = 20): string {
 	return "█".repeat(Math.min(width, Math.max(ms > 0 ? 1 : 0, filled))).padEnd(width, "·");
 }
 
-function main(): void {
-	const options = parseArgs(process.argv.slice(2));
-	// Local-midnight day window.
-	const dayStart = new Date(`${options.date}T00:00:00`).getTime();
-	const dayEnd = dayStart + 24 * 3_600_000;
-	if (!Number.isFinite(dayStart)) {
-		console.error(`Invalid date: ${options.date}`);
-		process.exit(1);
-	}
+function printJson(summary: ActivitySummary, options: Options): void {
+	const hours = summary.hours
+		.filter(hour => hour.trackedMs > 0)
+		.map(hour => ({
+			hour: hour.hourLabel,
+			startedAt: new Date(hour.hourStartedAt).toISOString(),
+			trackedMinutes: Math.round(hour.trackedMs / 60_000),
+			apps: Object.fromEntries(hour.apps.map(([app, ms]) => [app, Math.round(ms / 60_000)])),
+			...(options.digests ? { digests: hour.digests.slice(0, 8) } : {}),
+		}));
+	console.log(JSON.stringify({ date: options.date, clips: summary.clipCount, hours }, null, 2));
+}
 
-	let ledger: SqliteActivityLedger;
-	try {
-		ledger = new SqliteActivityLedger(options.ledgerPath);
-	} catch (error) {
-		console.error(`Could not open ledger at ${options.ledgerPath}: ${String(error)}`);
-		process.exit(1);
-	}
-	const evidence = ledger.list();
-	ledger.close();
-
-	const buckets = new Map<number, HourBucket>();
-	const dayApps = new Map<string, number>();
-	let dayTrackedMs = 0;
-	let clipCount = 0;
-
-	for (const item of evidence as readonly ActivityEvidence[]) {
-		const start = Date.parse(item.window.startedAt);
-		const end = Date.parse(item.window.endedAt);
-		if (!Number.isFinite(start) || !Number.isFinite(end) || end <= dayStart || start >= dayEnd) continue;
-		clipCount++;
-		const appId = item.application?.id ?? "unknown";
-		// Split each evidence window across the hour boundaries it spans.
-		for (let hourStart = Math.floor(Math.max(start, dayStart) / 3_600_000) * 3_600_000; hourStart < Math.min(end, dayEnd); hourStart += 3_600_000) {
-			const overlap = Math.min(end, hourStart + 3_600_000, dayEnd) - Math.max(start, hourStart, dayStart);
-			if (overlap <= 0) continue;
-			const hour = new Date(hourStart).getHours();
-			let bucket = buckets.get(hour);
-			if (!bucket) {
-				bucket = { hour, trackedMs: 0, appMs: new Map(), digests: [] };
-				buckets.set(hour, bucket);
-			}
-			bucket.trackedMs += overlap;
-			bucket.appMs.set(appId, (bucket.appMs.get(appId) ?? 0) + overlap);
-			dayApps.set(appId, (dayApps.get(appId) ?? 0) + overlap);
-			dayTrackedMs += overlap;
-			// Digests are multi-line (one sampled title per line); collapse to a
-			// deduped single-line summary for display.
-			const digest = [...new Set((item.redactedDigest ?? "").split("\n").map(line => line.trim()).filter(Boolean))].join("  ·  ");
-			if (digest && bucket.digests[bucket.digests.length - 1] !== digest) bucket.digests.push(digest);
-		}
-	}
-
-	if (options.json) {
-		const output = [...buckets.values()]
-			.sort((a, b) => a.hour - b.hour)
-			.map(bucket => ({
-				hour: bucket.hour,
-				trackedMinutes: Math.round(bucket.trackedMs / 60_000),
-				apps: Object.fromEntries([...bucket.appMs.entries()].map(([app, ms]) => [app, Math.round(ms / 60_000)])),
-				...(options.digests ? { digests: bucket.digests.slice(0, 8) } : {}),
-			}));
-		console.log(JSON.stringify({ date: options.date, clips: clipCount, hours: output }, null, 2));
-		return;
-	}
-
-	console.log(`\nActivity — ${options.date}   (${clipCount} clips, ${formatMinutes(dayTrackedMs)} tracked)`);
+function printTimeline(summary: ActivitySummary, options: Options): void {
+	console.log(
+		`\nActivity — ${options.date}   (${summary.clipCount} clips, ${formatTrackedMs(summary.trackedMs)} tracked)`,
+	);
 	console.log("─".repeat(64));
-	if (buckets.size === 0) {
-		console.log("No activity recorded for this day.");
-		console.log(`Ledger: ${options.ledgerPath}`);
+	const active = summary.hours.filter(hour => hour.trackedMs > 0);
+	if (active.length === 0) {
+		console.log(
+			summary.ledgerPresent
+				? "No activity recorded for this day."
+				: "No activity ledger yet — the Activity Memory app has not recorded anything.",
+		);
+		console.log(`Ledger: ${summary.ledgerPath}`);
 		return;
 	}
 
-	const maxHourMs = Math.max(...[...buckets.values()].map(bucket => bucket.trackedMs));
-	for (const bucket of [...buckets.values()].sort((a, b) => a.hour - b.hour)) {
-		const label = `${String(bucket.hour).padStart(2, "0")}:00`;
-		const apps = [...bucket.appMs.entries()]
-			.sort((a, b) => b[1] - a[1])
+	const maxHourMs = Math.max(...active.map(hour => hour.trackedMs));
+	for (const hour of active) {
+		const label = `${String(hour.hourLabel).padStart(2, "0")}:00`;
+		const apps = hour.apps
 			.slice(0, 4)
-			.map(([app, ms]) => `${app} ${formatMinutes(ms)}`)
+			.map(([app, ms]) => `${app} ${formatTrackedMs(ms)}`)
 			.join(", ");
-		console.log(`${label}  ${bar(bucket.trackedMs, maxHourMs)}  ${formatMinutes(bucket.trackedMs).padStart(5)}  ${apps}`);
+		const tracked = formatTrackedMs(hour.trackedMs).padStart(5);
+		console.log(`${label}  ${bar(hour.trackedMs, maxHourMs)}  ${tracked}  ${apps}`);
 		if (options.digests) {
-			for (const digest of bucket.digests.slice(0, 5)) {
+			for (const digest of hour.digests.slice(0, 5)) {
 				console.log(`         · ${digest.length > 90 ? `${digest.slice(0, 90)}…` : digest}`);
 			}
 		}
 	}
 
-	const topApps = [...dayApps.entries()].sort((a, b) => b[1] - a[1]).slice(0, 6);
 	console.log("─".repeat(64));
-	console.log(`Top apps: ${topApps.map(([app, ms]) => `${app} ${formatMinutes(ms)}`).join(", ")}`);
+	const topApps = summary.apps.slice(0, 6).map(([app, ms]) => `${app} ${formatTrackedMs(ms)}`);
+	console.log(`Top apps: ${topApps.join(", ")}`);
+}
+
+function main(): void {
+	const options = parseArgs(process.argv.slice(2));
+	let summary: ActivitySummary;
+	try {
+		summary = readActivitySummary({
+			window: localDayWindow(options.date),
+			...(options.ledgerPath ? { ledgerPath: options.ledgerPath } : {}),
+		});
+	} catch (error) {
+		console.error(String(error instanceof Error ? error.message : error));
+		process.exit(1);
+	}
+	if (options.json) printJson(summary, options);
+	else printTimeline(summary, options);
 }
 
 main();

--- a/packages/coding-agent/src/gopk-clips/session-state.ts
+++ b/packages/coding-agent/src/gopk-clips/session-state.ts
@@ -17,13 +17,17 @@
  *
  * Unlike the screenpipe bridge, this host is not re-bound on agent session
  * transitions — each derivative carries the *capture* session id it was
- * recorded under, and the sink attributes evidence to that id. One host per
- * `AgentSession` lifetime; built when `gopkClips.enabled` is on, torn down in
- * the session's `dispose()`.
+ * recorded under, and the sink attributes evidence to that id.
+ *
+ * Exactly one host may run per ledger, and it is owned by the always-on
+ * `gopk-ingest` daemon (see ./daemon.ts) — never by an `AgentSession`. The
+ * handoff directory is a single-consumer queue: a second host would race the
+ * daemon to `unlink` each file (splitting clips between them) and contend for
+ * the ledger's SQLite write lock. Sessions that want activity data read the
+ * ledger the daemon writes; they do not ingest.
  */
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
-import * as os from "node:os";
 import * as path from "node:path";
 import {
 	createGopkActivitySink,
@@ -38,8 +42,9 @@ import type { ConsentRecord } from "@pk-nerdsaver-ai/pi-context-policy";
 // pi_natives native addon, which can't bundle into a compiled single-file exe
 // (gopk-ingest.exe). dirs.ts / logger.ts are native-free, so importing narrowly
 // keeps this module — and the standalone ingester built from it — self-contained.
-import { getAgentDir, getInstallId } from "@pk-nerdsaver-ai/pi-utils/dirs";
+import { getInstallId } from "@pk-nerdsaver-ai/pi-utils/dirs";
 import * as logger from "@pk-nerdsaver-ai/pi-utils/logger";
+import { resolveGopkClipsPaths } from "./paths";
 import { DENIED_APPLICATION_IDS, MAXIMUM_RAW_CLIP_RETENTION_MS } from "./policy-constants";
 
 export interface GopkClipsHostConfig {
@@ -47,12 +52,13 @@ export interface GopkClipsHostConfig {
 	 * The capture daemon's root directory. The handoff drop lives at
 	 * `<captureRoot>/journal-handoff`, and manifest / raw-clip pointers inside
 	 * derivatives must resolve under this root or the sink rejects them.
-	 * Unset means `<agentDir>/gopk-clips/capture`.
+	 * Unset defers to {@link resolveGopkClipsPaths} (shared config, then
+	 * `<agentDir>/gopk-clips/capture`).
 	 */
 	readonly captureRoot?: string;
 	readonly pollIntervalMs: number;
 	readonly cleanupIntervalMs: number;
-	/** Test seam; defaults to `<agentDir>/gopk-clips/activity-ledger.sqlite`. */
+	/** Test seam; unset defers to {@link resolveGopkClipsPaths}. */
 	readonly ledgerPath?: string;
 }
 
@@ -74,13 +80,6 @@ export interface GopkClipsHostLogger {
 const HANDOFF_DIR_NAME = "journal-handoff";
 const REJECTED_SUFFIX = ".rejected";
 
-/** Expand a leading `~` so user-supplied capture roots behave like shell paths. */
-export function expandHomePath(value: string): string {
-	if (value === "~") return os.homedir();
-	if (value.startsWith("~/") || value.startsWith("~\\")) return path.join(os.homedir(), value.slice(2));
-	return value;
-}
-
 /**
  * Build the host and start both loops. Throws when the handoff directory or
  * ledger cannot be created — callers gate session startup on that never
@@ -91,12 +90,11 @@ export function createGopkClipsHost(
 	hostLogger: GopkClipsHostLogger = logger,
 ): GopkClipsHostState {
 	const installId = getInstallId();
-	const captureRoot = path.resolve(
-		config.captureRoot ? expandHomePath(config.captureRoot) : path.join(getAgentDir(), "gopk-clips", "capture"),
-	);
+	// Shared resolver: the daemon and the recall CLI derive the same absolute,
+	// `~`-expanded paths from the same precedence chain.
+	const { captureRoot, ledgerPath } = resolveGopkClipsPaths(config);
 	const handoffDir = path.join(captureRoot, HANDOFF_DIR_NAME);
 	fs.mkdirSync(handoffDir, { recursive: true });
-	const ledgerPath = config.ledgerPath ?? path.join(getAgentDir(), "gopk-clips", "activity-ledger.sqlite");
 	fs.mkdirSync(path.dirname(ledgerPath), { recursive: true });
 
 	const consent: ConsentRecord = {
@@ -166,9 +164,11 @@ export function createGopkClipsHost(
 			}
 			try {
 				// The sink re-validates timestamps, attestation, and path
-				// containment; rejected derivatives are logged (and their raw
-				// clips deleted) inside it. Either way the handoff file is
-				// consumed — replaying a rejected derivative can never succeed.
+				// containment; a derivative it *rejects* is logged (and its raw
+				// clip deleted) inside it and still returns normally, so the
+				// handoff file is consumed — replaying it could never succeed.
+				// A derivative it *throws* on (I/O fault, ledger contention)
+				// leaves the file in place for the next poll to retry.
 				await sinkFor(derivative.sessionId)(derivative);
 				await fsp.unlink(filePath);
 			} catch (error) {
@@ -194,24 +194,35 @@ export function createGopkClipsHost(
 		}
 	};
 
+	// Both passes swallow their own errors, but a rejection escaping one would
+	// poison `inFlight` and — since rescheduling is chained off it — silently
+	// stop the loop for the rest of the host's life. Absorb here so the next
+	// tick is always scheduled.
+	const guard = (pass: () => Promise<void>) => (): Promise<void> =>
+		pass().catch(error => {
+			hostLogger.warn("gopk-clips host pass threw", { error: String(error) });
+		});
+	const guardedPoll = guard(pollOnce);
+	const guardedCleanup = guard(cleanupOnce);
+
 	// setTimeout chains (not setInterval) so passes never overlap, however slow
 	// a pass runs; `inFlight` lets dispose await whichever pass is running.
 	const schedulePoll = (): void => {
 		if (stopped) return;
 		pollTimer = setTimeout(() => {
-			inFlight = inFlight.then(pollOnce).then(schedulePoll);
+			inFlight = inFlight.then(guardedPoll).then(schedulePoll);
 		}, config.pollIntervalMs);
 	};
 	const scheduleCleanup = (): void => {
 		if (stopped) return;
 		cleanupTimer = setTimeout(() => {
-			inFlight = inFlight.then(cleanupOnce).then(scheduleCleanup);
+			inFlight = inFlight.then(guardedCleanup).then(scheduleCleanup);
 		}, config.cleanupIntervalMs);
 	};
 
 	// One immediate pass of each: drain anything a dead host left behind, and
 	// purge raw clips that expired while nothing was running.
-	inFlight = inFlight.then(pollOnce).then(cleanupOnce);
+	inFlight = inFlight.then(guardedPoll).then(guardedCleanup);
 	schedulePoll();
 	scheduleCleanup();
 

--- a/packages/coding-agent/src/gopk-clips/tz-probe-fixture.ts
+++ b/packages/coding-agent/src/gopk-clips/tz-probe-fixture.ts
@@ -1,0 +1,44 @@
+/**
+ * Child-process fixture for the timezone-dependent assertions in read.test.ts.
+ *
+ * The local-time logic in ./read.ts is a function of the *process* timezone,
+ * and a process timezone cannot be changed twice: Bun applies the first
+ * `process.env.TZ` assignment and then ignores both `delete` and any later
+ * re-assignment, so a test that sets TZ in-process re-zones every sibling suite
+ * sharing its `bun test` process for the rest of the run — irreversibly, and
+ * invisibly, since reading `process.env.TZ` back reports the restored value
+ * while `Date` stays on the leaked zone.
+ *
+ * So the zone is set where it is safe to set it: in a child's environment.
+ * This script measures one calendar day under whatever TZ it inherits and
+ * prints the result as JSON.
+ *
+ * Usage: TZ=America/New_York bun tz-probe-fixture.ts 2026-03-08
+ */
+import { floorToLocalHour, localDayWindow, localHourStarts } from "./read";
+
+const date = process.argv[2];
+if (!date) {
+	process.stderr.write("usage: tz-probe-fixture.ts <YYYY-MM-DD>\n");
+	process.exit(2);
+}
+
+const window = localDayWindow(date);
+const starts = localHourStarts(window);
+
+process.stdout.write(
+	JSON.stringify({
+		zone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+		/** Length of the local calendar day: 23, 24, or 25 across a DST shift. */
+		dayHours: (window.endedAt - window.startedAt) / 3_600_000,
+		markCount: starts.length,
+		/** Local hour label of each bucket; a fall-back day repeats one. */
+		labels: starts.map(at => new Date(at).getHours()),
+		/** Minute-of-hour each mark lands on. Non-zero means a mislabelled bucket. */
+		markMinutes: [...new Set(starts.map(at => new Date(at).getMinutes()))],
+		/** floorToLocalHour must be idempotent on a value that is already a mark. */
+		marksAreFixpoints: starts.every(at => floorToLocalHour(at) === at),
+		/** No mark may precede the window it covers (a DST-gap hazard). */
+		firstMarkCoversStart: starts.length > 0 && (starts[0] as number) <= window.startedAt,
+	}),
+);

--- a/packages/coding-agent/src/prompts/tools/activity.md
+++ b/packages/coding-agent/src/prompts/tools/activity.md
@@ -1,0 +1,16 @@
+Look up what the user was actually doing on this machine, from the local Activity Memory timeline.
+
+The timeline is recorded continuously by a separate always-on app that samples the foreground window and stores sanitized metadata — which application, and window titles only. There are no screenshots, no page contents, and no keystrokes. Everything stays on this machine.
+
+Use this when the user refers to their own recent work in a way you cannot answer from the conversation or the repository:
+
+- "what was I working on this morning?"
+- "what did I do yesterday afternoon?"
+- "how long was I in the browser today?"
+- "pick up where I left off before lunch"
+
+Do not use it to infer what a *file* changed or what a command did — git history, the session transcript, and the filesystem are authoritative for that and are far more precise. This tool answers only "which apps and windows had focus, and for how long".
+
+Results are bucketed by local hour, with tracked time and the application mix per hour. Window-title digests are included by default and are the most useful signal for identifying a task; set `includeDigests: false` when you only need the time breakdown.
+
+Coverage is best-effort. Hours where the machine was asleep, the app was not running, or nothing had focus simply report no activity — absence of data is not evidence the user was idle, so do not assert that they were.

--- a/packages/coding-agent/src/screenpipe/session-state.ts
+++ b/packages/coding-agent/src/screenpipe/session-state.ts
@@ -27,8 +27,7 @@ import { getAgentDir, getInstallId, logger } from "@pk-nerdsaver-ai/pi-utils";
 
 // Denied-app list and raw-clip retention live in a dependency-free module so
 // the standalone ingester can share them without importing this screenpipe
-// module; re-exported here for existing call sites.
-export { DENIED_APPLICATION_IDS, MAXIMUM_RAW_CLIP_RETENTION_MS } from "../gopk-clips/policy-constants";
+// module (which pulls in the pi-utils barrel and its native addon).
 import { DENIED_APPLICATION_IDS, MAXIMUM_RAW_CLIP_RETENTION_MS } from "../gopk-clips/policy-constants";
 
 export interface ScreenpipeSessionConfig {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -284,7 +284,6 @@ import ttsrToolReminderTemplate from "../prompts/system/ttsr-tool-reminder.md" w
 import unexpectedStopRetryTemplate from "../prompts/system/unexpected-stop-retry.md" with { type: "text" };
 import { AgentLifecycleManager } from "../registry/agent-lifecycle";
 import { AgentRegistry } from "../registry/agent-registry";
-import type { GopkClipsHostState } from "../gopk-clips/session-state";
 import type { ScreenpipeSessionManager } from "../screenpipe/session-state";
 import {
 	deobfuscateAssistantContent,
@@ -1315,12 +1314,6 @@ export class AgentSession {
 	/** Resolves once the (dynamically imported) manager has been constructed. Set only when the
 	 *  feature is enabled; dispose and session re-binds await it so a slow start cannot leak the poller. */
 	#screenpipeManagerReady?: Promise<void>;
-	/** Gopk-clips handoff host; built when `gopkClips.enabled` is on, torn down in dispose.
-	 *  Not re-bound on session transitions — derivatives carry their own capture session id. */
-	#gopkClipsHost?: GopkClipsHostState;
-	/** Resolves once the (dynamically imported) host has been constructed. Set only when the
-	 *  feature is enabled; dispose awaits it so a slow start cannot leak the poller. */
-	#gopkClipsHostReady?: Promise<void>;
 	/** Session file minted empty by /move; cleaned up at dispose if it never gained real messages. */
 	#movedFromEmptySessionFile?: string;
 	/** Provenance set of built-in tool names in the registry (see AgentSessionConfig.builtInToolNames). */
@@ -1945,7 +1938,11 @@ export class AgentSession {
 
 		if (this.settings.get("screenpipe.enabled") as boolean) this.#startScreenpipeBridge();
 
-		if (this.settings.get("gopkClips.enabled") as boolean) this.#startGopkClipsHost();
+		// Note: gopk-clips activity ingestion is deliberately NOT started here.
+		// The always-on `gopk-ingest` daemon is the single consumer of the
+		// journal-handoff queue and the single writer of the activity ledger;
+		// a session-scoped second consumer would race it on file deletion and
+		// contend for the SQLite write lock. Sessions read the ledger instead.
 
 		// Always subscribe to agent events for internal handling
 		// (session persistence, hooks, auto-compaction, retry logic)
@@ -1976,26 +1973,6 @@ export class AgentSession {
 			})
 			.catch(error => {
 				logger.warn("Failed to start screenpipe activity bridge", { error: String(error) });
-			});
-	}
-
-	// Same passive-observer contract as the screenpipe bridge: a broken host
-	// (unwritable capture root, corrupt ledger) must never stop the session
-	// from starting, and the stack is loaded dynamically for the same
-	// private-workspace-dependency reason.
-	#startGopkClipsHost(): void {
-		const captureRoot = this.settings.get("gopkClips.captureRoot") as string | undefined;
-		const config = {
-			pollIntervalMs: this.settings.get("gopkClips.pollIntervalMs") as number,
-			cleanupIntervalMs: this.settings.get("gopkClips.cleanupIntervalMs") as number,
-			...(captureRoot ? { captureRoot } : {}),
-		};
-		this.#gopkClipsHostReady = import("../gopk-clips/session-state")
-			.then(({ createGopkClipsHost }) => {
-				this.#gopkClipsHost = createGopkClipsHost(config);
-			})
-			.catch(error => {
-				logger.warn("Failed to start gopk-clips activity host", { error: String(error) });
 			});
 	}
 
@@ -4702,19 +4679,6 @@ export class AgentSession {
 				logger.warn("Failed to dispose screenpipe activity bridge", { error: String(error) });
 			}
 			this.#screenpipeManager = undefined;
-		}
-		// Tear down the gopk-clips handoff host (stops its poll/retention loops
-		// and closes its ledger). Same await-the-async-start guard as above.
-		if (this.#gopkClipsHostReady) {
-			const ready = this.#gopkClipsHostReady;
-			this.#gopkClipsHostReady = undefined;
-			try {
-				await ready;
-				await this.#gopkClipsHost?.dispose();
-			} catch (error) {
-				logger.warn("Failed to dispose gopk-clips activity host", { error: String(error) });
-			}
-			this.#gopkClipsHost = undefined;
 		}
 		// Tear down the embeddings subprocess AFTER mnemopi state.dispose:
 		// consolidate-on-dispose may still call `embed()` to store the final

--- a/packages/coding-agent/src/tools/activity.ts
+++ b/packages/coding-agent/src/tools/activity.ts
@@ -1,0 +1,112 @@
+import type { AgentTool, AgentToolResult } from "@pk-nerdsaver-ai/pi-agent-core";
+import { type } from "arktype";
+import {
+	type ActivitySummary,
+	formatTrackedMs,
+	localDateOf,
+	localDayWindow,
+	readActivitySummary,
+} from "../gopk-clips/read";
+import activityDescription from "../prompts/tools/activity.md" with { type: "text" };
+import type { ToolSession } from ".";
+
+const activitySchema = type({
+	"date?": type("string").describe("local calendar day as YYYY-MM-DD; defaults to today"),
+	"lastHours?": type("number").describe("summarize the trailing N hours (1-24) instead of a calendar day"),
+	"includeDigests?": type("boolean").describe("include sampled window-title digests per hour (default true)"),
+});
+
+export type ActivityParams = typeof activitySchema.infer;
+
+const MAX_DIGESTS_PER_HOUR = 4;
+const MAX_APPS_PER_HOUR = 4;
+
+/**
+ * Read-only lookup over the local Activity Memory ledger.
+ *
+ * Strictly a reader: the ledger's single writer is the always-on `gopk-ingest`
+ * daemon, and this tool must never poll the handoff queue, ingest a
+ * derivative, or run retention. See src/gopk-clips/read.ts.
+ */
+export class ActivityTool implements AgentTool<typeof activitySchema> {
+	readonly name = "activity";
+	readonly approval = "read" as const;
+	readonly label = "Activity";
+	readonly description = activityDescription;
+	readonly parameters = activitySchema;
+	readonly strict = true;
+	readonly loadMode = "discoverable";
+	readonly summary = "Look up what the user was working on, from the local activity timeline";
+
+	// Stateless: the ledger location comes from the shared gopk-clips resolver,
+	// not from session state, so there is nothing session-scoped to hold.
+	static createIf(session: ToolSession): ActivityTool | null {
+		return session.settings.get("gopkClips.enabled") ? new ActivityTool() : null;
+	}
+
+	async execute(_id: string, params: ActivityParams): Promise<AgentToolResult> {
+		const includeDigests = params.includeDigests ?? true;
+		let summary: ActivitySummary;
+		let heading: string;
+		try {
+			if (params.lastHours !== undefined) {
+				const hours = Math.floor(params.lastHours);
+				if (!Number.isFinite(hours) || hours < 1 || hours > 24) {
+					throw new Error("lastHours must be a whole number between 1 and 24");
+				}
+				const endedAt = Date.now();
+				summary = readActivitySummary({ window: { startedAt: endedAt - hours * 3_600_000, endedAt } });
+				heading = `Activity — last ${hours}h`;
+			} else {
+				const date = params.date ?? localDateOf();
+				summary = readActivitySummary({ window: localDayWindow(date) });
+				heading = `Activity — ${date}`;
+			}
+		} catch (error) {
+			throw error instanceof Error ? error : new Error(String(error));
+		}
+
+		if (!summary.ledgerPresent) {
+			return {
+				content: [
+					{
+						type: "text",
+						text: "No activity timeline exists yet — the Activity Memory app has not recorded anything on this machine.",
+					},
+				],
+				details: {},
+				useless: true,
+			};
+		}
+
+		const active = summary.hours.filter(hour => hour.trackedMs > 0);
+		if (active.length === 0) {
+			return {
+				content: [{ type: "text", text: `${heading}: no activity recorded in this window.` }],
+				details: {},
+				useless: true,
+			};
+		}
+
+		const lines = [`${heading} — ${summary.clipCount} clips, ${formatTrackedMs(summary.trackedMs)} tracked`, ""];
+		for (const hour of active) {
+			const apps = hour.apps
+				.slice(0, MAX_APPS_PER_HOUR)
+				.map(([app, ms]) => `${app} ${formatTrackedMs(ms)}`)
+				.join(", ");
+			lines.push(`${String(hour.hourLabel).padStart(2, "0")}:00  ${formatTrackedMs(hour.trackedMs)}  ${apps}`);
+			if (includeDigests) {
+				for (const digest of hour.digests.slice(0, MAX_DIGESTS_PER_HOUR)) {
+					lines.push(`    · ${digest.length > 160 ? `${digest.slice(0, 160)}…` : digest}`);
+				}
+			}
+		}
+		lines.push("");
+		lines.push(`Top apps: ${summary.apps.map(([app, ms]) => `${app} ${formatTrackedMs(ms)}`).join(", ")}`);
+
+		return {
+			content: [{ type: "text", text: lines.join("\n") }],
+			details: { clipCount: summary.clipCount, trackedMs: summary.trackedMs, hours: active.length },
+		};
+	}
+}

--- a/packages/coding-agent/src/tools/builtin-names.ts
+++ b/packages/coding-agent/src/tools/builtin-names.ts
@@ -32,6 +32,7 @@ export const BUILTIN_TOOL_NAMES = [
 	"reflect",
 	"learn",
 	"manage_skill",
+	"activity",
 ] as const;
 
 export type BuiltinToolName = (typeof BUILTIN_TOOL_NAMES)[number];

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -36,6 +36,7 @@ import type { DiscoverableTool, DiscoverableToolSearchIndex } from "../tool-disc
 import type { EventBus } from "../utils/event-bus";
 import { WebSearchTool } from "../web/search";
 import type { WorkspaceTree } from "../workspace-tree";
+import { ActivityTool } from "./activity";
 import { AskTool } from "./ask";
 import { AstEditTool } from "./ast-edit";
 import { AstGrepTool } from "./ast-grep";
@@ -572,6 +573,7 @@ export const BUILTIN_TOOLS: Record<BuiltinToolName, ToolFactory> = {
 	reflect: MemoryReflectTool.createIf,
 	learn: LearnTool.createIf,
 	manage_skill: ManageSkillTool.createIf,
+	activity: ActivityTool.createIf,
 };
 
 export const HIDDEN_TOOLS: Record<string, ToolFactory> = {
@@ -728,6 +730,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		if (name === "retain" || name === "recall" || name === "reflect") {
 			return ["hindsight", "mnemopi"].includes(session.settings.get("memory.backend") ?? "");
 		}
+		if (name === "activity") return session.settings.get("gopkClips.enabled");
 		if (name === "manage_skill") return session.settings.get("autolearn.enabled") && (session.taskDepth ?? 0) === 0;
 		if (name === "learn") {
 			return (

--- a/packages/coding-agent/test/tool-discovery/initial-tools.test.ts
+++ b/packages/coding-agent/test/tool-discovery/initial-tools.test.ts
@@ -29,6 +29,7 @@ const allToolsSettings = Settings.isolated({
 	"todo.enabled": true,
 	"memory.backend": "mnemopi",
 	"autolearn.enabled": true,
+	"gopkClips.enabled": true,
 	"tools.discoveryMode": "all",
 });
 


### PR DESCRIPTION
## What

Makes the `gopk-ingest` daemon the sole consumer of the activity handoff queue and the sole writer of the activity ledger, then adds the read side that was missing.

- `AgentSession` no longer starts an ingest host. Sessions read the ledger; they do not drain the queue.
- New `SqliteActivityLedgerReader` opens the ledger read-only and skips the `CREATE TABLE` bootstrap.
- New `src/gopk-clips/read.ts` is the single query + bucketing implementation, shared by the recall CLI and the new tool.
- New `activity` tool (`approval: read`, discoverable, gated on `gopkClips.enabled`) answers "what was I working on this morning?" for a calendar day or a trailing window.
- Path resolution unified behind one resolver: explicit override → shared `config.json` → agent dir, with `~` expansion and absolute resolution on both paths.
- Removes `gopkClips.captureRoot`, `.pollIntervalMs`, `.cleanupIntervalMs`.

## Why

The in-session ingest host and the always-on daemon were both draining `<captureRoot>/journal-handoff` and both writing `activity-ledger.sqlite`. They raced to `unlink` each handoff file, so clips split nondeterministically between whichever ledger each had resolved; when both resolved the same file they contended for SQLite's write lock, which the ledger takes with no WAL and no `busy_timeout`.

Separately, `gopkClips.enabled` gated a capability that did not exist — nothing in-session could read the ledger, so the setting's description was inaccurate and its three companion knobs configured a component that is now gone.

Two local-time bugs are fixed while lifting the bucketing out of `recall-cli.ts`:

- A calendar day was assumed to be 24h, truncating or overrunning DST transition days.
- Buckets were floored to UTC hour boundaries then labelled with `getHours()`, straddling two local hours in half-hour-offset zones (IST, NPT). Buckets now start on real local hour marks and are keyed by absolute instant, so the repeated hour on a fall-back day stays two distinct buckets.

## Testing

- `biome check .` — clean repo-wide (3628 files).
- `tsgo --noEmit` — clean in `coding-agent` and `activity-journal`.
- `bun test src/gopk-clips src/screenpipe test/tool-discovery test/autolearn-tools-gating.test.ts test/sdk-autolearn-active-tools.test.ts` — 116 pass.
- `bun test` in `activity-journal` — 24 pass.
- 18 new tests in `read.test.ts`, TZ-pinned to `America/New_York`, covering an empty ledger, hour-boundary splitting, window clipping, both DST transitions (2026-03-08 = 23h, 2026-11-01 = 25h), and that reading neither creates nor mutates the ledger file.
- Live ledger: `recall-cli --date 2026-07-27` returns the same 101 clips as before the refactor, confirming the new `listOverlapping` query works rather than silently returning nothing.
- `activity` tool exercised directly: gate off → `null`; gate on → real output; empty day → `useless: true`; `lastHours: 99` and `date: 2026-02-30` both rejected.

Deferred follow-ups filed as NER-63 … NER-69 (daemon autostart, WAL/busy_timeout on the writer, poison-file retry bound, denylist hardening, `.omp`/`.ompk` split, unbounded growth, pid locking).

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Activity Memory recall, allowing the agent to summarize recent work by day or trailing hours.
  * Added hourly timelines, top-app summaries, tracked durations, and optional window-title digests.
  * Added read-only activity ledger access without creating or modifying ledger files.
  * Added consistent path handling with home-directory expansion and absolute paths.

* **Bug Fixes**
  * Improved daylight-saving and half-hour timezone handling.
  * Prevented background activity-processing errors from disrupting scheduled operations.

* **Changes**
  * Activity recording is now handled by the always-on Activity Memory service; agent settings provide lookup access only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->