### PR TITLE
docs(changelog): note that pre-rename entries refer to .omp, not .ompk (NER-140)

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+> **Note on `.omp` paths below.** The configuration directory was renamed to
+> `~/.ompk` (and project-local `.omp/` to `.ompk/`). Entries dated before that
+> rename still say `.omp` because that is what those releases actually shipped;
+> they are left unedited so this history stays accurate. When following an older
+> entry today, read `.omp` as `.ompk`.
+
 ## [Unreleased]
 
 ## [16.3.0] - 2026-07-23

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+> **Note on `.omp` paths below.** The configuration directory was renamed to
+> `~/.ompk` (and project-local `.omp/` to `.ompk/`). Entries dated before that
+> rename still say `.omp` because that is what those releases actually shipped;
+> they are left unedited so this history stays accurate. When following an older
+> entry today, read `.omp` as `.ompk`.
+
 ## [Unreleased]
 
 ## [16.3.0] - 2026-07-23

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+> **Note on `.omp` paths below.** The configuration directory was renamed to
+> `~/.ompk` (and project-local `.omp/` to `.ompk/`). Entries dated before that
+> rename still say `.omp` because that is what those releases actually shipped;
+> they are left unedited so this history stays accurate. When following an older
+> entry today, read `.omp` as `.ompk`.
+
 ## [Unreleased]
 
 ### Added

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+> **Note on `.omp` paths below.** The configuration directory was renamed to
+> `~/.ompk` (and project-local `.omp/` to `.ompk/`). Entries dated before that
+> rename still say `.omp` because that is what those releases actually shipped;
+> they are left unedited so this history stays accurate. When following an older
+> entry today, read `.omp` as `.ompk`.
+
 ## [Unreleased]
 
 ## [16.3.0] - 2026-07-23

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+> **Note on `.omp` paths below.** The configuration directory was renamed to
+> `~/.ompk` (and project-local `.omp/` to `.ompk/`). Entries dated before that
+> rename still say `.omp` because that is what those releases actually shipped;
+> they are left unedited so this history stays accurate. When following an older
+> entry today, read `.omp` as `.ompk`.
+
 ## [Unreleased]
 
 ## [16.1.23] - 2026-06-26

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+> **Note on `.omp` paths below.** The configuration directory was renamed to
+> `~/.ompk` (and project-local `.omp/` to `.ompk/`). Entries dated before that
+> rename still say `.omp` because that is what those releases actually shipped;
+> they are left unedited so this history stays accurate. When following an older
+> entry today, read `.omp` as `.ompk`.
+
 ## [Unreleased]
 
 ## [16.3.0] - 2026-07-23


### PR DESCRIPTION
Implements **option 3** of the three in NER-140 — the one I recommended there.

## Why not rewrite the entries

The `.omp` → `.ompk` sweep in PR #18 deliberately skipped CHANGELOGs. A changelog records *what shipped*, and those releases genuinely did read `~/.omp/`. Rewriting entries such as "Custom `~/.omp/agent/share.{ts,js,mjs}` handlers keep the legacy HTML-file contract" would make the history false.

## Why not leave it bare

A reader grepping the changelog for configuration paths gets stale guidance with nothing marking it as historical.

So: a banner at the top of each affected changelog, **entries untouched**.

## Checked before writing

68 references across 6 changelogs, and **none of them sit in an `[Unreleased]` section**.

That check mattered. An `.omp` reference in unreleased work would describe *current* behaviour — genuinely wrong, needing correction rather than annotation. All 68 are in dated entries, so annotating is the right treatment and no entry needed editing.

| file | refs |
|---|---|
| `packages/coding-agent/CHANGELOG.md` | 56 |
| `packages/natives/CHANGELOG.md` | 6 |
| `packages/ai/CHANGELOG.md` | 2 |
| `packages/utils/CHANGELOG.md` | 2 |
| `packages/catalog/CHANGELOG.md` | 1 |
| `packages/mnemopi/CHANGELOG.md` | 1 |

**Correction:** NER-140 said 57 references. The accurate count is 68 — the earlier figure came from a looser pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)