### PR TITLE
test: restore os.homedir spies individually in four singleton-bucket files (NER-134)

### DIFF
--- a/packages/coding-agent/test/discovery/claude-commands.test.ts
+++ b/packages/coding-agent/test/discovery/claude-commands.test.ts
@@ -19,6 +19,12 @@ describe("Claude Code slash command discovery", () => {
 	let project = "";
 	let originalHome: string | undefined;
 
+	// Restore this spy individually rather than via `vi.restoreAllMocks()`.
+	// That call IS `mock.restore()` (same native function), and the global
+	// restore walks Bun's mock registry to unpatch the sealed `os` namespace,
+	// segfaulting this shared-process bucket (exit 132) once a later file
+	// imports an overlapping module graph.
+	let homedirSpy: { mockRestore: () => void } | undefined;
 	beforeEach(async () => {
 		clearFsCache();
 		resetSettingsForTest();
@@ -27,14 +33,15 @@ describe("Claude Code slash command discovery", () => {
 		home = path.join(root, "home");
 		project = path.join(root, "project");
 		process.env.HOME = home;
-		vi.spyOn(os, "homedir").mockReturnValue(home);
+		homedirSpy = vi.spyOn(os, "homedir").mockReturnValue(home);
 		await fs.mkdir(path.join(project, ".git"), { recursive: true });
 	});
 
 	afterEach(async () => {
 		clearFsCache();
 		resetSettingsForTest();
-		vi.restoreAllMocks();
+		homedirSpy?.mockRestore();
+		homedirSpy = undefined;
 		if (originalHome === undefined) {
 			delete process.env.HOME;
 		} else {

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -64,19 +64,26 @@ describe("listClaudePluginRoots", () => {
 	let tempDir: string;
 	let originalHome: string | undefined;
 
+	// Restore this spy individually rather than via `vi.restoreAllMocks()`.
+	// That call IS `mock.restore()` (same native function), and the global
+	// restore walks Bun's mock registry to unpatch the sealed `os` namespace,
+	// segfaulting this shared-process bucket (exit 132) once a later file
+	// imports an overlapping module graph.
+	let homedirSpy: { mockRestore: () => void } | undefined;
 	beforeEach(async () => {
 		clearClaudePluginRootsCache();
 		clearFsCache();
 		originalHome = process.env.HOME;
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "claude-plugins-test-"));
 		process.env.HOME = tempDir;
-		vi.spyOn(os, "homedir").mockReturnValue(tempDir);
+		homedirSpy = vi.spyOn(os, "homedir").mockReturnValue(tempDir);
 	});
 
 	afterEach(async () => {
 		clearClaudePluginRootsCache();
 		clearFsCache();
-		vi.restoreAllMocks();
+		homedirSpy?.mockRestore();
+		homedirSpy = undefined;
 		if (originalHome === undefined) {
 			delete process.env.HOME;
 		} else {

--- a/packages/coding-agent/test/discovery/disabled-extensions.test.ts
+++ b/packages/coding-agent/test/discovery/disabled-extensions.test.ts
@@ -12,12 +12,18 @@ describe("disabledExtensions runtime filtering", () => {
 	let tempHomeDir = "";
 	let originalHome: string | undefined;
 
+	// Restore this spy individually rather than via `vi.restoreAllMocks()`.
+	// That call IS `mock.restore()` (same native function), and the global
+	// restore walks Bun's mock registry to unpatch the sealed `os` namespace,
+	// segfaulting this shared-process bucket (exit 132) once a later file
+	// imports an overlapping module graph.
+	let homedirSpy: { mockRestore: () => void } | undefined;
 	beforeEach(async () => {
 		resetSettingsForTest();
 		originalHome = process.env.HOME;
 		tempHomeDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-disabled-ext-home-"));
 		process.env.HOME = tempHomeDir;
-		vi.spyOn(os, "homedir").mockReturnValue(tempHomeDir);
+		homedirSpy = vi.spyOn(os, "homedir").mockReturnValue(tempHomeDir);
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-disabled-ext-"));
 		await fs.mkdir(path.join(tempDir, ".ompk"), { recursive: true });
 		await fs.writeFile(path.join(tempDir, ".ompk", "AGENTS.md"), "# project instructions\n");
@@ -34,7 +40,8 @@ describe("disabledExtensions runtime filtering", () => {
 
 	afterEach(async () => {
 		resetSettingsForTest();
-		vi.restoreAllMocks();
+		homedirSpy?.mockRestore();
+		homedirSpy = undefined;
 		if (originalHome === undefined) {
 			delete process.env.HOME;
 		} else {

--- a/packages/coding-agent/test/issue-851-repro.test.ts
+++ b/packages/coding-agent/test/issue-851-repro.test.ts
@@ -13,19 +13,26 @@ describe("issue-851: claude-plugins loads flat .mcp.json shape", () => {
 	let tempDir: string;
 	let originalHome: string | undefined;
 
+	// Restore this spy individually rather than via `vi.restoreAllMocks()`.
+	// That call IS `mock.restore()` (same native function), and the global
+	// restore walks Bun's mock registry to unpatch the sealed `os` namespace,
+	// segfaulting this shared-process bucket (exit 132) once a later file
+	// imports an overlapping module graph.
+	let homedirSpy: { mockRestore: () => void } | undefined;
 	beforeEach(async () => {
 		clearClaudePluginRootsCache();
 		clearFsCache();
 		originalHome = process.env.HOME;
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "issue-851-"));
 		process.env.HOME = tempDir;
-		vi.spyOn(os, "homedir").mockReturnValue(tempDir);
+		homedirSpy = vi.spyOn(os, "homedir").mockReturnValue(tempDir);
 	});
 
 	afterEach(async () => {
 		clearClaudePluginRootsCache();
 		clearFsCache();
-		vi.restoreAllMocks();
+		homedirSpy?.mockRestore();
+		homedirSpy = undefined;
 		if (originalHome === undefined) delete process.env.HOME;
 		else process.env.HOME = originalHome;
 		await removeWithRetries(tempDir);


### PR DESCRIPTION
## Evidence this was still broken

The singleton bucket segfaulted again on PR #20's branch — `exit 132`,
`panic(main thread): Segmentation fault at address 0x4` — even though **that PR
only touched runtime-bucket files**. So `93e09629` did not close this.

Its commit message claimed to have removed "the last remaining global
`mock.restore()`" in the bucket. That claim was measured with a grep that could
not see the alias.

## Why the earlier sweep missed 11 files

`vi.restoreAllMocks` **is** `mock.restore` — identity verified under bun 1.3.14.

Scanning all 62 singleton-bucket files for the actual hazard — a blanket restore
in a file that **also spies a module namespace** — finds **11**. Every single one
spells it `vi.restoreAllMocks()`.

(The detector excludes comments, so it doesn't match the explanatory comments the
earlier fixes added — an easy way to get a falsely reassuring count.)

## This PR: the four unambiguous ones

Each has **exactly one** `spyOn` call, so the blanket restore was doing nothing
else and removing it cannot change other behaviour:

- `test/discovery/claude-commands.test.ts`
- `test/discovery/claude-plugins.test.ts`
- `test/discovery/disabled-extensions.test.ts`
- `test/issue-851-repro.test.ts`

## Seven deliberately left

`agent-bridge`, `agent-session-auto-compaction-queue`,
`agent-session-python-cleanup`, `issue-846-repro`, `issue-956-repro`,
`memories-runtime`, `utils/open` — these spy **multiple** namespaces and their
blanket restore may be load-bearing for other spies. `plugin-install-local` showed
that removing it blind leaks into sibling files, so each needs reading rather than
a mechanical rewrite.

**This PR therefore reduces the crash surface; it does not prove the flake gone.**
The rate was ~40% of full-bucket runs, so a single green CI run is not evidence.

## Verification

27 pass / 2 fail. The 2 are byte-identical to `main` — `disabled-extensions`'
Windows-only `HOME` mock (Windows reads `USERPROFILE`), which is green on Linux CI.
Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)