### PR TITLE
fix(eval): bound kernel-disposal waits so a wedged kernel can't hang teardown (NER-135)

### DIFF
--- a/packages/coding-agent/src/eval/executor-base.ts
+++ b/packages/coding-agent/src/eval/executor-base.ts
@@ -423,3 +423,52 @@ export async function executeWithKernelBase<
 		unregisterBridge?.();
 	}
 }
+
+/**
+ * Default ceiling for kernel-disposal waits. Generous enough that a healthy
+ * kernel always finishes inside it, short enough that a wedged one cannot
+ * outlast a test hook budget or a session teardown.
+ */
+export const KERNEL_DISPOSE_TIMEOUT_MS = 10_000;
+
+/**
+ * `Promise.allSettled` with a ceiling.
+ *
+ * Kernel disposal awaits two things that can block indefinitely: a *starting*
+ * kernel's boot promise (Julia's cold-start JIT is the worst offender) and
+ * `kernel.shutdown()` on a wedged process. Neither has an internal timeout, so
+ * a single stuck kernel hangs disposal forever — which in tests blew a 35s
+ * beforeEach/afterEach hook budget and failed a test whose assertions had all
+ * passed, and in a live session would stall teardown.
+ *
+ * On timeout every outstanding entry is reported as `rejected`, which is the
+ * path every caller already handles: log "shutdown not confirmed" and re-register
+ * the session rather than dropping it. So a timeout degrades to the existing
+ * unconfirmed-shutdown behaviour instead of inventing a new one.
+ */
+export async function settleWithin<T>(
+	promises: ReadonlyArray<Promise<T>>,
+	timeoutMs: number = KERNEL_DISPOSE_TIMEOUT_MS,
+): Promise<PromiseSettledResult<T>[]> {
+	if (promises.length === 0) return [];
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<PromiseSettledResult<T>[]>(resolve => {
+		timer = setTimeout(
+			() =>
+				resolve(
+					promises.map(() => ({
+						status: "rejected" as const,
+						reason: new Error(`kernel disposal timed out after ${timeoutMs}ms`),
+					})),
+				),
+			timeoutMs,
+		);
+		// Never let the ceiling itself keep the process alive.
+		(timer as { unref?: () => void }).unref?.();
+	});
+	try {
+		return await Promise.race([Promise.allSettled(promises), timeout]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}

--- a/packages/coding-agent/src/eval/jl/executor.ts
+++ b/packages/coding-agent/src/eval/jl/executor.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import { getProjectDir, logger } from "@pk-nerdsaver-ai/pi-utils";
 import type { ToolSession } from "../../tools";
-import { attachSessionOwner, createCancelledKernelResult, executeWithKernelBase } from "../executor-base";
+import { attachSessionOwner, createCancelledKernelResult, executeWithKernelBase, settleWithin } from "../executor-base";
 import { ensurePyToolBridge, type PyToolBridgeInfo } from "../py/tool-bridge";
 import type { EvalDisplayOutput, EvalStatusEvent } from "../types";
 import {
@@ -382,14 +382,14 @@ export async function disposeJuliaKernelSessionsByOwner(ownerId: string): Promis
 	for (const session of toShutdown) {
 		if (sessions.get(session.sessionKey) === session) sessions.delete(session.sessionKey);
 	}
-	const started = await Promise.allSettled(startingToShutdown.map(starting => starting.promise));
+	const started = await settleWithin(startingToShutdown.map(starting => starting.promise));
 	for (const result of started) {
 		if (result.status !== "fulfilled") continue;
 		const session = result.value;
 		if (sessions.get(session.sessionKey) === session) sessions.delete(session.sessionKey);
 		toShutdown.push(session);
 	}
-	const results = await Promise.allSettled(toShutdown.map(session => session.kernel.shutdown()));
+	const results = await settleWithin(toShutdown.map(session => session.kernel.shutdown()));
 	for (let i = 0; i < toShutdown.length; i += 1) {
 		const session = toShutdown[i];
 		const result = results[i];

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -15,6 +15,7 @@ import {
 	createCancelledKernelResult,
 	getExecutionDeadlineMs,
 	getRemainingTimeoutMs,
+	settleWithin,
 	waitForPromiseWithCancellation,
 } from "../executor-base";
 import type { JsStatusEvent } from "../js/shared/types";
@@ -420,7 +421,7 @@ export async function disposeKernelSessionsByOwner(ownerId: string): Promise<voi
 	for (const session of toShutdown) {
 		if (sessions.get(session.sessionKey) === session) sessions.delete(session.sessionKey);
 	}
-	const results = await Promise.allSettled(toShutdown.map(session => session.kernel.shutdown()));
+	const results = await settleWithin(toShutdown.map(session => session.kernel.shutdown()));
 	for (let i = 0; i < toShutdown.length; i += 1) {
 		const session = toShutdown[i];
 		const result = results[i];

--- a/packages/coding-agent/src/eval/rb/executor.ts
+++ b/packages/coding-agent/src/eval/rb/executor.ts
@@ -13,6 +13,7 @@ import {
 	getRemainingTimeoutMs,
 	isCancellationError,
 	isTimedOutCancellation,
+	settleWithin,
 	waitForPromiseWithCancellation,
 } from "../executor-base";
 import type { JsStatusEvent } from "../js/shared/types";
@@ -335,14 +336,14 @@ export async function disposeRubyKernelSessionsByOwner(ownerId: string): Promise
 	for (const session of toShutdown) {
 		if (sessions.get(session.sessionKey) === session) sessions.delete(session.sessionKey);
 	}
-	const started = await Promise.allSettled(startingToShutdown.map(starting => starting.promise));
+	const started = await settleWithin(startingToShutdown.map(starting => starting.promise));
 	for (const result of started) {
 		if (result.status !== "fulfilled") continue;
 		const session = result.value;
 		if (sessions.get(session.sessionKey) === session) sessions.delete(session.sessionKey);
 		toShutdown.push(session);
 	}
-	const results = await Promise.allSettled(toShutdown.map(session => session.kernel.shutdown()));
+	const results = await settleWithin(toShutdown.map(session => session.kernel.shutdown()));
 	for (let i = 0; i < toShutdown.length; i += 1) {
 		const session = toShutdown[i];
 		const result = results[i];


### PR DESCRIPTION
## The failure

```
(fail) eval Julia prelude helpers > supports output ranges, JSON queries, metadata, and ANSI stripping [35003.98ms]
  ^ a beforeEach/afterEach hook timed out for this test.
```

The **assertions all passed**. `disposeJuliaKernelSessionsByOwner` in `afterEach`
blocked ~35s and blew the hook budget. The trailing
`expect(result.exitCode).toBe(0) → undefined` is fallout from the kernel never
coming up, reported as "Unhandled error between tests" — not a second defect.

It sat in **chunk 1 of 51** of `coding-agent-native`, so it hid the other 50.

## Root cause

Disposal awaited two things with no ceiling:

- `Promise.allSettled(startingToShutdown.map(s => s.promise))` — a *starting*
  kernel's boot promise. Julia's cold-start JIT/precompilation is the worst
  offender on a loaded runner.
- `Promise.allSettled(toShutdown.map(s => s.kernel.shutdown()))` — shutdown on a
  wedged process.

## Fix

`settleWithin()` in `executor-base` — `Promise.allSettled` with a 10s ceiling.

The important property: **on timeout, every outstanding entry is reported as
`rejected`, which is the path all three callers already handle** — log
"shutdown not confirmed" and re-register the session rather than dropping it. A
timeout therefore degrades to the existing unconfirmed-shutdown behaviour rather
than inventing new semantics. The timer is `unref`'d so the ceiling itself never
holds the process open.

## Why all three executors

`py/` and `rb/` carry the identical unbounded shape — Ruby has both awaits,
Python has the shutdown one. Fixing only Julia would leave two copies of the same
latent hang.

## Why source, not test

The same hang stalls a **live session's** teardown, not just a test hook. Bounding
the test's `afterEach` would have hidden a real robustness bug.

## Verification

Eval suite: 86 pass / 4 fail — **byte-identical to the same 4 failures on `main`**
(pre-existing Windows Python-eval issues). This change neither causes nor fixes
them. Lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)