### PR TITLE
test: restore ESM-namespace spies individually in the runtime bucket (NER-141)

### DIFF
--- a/packages/coding-agent/test/plugin-config.test.ts
+++ b/packages/coding-agent/test/plugin-config.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -10,20 +10,28 @@ describe("plugin config", () => {
 	let tmpRoot: string;
 	let pluginsDir: string;
 	let lockfile: string;
+	// Restore each spy individually rather than via `mock.restore()`. These patch
+	// the pi-utils barrel — a sealed ESM namespace that nearly every other test
+	// file imports — and the global restore walks Bun's whole mock registry to
+	// undo that, segfaulting the shared-process bucket (exit 132) as soon as a
+	// later file touches an overlapping module graph.
+	let spies: Array<{ mockRestore: () => void }> = [];
 
 	beforeEach(async () => {
 		tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-plugin-config-"));
 		pluginsDir = path.join(tmpRoot, "plugins");
 		lockfile = path.join(pluginsDir, "omp-plugins.lock.json");
 
-		spyOn(piUtils, "getPluginsDir").mockReturnValue(pluginsDir);
-		spyOn(piUtils, "getPluginsLockfile").mockReturnValue(lockfile);
-		spyOn(piUtils, "getProjectDir").mockReturnValue(tmpRoot);
-		spyOn(piUtils, "getProjectPluginOverridesPath").mockReturnValue(path.join(tmpRoot, "plugin-overrides.json"));
+		spies = [
+			spyOn(piUtils, "getPluginsDir").mockReturnValue(pluginsDir),
+			spyOn(piUtils, "getPluginsLockfile").mockReturnValue(lockfile),
+			spyOn(piUtils, "getProjectDir").mockReturnValue(tmpRoot),
+			spyOn(piUtils, "getProjectPluginOverridesPath").mockReturnValue(path.join(tmpRoot, "plugin-overrides.json")),
+		];
 	});
 
 	afterEach(async () => {
-		mock.restore();
+		for (const spy of spies.splice(0)) spy.mockRestore();
 		await removeWithRetries(tmpRoot);
 	});
 

--- a/packages/coding-agent/test/plugin-install-local.test.ts
+++ b/packages/coding-agent/test/plugin-install-local.test.ts
@@ -69,18 +69,21 @@ async function createLocalCodexPlugin(root: string): Promise<string> {
 
 describe("runPluginCommand({ action: 'install', args: [<local>] })", () => {
 	let tmpRoot: string;
+	let namespaceSpies: Array<{ mockRestore: () => void }> = [];
 
 	beforeEach(async () => {
 		tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-plugin-install-local-"));
 		const pluginsDir = path.join(tmpRoot, "plugins");
 		await fs.mkdir(path.join(pluginsDir, "node_modules"), { recursive: true });
 
-		spyOn(piUtils, "getPluginsDir").mockReturnValue(pluginsDir);
-		spyOn(piUtils, "getPluginsNodeModules").mockReturnValue(path.join(pluginsDir, "node_modules"));
-		spyOn(piUtils, "getPluginsPackageJson").mockReturnValue(path.join(pluginsDir, "package.json"));
-		spyOn(piUtils, "getPluginsLockfile").mockReturnValue(path.join(tmpRoot, "omp-plugins.lock.json"));
-		spyOn(piUtils, "getProjectDir").mockReturnValue(tmpRoot);
-		spyOn(piUtils, "getProjectPluginOverridesPath").mockReturnValue(path.join(tmpRoot, "plugin-overrides.json"));
+		namespaceSpies = [
+			spyOn(piUtils, "getPluginsDir").mockReturnValue(pluginsDir),
+			spyOn(piUtils, "getPluginsNodeModules").mockReturnValue(path.join(pluginsDir, "node_modules")),
+			spyOn(piUtils, "getPluginsPackageJson").mockReturnValue(path.join(pluginsDir, "package.json")),
+			spyOn(piUtils, "getPluginsLockfile").mockReturnValue(path.join(tmpRoot, "omp-plugins.lock.json")),
+			spyOn(piUtils, "getProjectDir").mockReturnValue(tmpRoot),
+			spyOn(piUtils, "getProjectPluginOverridesPath").mockReturnValue(path.join(tmpRoot, "plugin-overrides.json")),
+		];
 		// runPluginCommand always builds a MarketplaceManager to enumerate
 		// registered marketplaces. Stub the registry list so classification has
 		// no marketplace candidates to confuse local paths with.
@@ -91,10 +94,15 @@ describe("runPluginCommand({ action: 'install', args: [<local>] })", () => {
 		spyOn(console, "error").mockImplementation(() => undefined);
 	});
 	afterEach(async () => {
-		// Restore every spy installed in beforeEach plus the per-test
-		// linkSpy/installSpy/console spies. Without this, the piUtils.*
-		// stubs leak into sibling test files (e.g. marketplace/manager.test.ts
-		// breaks because listMarketplaces() still returns []).
+		// Undo the pi-utils namespace spies FIRST, individually. `mock.restore()`
+		// walking Bun's registry to unpatch a sealed ESM namespace is what
+		// segfaults a shared-process bucket (exit 132); with those already
+		// restored, the blanket call has no namespace patch left to undo.
+		for (const spy of namespaceSpies.splice(0)) spy.mockRestore();
+		// Still needed for the per-test linkSpy/installSpy/console spies and the
+		// MarketplaceManager.prototype stub — those are ordinary objects, not
+		// module namespaces. Without this, listMarketplaces() keeps returning []
+		// and breaks sibling files such as marketplace/manager.test.ts.
 		mock.restore();
 		await fs.rm(tmpRoot, { recursive: true, force: true });
 	});

--- a/packages/coding-agent/test/sdk-mcp-instructions.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-instructions.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -48,10 +48,18 @@ describe("createAgentSession MCP server instructions (deferred UI)", () => {
 		}
 	});
 
+	// Restore this spy individually rather than via `mock.restore()`. It patches a
+	// sealed ESM module namespace (os.homedir), and the global restore walks Bun's
+	// whole mock registry to undo that, segfaulting the process once a later file
+	// in the same run imports an overlapping module graph. Buckets share one
+	// process, so that crash takes every co-resident file down (exit 132).
+	// `vi.restoreAllMocks()` is the same native function — not a safer spelling.
+	let homedirSpy: { mockRestore: () => void } | undefined;
+
 	beforeEach(() => {
 		tempDir = path.join(os.tmpdir(), `pi-sdk-mcp-instr-${Snowflake.next()}`);
 		fs.mkdirSync(tempDir, { recursive: true });
-		spyOn(os, "homedir").mockReturnValue(isolatedHome);
+		homedirSpy = spyOn(os, "homedir").mockReturnValue(isolatedHome);
 		fs.writeFileSync(
 			path.join(tempDir, ".mcp.json"),
 			JSON.stringify({
@@ -66,7 +74,8 @@ describe("createAgentSession MCP server instructions (deferred UI)", () => {
 		if (tempDir && fs.existsSync(tempDir)) {
 			removeSyncWithRetries(tempDir);
 		}
-		mock.restore();
+		homedirSpy?.mockRestore();
+		homedirSpy = undefined;
 	});
 
 	it("folds server instructions into the prompt once deferred discovery connects", async () => {


### PR DESCRIPTION
Closes the runtime-bucket half of the segfault tracked in NER-134 / NER-141.

## Mechanism

Spies on a **sealed ESM module namespace** plus a global `mock.restore()`: the
global restore walks bun's whole mock registry to undo the namespace patch and
segfaults the process (`panic(main thread): Segmentation fault at address 0x4`,
exit 132) once a later file in the same run imports an overlapping module graph.
Buckets share one process, so the crash takes every co-resident file down.

Measured at ~40% of full-bucket runs on Linux.

## Why these files were missed

The earlier sweep (`32b2be62`, `93e09629`) was scoped to
`coding-agent-singleton`. `sdk-mcp-instructions.test.ts` is byte-for-byte the
sibling of the file fixed in `93e09629` — but it lands in **`coding-agent-runtime`**
via the `^test/(acp|mcp|rpc|sdk)[^/]*\.test\.ts$` pattern, while its sibling
carries the `setAgentDir(` singleton content marker. One classifier marker
separated them.

`plugin-config.test.ts` is worse exposure than a node builtin: it patches the
**pi-utils barrel**, which essentially every test file imports, so the "later
file imports an overlapping graph" precondition is satisfied by the very next
file rather than an unlucky pairing.

## `plugin-install-local.test.ts` is handled differently, on purpose

Its blanket `mock.restore()` is load-bearing — it also catches per-test spies on
`PluginManager`/`MarketplaceManager` prototypes and `console`, and removing it
leaks into `marketplace/manager.test.ts`. So the six pi-utils namespace spies are
restored individually **first**, leaving the blanket call with no namespace patch
to unwind. Ordinary objects and class prototypes are not affected by this bug.

## Verification

61 pass / 0 fail across the three modified files plus `marketplace/manager.test.ts`
— the sibling that regresses if the leak reappears. Lint clean.

## Note for future sweeps

`vi.restoreAllMocks` **is** `mock.restore` — identity verified under bun 1.3.14 —
and 231 files use the alias form. Grepping the literal string is exactly how these
two were missed. Contributor guidance still prescribes the alias; tracked in NER-142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)