### PR TITLE
fix(capability): drop the pinned Settings when the singleton is reset (NER-144)

### DIFF
--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -10,6 +10,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { getProjectDir, logger } from "@pk-nerdsaver-ai/pi-utils";
 
+import { registerSettingsResetHook } from "../config/reset-hooks";
 import type { Settings } from "../config/settings";
 import { clearCache as clearFsCache, findRepoRoot, cacheStats as fsCacheStats, invalidate as invalidateFs } from "./fs";
 import type {
@@ -41,6 +42,28 @@ const disabledProviders = new Set<string>();
 
 /** Settings manager for persistence (if set) */
 let settings: Settings | null = null;
+
+/**
+ * Drop the pinned `Settings` reference whenever the settings singleton is reset.
+ *
+ * Without this, `initializeWithSettings` pins an object that outlives
+ * `resetSettingsForTest()`: every later `loadCapability()` in the process keeps
+ * reading `disabledExtensions` off the discarded instance. Because test buckets
+ * share one process, a single test that disabled an extension suppressed it for
+ * every subsequent file in the run.
+ *
+ * Registered lazily on first `initializeWithSettings` so importing this module
+ * has no side effect, and idempotent via the hook set.
+ */
+let capabilityResetHookRegistered = false;
+function registerCapabilitySettingsReset(): void {
+	if (capabilityResetHookRegistered) return;
+	capabilityResetHookRegistered = true;
+	registerSettingsResetHook(() => {
+		settings = null;
+		disabledProviders.clear();
+	});
+}
 
 // =============================================================================
 // Registration API
@@ -249,6 +272,7 @@ export async function loadCapability<T>(capabilityId: string, options: LoadOptio
  * Call this once on startup to enable persistent provider state.
  */
 export function initializeWithSettings(activeSettings: Settings): void {
+	registerCapabilitySettingsReset();
 	settings = activeSettings;
 	// Load disabled providers from settings
 	const disabled = settings.get("disabledProviders");

--- a/packages/coding-agent/src/config/reset-hooks.ts
+++ b/packages/coding-agent/src/config/reset-hooks.ts
@@ -1,0 +1,31 @@
+/**
+ * Reset hooks for modules that pin their own reference to the `Settings`
+ * singleton.
+ *
+ * Clearing the singleton is not enough on its own: a module that captured the
+ * old object keeps reading from it forever. `capability/index.ts` does exactly
+ * that via `initializeWithSettings`, so a test that disabled an extension leaked
+ * its `disabledExtensions` filter into every later file in the same process —
+ * and test buckets share one process.
+ *
+ * This module deliberately imports NOTHING. `config/settings.ts` and
+ * `capability/index.ts` both depend on it, and a direct edge between those two
+ * is a cycle: `capability/index` → `config/settings` → … → `capability/settings`
+ * → `capability/index`, which trips a TDZ `ReferenceError: Cannot access
+ * 'capabilities' before initialization` at import time. Routing through a leaf
+ * module keeps the graph acyclic.
+ */
+
+const settingsResetHooks = new Set<() => void>();
+
+/** Register a callback invoked whenever the settings singleton is reset for tests. */
+export function registerSettingsResetHook(hook: () => void): void {
+	settingsResetHooks.add(hook);
+}
+
+/** Invoke every registered reset hook. Called by `resetSettingsForTest()`. */
+export function runSettingsResetHooks(): void {
+	for (const hook of settingsResetHooks) {
+		hook();
+	}
+}

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -35,6 +35,7 @@ import { AgentStorage } from "../session/agent-storage";
 import { normalizeToolName } from "../tools/builtin-names";
 import { type EditMode, normalizeEditMode } from "../utils/edit-mode";
 import { withFileLock } from "./file-lock";
+import { runSettingsResetHooks } from "./reset-hooks";
 import {
 	type AgentPolicySettings,
 	type BashInterceptorRule,
@@ -1552,6 +1553,9 @@ export function resetSettingsForTest(): void {
 	globalInstance = null;
 	globalInstancePromise = null;
 	clearBoundSettingsMethods();
+	// Modules that pinned their own reference to the discarded instance must drop
+	// it too — see config/reset-hooks.ts.
+	runSettingsResetHooks();
 }
 
 /**

--- a/packages/coding-agent/test/capability/settings-reset.test.ts
+++ b/packages/coding-agent/test/capability/settings-reset.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type ContextFile, contextFileCapability } from "@pk-nerdsaver-ai/pi-coding-agent/capability/context-file";
+import { resetSettingsForTest, Settings } from "@pk-nerdsaver-ai/pi-coding-agent/config/settings";
+import { initializeWithSettings, loadCapability } from "@pk-nerdsaver-ai/pi-coding-agent/discovery";
+import { removeWithRetries } from "@pk-nerdsaver-ai/pi-utils";
+
+/**
+ * Regression guard for the capability module pinning a discarded `Settings`.
+ *
+ * `initializeWithSettings` stores the instance in a module-level variable.
+ * Clearing the singleton via `resetSettingsForTest()` did NOT clear that
+ * reference, so every later `loadCapability()` in the process kept reading
+ * `disabledExtensions` off the dead object. Test buckets share one process, so a
+ * single file that disabled an extension suppressed it for the rest of the run —
+ * `test/discovery/disabled-extensions.test.ts` poisoning `system-prompt-dedup`
+ * dozens of files later.
+ *
+ * Asserting on the specific project file rather than a count keeps this honest:
+ * user-level discovery may contribute additional entries depending on the host.
+ */
+describe("capability settings pin", () => {
+	let projectDir = "";
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-cap-reset-"));
+		await fs.mkdir(path.join(projectDir, ".ompk"), { recursive: true });
+		await fs.writeFile(path.join(projectDir, ".ompk", "AGENTS.md"), "# project instructions\n");
+	});
+
+	afterEach(async () => {
+		resetSettingsForTest();
+		await removeWithRetries(projectDir).catch(() => {});
+	});
+
+	const projectAgentsPresent = (items: ReadonlyArray<ContextFile>): boolean =>
+		items.some(item => path.resolve(item.path) === path.resolve(projectDir, ".ompk", "AGENTS.md"));
+
+	test("resetSettingsForTest drops the pinned settings so disabledExtensions stops applying", async () => {
+		const disabling = await Settings.init({
+			inMemory: true,
+			cwd: projectDir,
+			overrides: { disabledExtensions: ["context-file:project:AGENTS.md"] },
+		});
+		initializeWithSettings(disabling);
+
+		const whileDisabled = await loadCapability<ContextFile>(contextFileCapability.id, { cwd: projectDir });
+		expect(projectAgentsPresent(whileDisabled.items)).toBe(false);
+
+		// The pin must not outlive the singleton. Before the fix the capability
+		// module kept reading `disabling` here and the file stayed suppressed.
+		resetSettingsForTest();
+
+		const afterReset = await loadCapability<ContextFile>(contextFileCapability.id, { cwd: projectDir });
+		expect(projectAgentsPresent(afterReset.items)).toBe(true);
+	});
+});


### PR DESCRIPTION
## The bug

`initializeWithSettings()` stores the `Settings` instance in a module-level variable. `resetSettingsForTest()` cleared the singleton but **not that reference**, so every later `loadCapability()` in the process kept reading `disabledExtensions` off the discarded object.

Test buckets share one process, so one file that disabled an extension suppressed it for the rest of the run — `test/discovery/disabled-extensions.test.ts` poisoning `test/system-prompt-dedup.test.ts` dozens of files later. Currently masked only by an accident of file ordering, which `--only-failures` replay can change at any time.

## The import cycle, learned the hard way

The obvious fix — import `registerSettingsResetHook` from `config/settings` into `capability/index` — is a **cycle**:

```
capability/index → config/settings → capability/settings → capability/index
```

It throws at import time from the TDZ:

```
ReferenceError: Cannot access 'capabilities' before initialization
    at defineCapability (src/capability/index.ts:75:6)
    at src/capability/settings.ts:23:35
```

So registration routes through a new **leaf** module, `config/reset-hooks.ts`, which imports nothing. Both sides depend on it; neither depends on the other.

## The test is a real guard

`test/capability/settings-reset.test.ts` **fails on current `main`**:

```
Expected: true
Received: false
(fail) capability settings pin > resetSettingsForTest drops the pinned settings…
```

and passes with the fix. It cannot rot into a tautology. It asserts on the specific project file rather than a count, since user-level discovery contributes host-dependent extras.

## Deliberately not fixed here

`contextFileCapability` keys extensions by `path.basename(file.path)` (`capability/context-file.ts:37`), so one disabled id suppresses **every** same-named file at that level. Confirmed as claimed — but those ids are persisted in user settings, so changing the format silently **re-enables previously-disabled files**. That needs a migration, not a one-line change. Left open in NER-144.

## Verification

18 pass / 2 fail across `capability`, `disabled-extensions` and `system-prompt-dedup`. The 2 are byte-identical to `main` — the Windows-only `HOME` mock (Windows reads `USERPROFILE`), green on Linux CI. Lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)