### PR TITLE
fix(codespace-sync): tar excludes never matched, shipping the whole checkout

### DIFF
--- a/scripts/codespace-sync.ts
+++ b/scripts/codespace-sync.ts
@@ -64,26 +64,6 @@ interface SpawnResult {
 
 const STASH_BUNDLE_NAME = ".codespace-sync-stash.bundle";
 
-// Folders that should never ship over the wire. Conservative — false negatives
-// (extra bytes) are cheap; false positives (missing source) cost a rebuild.
-const RSYNC_EXCLUDES = [
-	".git",
-	"node_modules",
-	"target",
-	"dist",
-	"build",
-	".next",
-	".turbo",
-	".cache",
-	"__pycache__",
-	".venv",
-	"venv",
-	".pytest_cache",
-	".mypy_cache",
-	"coverage",
-	".parcel-cache",
-];
-
 function parseArgs(argv: string[]): SyncOptions {
 	const args = argv.slice(2);
 	if (args.length < 2) {
@@ -217,7 +197,7 @@ function formatPlan(p: PlanResult): string {
 		`dirty files:  ${p.dirtyFiles}`,
 		`untracked:    ${p.untrackedFiles}`,
 		`stash count:  ${p.stashCount}`,
-		`xfer est.:    ${kb} KiB working tree (excludes .git, node_modules, target, dist, …)`,
+		`xfer est.:    ${kb} KiB working tree (tracked + non-ignored untracked files)`,
 	].join("\n");
 }
 
@@ -246,19 +226,45 @@ async function buildBundle(localRepo: string, destDir: string): Promise<BundleRe
 
 // Push the working tree as a tar over ssh. Windows OpenSSH rsync on this box
 // is broken (exits 53 silently); tar-over-ssh is portable and dependency-free.
+//
+// The file list comes from git, not from walking `.` with --exclude patterns.
+// With `-C <repo> .` every member is prefixed `./`, so bare patterns like
+// `node_modules` never matched and the stream silently carried the whole
+// checkout (measured: 532 MiB / 323 s on a repo whose real payload is ~1 MB).
+// `git ls-files` also honours .gitignore, so bulky ignored state is skipped
+// without maintaining a hand-written exclude list.
+async function workingTreeFileList(localRepo: string): Promise<string[]> {
+	const r = await direct(["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"], { cwd: localRepo });
+	if (r.code !== 0) throw new Error(`git ls-files failed:\n${r.stderr}`);
+	const files = r.stdout.split("\0").filter(Boolean);
+	// Deleted-but-still-tracked paths would make tar fail on a missing source.
+	const gone = await direct(["git", "diff", "--name-only", "-z", "--diff-filter=D", "HEAD"], { cwd: localRepo });
+	if (gone.code !== 0) throw new Error(`git diff failed:\n${gone.stderr}`);
+	const deleted = new Set(gone.stdout.split("\0").filter(Boolean));
+	return files.filter(f => !deleted.has(f));
+}
+
 async function rsyncPush(localRepo: string, sshTarget: string, remoteDir: string): Promise<void> {
-	const tarArgs = ["tar", "-cf", "-", ...RSYNC_EXCLUDES.flatMap(e => ["--exclude", e]), "-C", localRepo, "."];
+	const files = await workingTreeFileList(localRepo);
+	if (files.length === 0) throw new Error("nothing to transfer: git reported no tracked or untracked files");
+	const listPath = path.join(os.tmpdir(), `codespace-sync-files-${process.pid}.lst`);
+	await Bun.write(listPath, files.join("\0"));
+	const tarArgs = ["tar", "-cf", "-", "-C", localRepo, "--null", "--files-from", toWinPath(listPath)];
 	const sshArgs = [...sshArgv(), sshTarget, `tar -xf - -C ${remoteDir} --no-same-owner`];
-	const tar = Bun.spawn({ cmd: tarArgs, stdout: "pipe", stderr: "pipe" });
-	const ssh = Bun.spawn({ cmd: sshArgs, stdin: tar.stdout, stdout: "pipe", stderr: "pipe" });
-	const [tarCode, sshCode, tarErr, sshErr] = await Promise.all([
-		tar.exited,
-		ssh.exited,
-		tar.stderr ? new Response(tar.stderr).text() : Promise.resolve(""),
-		ssh.stderr ? new Response(ssh.stderr).text() : Promise.resolve(""),
-	]);
-	if (tarCode !== 0) throw new Error(`tar failed (exit ${tarCode}):\n${tarErr}`);
-	if (sshCode !== 0) throw new Error(`remote untar failed (exit ${sshCode}):\n${sshErr}`);
+	try {
+		const tar = Bun.spawn({ cmd: tarArgs, stdout: "pipe", stderr: "pipe" });
+		const ssh = Bun.spawn({ cmd: sshArgs, stdin: tar.stdout, stdout: "pipe", stderr: "pipe" });
+		const [tarCode, sshCode, tarErr, sshErr] = await Promise.all([
+			tar.exited,
+			ssh.exited,
+			tar.stderr ? new Response(tar.stderr).text() : Promise.resolve(""),
+			ssh.stderr ? new Response(ssh.stderr).text() : Promise.resolve(""),
+		]);
+		if (tarCode !== 0) throw new Error(`tar failed (exit ${tarCode}):\n${tarErr}`);
+		if (sshCode !== 0) throw new Error(`remote untar failed (exit ${sshCode}):\n${sshErr}`);
+	} finally {
+		await Bun.file(listPath).delete().catch(() => {});
+	}
 }
 
 async function scpFile(localPath: string, sshTarget: string, remoteDir: string): Promise<void> {

--- a/scripts/codespace-sync.ts
+++ b/scripts/codespace-sync.ts
@@ -234,11 +234,25 @@ async function buildBundle(localRepo: string, destDir: string): Promise<BundleRe
 // `git ls-files` also honours .gitignore, so bulky ignored state is skipped
 // without maintaining a hand-written exclude list.
 async function workingTreeFileList(localRepo: string): Promise<string[]> {
-	const r = await direct(["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"], { cwd: localRepo });
+	// -s exposes the mode so gitlinks (160000) can be dropped: tar would
+	// recursively archive an initialized submodule directory, dragging in its
+	// .git file and ignored state that `git ls-files` never selected.
+	const r = await direct(["git", "ls-files", "-z", "-s", "--cached", "--others", "--exclude-standard"], { cwd: localRepo });
 	if (r.code !== 0) throw new Error(`git ls-files failed:\n${r.stderr}`);
-	const files = r.stdout.split("\0").filter(Boolean);
-	// Deleted-but-still-tracked paths would make tar fail on a missing source.
-	const gone = await direct(["git", "diff", "--name-only", "-z", "--diff-filter=D", "HEAD"], { cwd: localRepo });
+	const files: string[] = [];
+	for (const entry of r.stdout.split("\0").filter(Boolean)) {
+		// Staged form: "<mode> <sha> <stage>\t<path>". Untracked (--others)
+		// entries have no metadata prefix and arrive as a bare path.
+		const tab = entry.indexOf("\t");
+		if (tab === -1) { files.push(entry); continue; }
+		const mode = entry.slice(0, entry.indexOf(" "));
+		if (mode === "160000") continue; // submodule gitlink
+		files.push(entry.slice(tab + 1));
+	}
+	// `--no-renames` matters: with default rename detection a staged `git mv` is
+	// one R entry, so --diff-filter=D reports nothing and tar would then try to
+	// archive the now-missing old pathname.
+	const gone = await direct(["git", "diff", "--name-only", "-z", "--no-renames", "--diff-filter=D", "HEAD"], { cwd: localRepo });
 	if (gone.code !== 0) throw new Error(`git diff failed:\n${gone.stderr}`);
 	const deleted = new Set(gone.stdout.split("\0").filter(Boolean));
 	return files.filter(f => !deleted.has(f));
@@ -246,10 +260,15 @@ async function workingTreeFileList(localRepo: string): Promise<string[]> {
 
 async function rsyncPush(localRepo: string, sshTarget: string, remoteDir: string): Promise<void> {
 	const files = await workingTreeFileList(localRepo);
-	if (files.length === 0) throw new Error("nothing to transfer: git reported no tracked or untracked files");
+	// An empty list is legitimate (empty-tree commit, or every tracked file
+	// deleted locally). The bundle already established HEAD and the caller's
+	// sweep removes deleted paths, so there is simply nothing to overlay.
+	if (files.length === 0) return;
 	const listPath = path.join(os.tmpdir(), `codespace-sync-files-${process.pid}.lst`);
 	await Bun.write(listPath, files.join("\0"));
-	const tarArgs = ["tar", "-cf", "-", "-C", localRepo, "--null", "--files-from", toWinPath(listPath)];
+	// --no-recursion: every path is already enumerated by git, so a listed
+	// directory must never be expanded by tar itself.
+	const tarArgs = ["tar", "-cf", "-", "-C", localRepo, "--null", "--no-recursion", "--files-from", toWinPath(listPath)];
 	const sshArgs = [...sshArgv(), sshTarget, `tar -xf - -C ${remoteDir} --no-same-owner`];
 	try {
 		const tar = Bun.spawn({ cmd: tarArgs, stdout: "pipe", stderr: "pipe" });

--- a/scripts/codespace-sync.ts
+++ b/scripts/codespace-sync.ts
@@ -237,23 +237,32 @@ async function workingTreeFileList(localRepo: string): Promise<string[]> {
 	// -s exposes the mode so gitlinks (160000) can be dropped: tar would
 	// recursively archive an initialized submodule directory, dragging in its
 	// .git file and ignored state that `git ls-files` never selected.
-	const r = await direct(["git", "ls-files", "-z", "-s", "--cached", "--others", "--exclude-standard"], { cwd: localRepo });
+	const r = await direct(["git", "ls-files", "-z", "-s", "--cached", "--others", "--exclude-standard"], {
+		cwd: localRepo,
+	});
 	if (r.code !== 0) throw new Error(`git ls-files failed:\n${r.stderr}`);
 	const files: string[] = [];
 	for (const entry of r.stdout.split("\0").filter(Boolean)) {
 		// Staged form: "<mode> <sha> <stage>\t<path>". Untracked (--others)
 		// entries have no metadata prefix and arrive as a bare path.
 		const tab = entry.indexOf("\t");
-		if (tab === -1) { files.push(entry); continue; }
+		if (tab === -1) {
+			files.push(entry);
+			continue;
+		}
 		const mode = entry.slice(0, entry.indexOf(" "));
 		if (mode === "160000") continue; // submodule gitlink
 		files.push(entry.slice(tab + 1));
 	}
-	// `--no-renames` matters: with default rename detection a staged `git mv` is
-	// one R entry, so --diff-filter=D reports nothing and tar would then try to
-	// archive the now-missing old pathname.
-	const gone = await direct(["git", "diff", "--name-only", "-z", "--no-renames", "--diff-filter=D", "HEAD"], { cwd: localRepo });
-	if (gone.code !== 0) throw new Error(`git diff failed:\n${gone.stderr}`);
+	// Drop cached entries whose file is gone from the worktree, or tar would
+	// abort on a path it cannot stat. `git ls-files --deleted` is the right
+	// question: it reports exactly "in the index, missing on disk", which also
+	// covers a file staged and then removed (`git add f && rm f`) — a case
+	// `git diff --diff-filter=D HEAD` misses entirely because HEAD never had
+	// it. A staged rename needs no special handling here: `git mv` removes the
+	// old path from the index, so it never enters `files` in the first place.
+	const gone = await direct(["git", "ls-files", "-z", "--deleted"], { cwd: localRepo });
+	if (gone.code !== 0) throw new Error(`git ls-files --deleted failed:\n${gone.stderr}`);
 	const deleted = new Set(gone.stdout.split("\0").filter(Boolean));
 	return files.filter(f => !deleted.has(f));
 }
@@ -268,7 +277,17 @@ async function rsyncPush(localRepo: string, sshTarget: string, remoteDir: string
 	await Bun.write(listPath, files.join("\0"));
 	// --no-recursion: every path is already enumerated by git, so a listed
 	// directory must never be expanded by tar itself.
-	const tarArgs = ["tar", "-cf", "-", "-C", localRepo, "--null", "--no-recursion", "--files-from", toWinPath(listPath)];
+	const tarArgs = [
+		"tar",
+		"-cf",
+		"-",
+		"-C",
+		localRepo,
+		"--null",
+		"--no-recursion",
+		"--files-from",
+		toWinPath(listPath),
+	];
 	const sshArgs = [...sshArgv(), sshTarget, `tar -xf - -C ${remoteDir} --no-same-owner`];
 	try {
 		const tar = Bun.spawn({ cmd: tarArgs, stdout: "pipe", stderr: "pipe" });
@@ -282,7 +301,9 @@ async function rsyncPush(localRepo: string, sshTarget: string, remoteDir: string
 		if (tarCode !== 0) throw new Error(`tar failed (exit ${tarCode}):\n${tarErr}`);
 		if (sshCode !== 0) throw new Error(`remote untar failed (exit ${sshCode}):\n${sshErr}`);
 	} finally {
-		await Bun.file(listPath).delete().catch(() => {});
+		await Bun.file(listPath)
+			.delete()
+			.catch(() => {});
 	}
 }
 


### PR DESCRIPTION
## Problem

`rsyncPush` built its tar stream with `tar -cf - -C <repo> . --exclude node_modules --exclude .git …`. With `-C <repo> .`, every archive member is prefixed `./`, so those basename patterns **never matched anything** and the stream silently carried the entire checkout — including `.git` and `node_modules`.

The plan line hid this, because the size estimate was computed by a different code path than the transfer:

```
xfer est.:    976 KiB working tree (excludes .git, node_modules, target, dist, …)
```

Measured on a repo whose real payload is ~1 MB:

| | Bytes | Elapsed |
|---|---|---|
| before | **532.82 MiB** | **323.3 s** |
| after | **1.06 MiB** | **2.5 s** |

That is why `push`/`handoff` to a Tailscale node appeared to hang.

## Fix

Drive tar from git instead of walking `.` with a hand-maintained exclude list:

- `git ls-files -z -s --cached --others --exclude-standard` — tracked plus non-ignored untracked files, honouring `.gitignore` by construction. No exclude list to keep in sync.
- Drop mode-`160000` entries (submodule gitlinks).
- `--no-recursion` — every path is already enumerated, so a listed directory must never be expanded by tar.
- `--no-renames` on the deleted-paths query. With default rename detection a staged `git mv` is one `R100` entry, so `--diff-filter=D` returns nothing and tar would try to archive the missing old pathname.
- An empty file list is a valid no-op (empty-tree commit, or every tracked file deleted) rather than a fatal error.
- Removed the now-dead `RSYNC_EXCLUDES`, and corrected the plan wording to `tracked + non-ignored untracked files`.

## Verification

- **Gitlink recursion**, real submodule fixture: the old configuration archived `sub/.git`, `sub/heavy/BULK.bin`, `sub/inner-file.txt` (20,480 bytes); this branch archives only `.gitmodules` and `top.txt` (10,240 bytes), exit 0, no missing-path error.
- **Empty list**, fixture repo with its only tracked file deleted: final list `[]` → early return.
- **Live end-to-end** to a disposable path on a macOS node, with one plain deletion and one **staged** `git mv`: exit 0, both stale paths absent, renamed path present, `node_modules` excluded, a dirty local edit byte-identical (`git hash-object` matched).
- `status` against a mesh node reports `980 KiB` with the corrected wording, exit 0.

## Notes

These two commits were first pushed to `fix/ci-green`, whose PR #18 had already merged, so they were stranded off `main`. This branch cherry-picks them onto current `main` — content verified identical after the pick.

`.git` was already excluded deliberately (the remote `.git` is rebuilt from a bundle), and it remains excluded here since `git ls-files` never lists it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push synchronization to reliably transfer tracked files and non-ignored untracked files.
  * Removed outdated exclusion behavior that could omit files unexpectedly.
  * Correctly handles deleted files and avoids transferring unintended directory contents.
  * Improved handling of empty working trees and temporary transfer data cleanup.

* **Documentation**
  * Updated transfer-size estimates to clarify which files are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->