### PR TITLE
fix(activity-journal): open ledger writer in WAL mode with busy_timeout

### DIFF
--- a/packages/activity-journal/CHANGELOG.md
+++ b/packages/activity-journal/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added `ActivityLedgerReader` and `SqliteActivityLedgerReader`: a query-only view over a ledger owned by another process. It opens the sqlite handle read-only and deliberately skips the `CREATE TABLE IF NOT EXISTS` bootstrap that `SqliteActivityLedger` runs, since that DDL takes a write lock and would contend with the live writer on every open. Adds `listOverlapping(startedAt, endedAt)` for windowed queries.
 
+### Changed
+
+- `SqliteActivityLedger` now opens with `PRAGMA journal_mode = WAL` and `PRAGMA busy_timeout = 5000`. WAL lets readers proceed during writes instead of blocking on the rollback journal; the busy timeout turns a lost write race into a short wait instead of an immediate `SQLITE_BUSY` throw. WAL produces `-wal` and `-shm` sidecar files beside the main database — any code that copies, backs up, or deletes the ledger path must account for them.
+
 ## [16.3.0] - 2026-07-23
 
 ### Added

--- a/packages/activity-journal/src/ledger.ts
+++ b/packages/activity-journal/src/ledger.ts
@@ -30,12 +30,22 @@ interface LedgerRow {
  * Local-only source of truth for redacted activity evidence. Raw clip bytes are
  * never written to this database; a short-lived local pointer may be retained
  * solely so the configured lifecycle can delete the source file.
+ *
+ * The writer opens in WAL mode with a 5s busy_timeout. WAL produces
+ * `-wal` and `-shm` sidecar files beside the main database file; any code
+ * that copies, backs up, or deletes the ledger path must account for them.
  */
 export class SqliteActivityLedger implements ActivityLedger {
 	#db: Database;
 
 	constructor(path: string) {
 		this.#db = new Database(path, { create: true, strict: true });
+		// WAL lets readers proceed during writes; busy_timeout turns a lost
+		// write race into a short wait instead of an immediate SQLITE_BUSY
+		// throw. Both apply only to the writer — readers open read-only via
+		// SqliteActivityLedgerReader and are unaffected.
+		this.#db.exec("PRAGMA journal_mode = WAL");
+		this.#db.exec("PRAGMA busy_timeout = 5000");
 		this.#db.exec(`
 			CREATE TABLE IF NOT EXISTS activity_evidence (
 				id TEXT PRIMARY KEY,

--- a/packages/activity-journal/test/gopk-clips.test.ts
+++ b/packages/activity-journal/test/gopk-clips.test.ts
@@ -1,4 +1,8 @@
+import { Database } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { ConsentRecord } from "@pk-nerdsaver-ai/pi-context-policy";
 import {
 	createActivitySynthesisFacts,
@@ -146,5 +150,24 @@ describe("gopk clip activity ingestion", () => {
 		expect(removed).toEqual(["C:\\captures\\clip-1.webm"]);
 		expect(ledger.list()[0]?.rawClip?.deletedAt).toBe("2026-07-13T14:11:00.000Z");
 		ledger.close();
+	});
+});
+
+describe("SqliteActivityLedger durability pragmas", () => {
+	it("persists WAL mode so readers don't block on a writer's rollback journal", () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ledger-pragma-"));
+		const ledgerPath = path.join(tmpDir, "test.sqlite");
+		try {
+			const ledger = new SqliteActivityLedger(ledgerPath);
+			ledger.close();
+			// WAL mode is a database-level property that persists across
+			// connections; re-opening read-only proves the writer set it.
+			const probe = new Database(ledgerPath, { readonly: true, strict: true });
+			const row = probe.query<{ journal_mode: string }, []>("PRAGMA journal_mode").get();
+			probe.close();
+			expect(row?.journal_mode.toLowerCase()).toBe("wal");
+		} finally {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
 	});
 });


### PR DESCRIPTION
## Summary

- `SqliteActivityLedger` now opens with `PRAGMA journal_mode = WAL` and `PRAGMA busy_timeout = 5000` before the `CREATE TABLE` bootstrap
- WAL lets readers proceed during writes instead of blocking on the rollback journal; busy_timeout turns a lost write race into a 5s wait instead of an immediate `SQLITE_BUSY` throw
- Class docstring documents the `-wal`/`-shm` sidecar files so future code that copies/backs up/deletes the ledger path accounts for them
- Added a test that re-opens the ledger read-only and asserts `PRAGMA journal_mode` returns `wal` (proving the mode persists across connections)

Closes [NER-67](https://linear.app/nerdsaver/issue/NER-67/activity-ledger-opens-without-wal-or-busy-timeout)

#### Test plan

- [x] `bun test packages/activity-journal/` — 25/25 pass
- [x] `bun test packages/coding-agent/src/gopk-clips/ packages/coding-agent/src/screenpipe/` — 38/38 pass (no regressions)
- [x] `bun check` — clean (biome + tsgo)
- [ ] Screenpipe bridge regression check confirmed (constructs + closes ledger, no path manipulation)

Generated with [Devin](https://devin.ai)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved activity ledger reliability during concurrent reads and writes.
  * Added a short wait when the database is temporarily busy, reducing immediate write failures.
  * SQLite databases now create `-wal` and `-shm` sidecar files; backups, copies, and cleanup processes should include them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->