### PR TITLE
test: per-file spy trackers in four more singleton-bucket files (NER-134)

### DIFF
--- a/packages/coding-agent/test/issue-846-repro.test.ts
+++ b/packages/coding-agent/test/issue-846-repro.test.ts
@@ -65,12 +65,31 @@ function createModelRegistry(model: Model): ModelRegistryLike {
 	};
 }
 
+// Per-file spy tracking. `vi.restoreAllMocks()` IS `mock.restore()` — the same
+// native function — and that global restore walks Bun's whole mock registry to
+// unpatch spies. When one of them patched a sealed ESM module namespace, the
+// walk segfaults the process (exit 132) once a later file in the same run
+// imports an overlapping module graph, taking the shared-process bucket with it.
+//
+// The tracker is deliberately PER FILE. A module-shared array would let one
+// file's teardown restore another file's still-live spies — the same cross-file
+// leak, pointing the other way.
+const trackedSpies: Array<{ mockRestore: () => void }> = [];
+function trackedSpyOn<T extends object, K extends keyof T>(obj: T, key: K) {
+	const spy = vi.spyOn(obj, key);
+	trackedSpies.push(spy as unknown as { mockRestore: () => void });
+	return spy;
+}
+function restoreTrackedSpies(): void {
+	for (const spy of trackedSpies.splice(0).reverse()) spy.mockRestore();
+}
+
 describe("issue #846: phase1 stage1 failures must be logged", () => {
 	let savedXdgData: string | undefined;
 	let savedXdgState: string | undefined;
 
 	beforeEach(() => {
-		vi.restoreAllMocks();
+		restoreTrackedSpies();
 		savedXdgData = process.env.XDG_DATA_HOME;
 		savedXdgState = process.env.XDG_STATE_HOME;
 		process.env.XDG_DATA_HOME = "/nonexistent-xdg-data";
@@ -78,7 +97,7 @@ describe("issue #846: phase1 stage1 failures must be logged", () => {
 	});
 
 	afterEach(async () => {
-		vi.restoreAllMocks();
+		restoreTrackedSpies();
 		process.env.XDG_DATA_HOME = savedXdgData;
 		process.env.XDG_STATE_HOME = savedXdgState;
 		await Bun.sleep(0);
@@ -132,8 +151,8 @@ describe("issue #846: phase1 stage1 failures must be logged", () => {
 		]);
 		memoryStorage.closeMemoryDb(db);
 
-		const completeSpy = vi.spyOn(ai, "completeSimple");
-		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+		const completeSpy = trackedSpyOn(ai, "completeSimple");
+		const errorSpy = trackedSpyOn(logger, "error").mockImplementation(() => {});
 
 		// Use a sessionish object that matches the AgentSession surface used by
 		// startMemoryStartupTask. The function only touches sessionManager.* and

--- a/packages/coding-agent/test/issue-956-repro.test.ts
+++ b/packages/coding-agent/test/issue-956-repro.test.ts
@@ -17,6 +17,25 @@ const originalProjectDir = getProjectDir();
 const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
 const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
 
+// Per-file spy tracking. `vi.restoreAllMocks()` IS `mock.restore()` — the same
+// native function — and that global restore walks Bun's whole mock registry to
+// unpatch spies. When one of them patched a sealed ESM module namespace, the
+// walk segfaults the process (exit 132) once a later file in the same run
+// imports an overlapping module graph, taking the shared-process bucket with it.
+//
+// The tracker is deliberately PER FILE. A module-shared array would let one
+// file's teardown restore another file's still-live spies — the same cross-file
+// leak, pointing the other way.
+const trackedSpies: Array<{ mockRestore: () => void }> = [];
+function trackedSpyOn<T extends object, K extends keyof T>(obj: T, key: K) {
+	const spy = vi.spyOn(obj, key);
+	trackedSpies.push(spy as unknown as { mockRestore: () => void });
+	return spy;
+}
+function restoreTrackedSpies(): void {
+	for (const spy of trackedSpies.splice(0).reverse()) spy.mockRestore();
+}
+
 describe("issue #956: interactive /mcp test", () => {
 	let projectDir = "";
 	let agentDir = "";
@@ -50,7 +69,7 @@ describe("issue #956: interactive /mcp test", () => {
 	});
 
 	afterEach(async () => {
-		vi.restoreAllMocks();
+		restoreTrackedSpies();
 		setProjectDir(originalProjectDir);
 		if (originalAgentDir) {
 			setAgentDir(originalAgentDir);
@@ -81,9 +100,9 @@ describe("issue #956: interactive /mcp test", () => {
 		const requestRender = vi.fn();
 		const addChild = vi.fn();
 		const refreshMCPTools = vi.fn();
-		const connectToServer = vi.spyOn(mcpClient, "connectToServer").mockResolvedValue(connection);
-		const listTools = vi.spyOn(mcpClient, "listTools").mockResolvedValue([{ name: "search_issues" }] as never);
-		const disconnectServer = vi.spyOn(mcpClient, "disconnectServer").mockResolvedValue();
+		const connectToServer = trackedSpyOn(mcpClient, "connectToServer").mockResolvedValue(connection);
+		const listTools = trackedSpyOn(mcpClient, "listTools").mockResolvedValue([{ name: "search_issues" }] as never);
+		const disconnectServer = trackedSpyOn(mcpClient, "disconnectServer").mockResolvedValue();
 		const controller = new MCPCommandController({
 			chatContainer: { addChild },
 			present: (content: unknown) => {

--- a/packages/coding-agent/test/memories-runtime.test.ts
+++ b/packages/coding-agent/test/memories-runtime.test.ts
@@ -129,13 +129,32 @@ afterAll(async () => {
 	sharedRoot = undefined;
 });
 
+// Per-file spy tracking. `vi.restoreAllMocks()` IS `mock.restore()` — the same
+// native function — and that global restore walks Bun's whole mock registry to
+// unpatch spies. When one of them patched a sealed ESM module namespace, the
+// walk segfaults the process (exit 132) once a later file in the same run
+// imports an overlapping module graph, taking the shared-process bucket with it.
+//
+// The tracker is deliberately PER FILE. A module-shared array would let one
+// file's teardown restore another file's still-live spies — the same cross-file
+// leak, pointing the other way.
+const trackedSpies: Array<{ mockRestore: () => void }> = [];
+function trackedSpyOn<T extends object, K extends keyof T>(obj: T, key: K) {
+	const spy = vi.spyOn(obj, key);
+	trackedSpies.push(spy as unknown as { mockRestore: () => void });
+	return spy;
+}
+function restoreTrackedSpies(): void {
+	for (const spy of trackedSpies.splice(0).reverse()) spy.mockRestore();
+}
+
 describe("memories runtime", () => {
 	let savedXdgData: string | undefined;
 	let savedXdgState: string | undefined;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		vi.restoreAllMocks();
+		restoreTrackedSpies();
 		// Prevent getXdgDataPath/getXdgStatePath from resolving to real user data
 		savedXdgData = process.env.XDG_DATA_HOME;
 		savedXdgState = process.env.XDG_STATE_HOME;
@@ -144,14 +163,14 @@ describe("memories runtime", () => {
 	});
 
 	afterEach(async () => {
-		vi.restoreAllMocks();
+		restoreTrackedSpies();
 		process.env.XDG_DATA_HOME = savedXdgData;
 		process.env.XDG_STATE_HOME = savedXdgState;
 	});
 
 	test("startup gating skips when disabled or subagent depth", async () => {
 		const disabled = await createFixture({ "memories.enabled": false });
-		const openSpy = vi.spyOn(memoryStorage, "openMemoryDb");
+		const openSpy = trackedSpyOn(memoryStorage, "openMemoryDb");
 		startMemoryStartupTask({
 			session: disabled.session,
 			settings: disabled.settings,
@@ -174,10 +193,10 @@ describe("memories runtime", () => {
 
 	test("startup gating skips when DB is unavailable", async () => {
 		const fx = await createFixture();
-		vi.spyOn(memoryStorage, "openMemoryDb").mockImplementation(() => {
+		trackedSpyOn(memoryStorage, "openMemoryDb").mockImplementation(() => {
 			throw new Error("db unavailable");
 		});
-		const stage1Spy = vi.spyOn(ai, "completeSimple");
+		const stage1Spy = trackedSpyOn(ai, "completeSimple");
 
 		startMemoryStartupTask({
 			session: fx.session,
@@ -330,7 +349,7 @@ describe("memories runtime", () => {
 
 	test("phase2 sync prunes stale summaries and preserves raw memory ordering", async () => {
 		const fx = await createFixture();
-		vi.spyOn(ai, "completeSimple").mockResolvedValue({
+		trackedSpyOn(ai, "completeSimple").mockResolvedValue({
 			stopReason: "end_turn",
 			content: [
 				{
@@ -436,7 +455,7 @@ describe("buildMemoryToolDeveloperInstructions", () => {
 	});
 
 	afterEach(async () => {
-		vi.restoreAllMocks();
+		restoreTrackedSpies();
 		process.env.XDG_DATA_HOME = savedXdgData;
 		process.env.XDG_STATE_HOME = savedXdgState;
 	});

--- a/packages/coding-agent/test/memories-runtime.test.ts
+++ b/packages/coding-agent/test/memories-runtime.test.ts
@@ -219,8 +219,7 @@ describe("memories runtime", () => {
 		];
 		await fs.writeFile(rolloutPath, `${rolloutRows.map(row => JSON.stringify(row)).join("\n")}\n`);
 
-		const completeSpy = vi
-			.spyOn(ai, "completeSimple")
+		const completeSpy = trackedSpyOn(ai, "completeSimple")
 			.mockResolvedValueOnce({
 				stopReason: "end_turn",
 				content: [
@@ -298,8 +297,7 @@ describe("memories runtime", () => {
 		];
 		await fs.writeFile(rolloutPath, `${rolloutRows.map(row => JSON.stringify(row)).join("\n")}\n`);
 
-		const spy = vi
-			.spyOn(ai, "completeSimple")
+		const spy = trackedSpyOn(ai, "completeSimple")
 			.mockResolvedValueOnce({
 				stopReason: "end_turn",
 				content: [

--- a/packages/coding-agent/test/utils/open.test.ts
+++ b/packages/coding-agent/test/utils/open.test.ts
@@ -45,7 +45,7 @@ function spySpawn(calls: SpawnCall[]) {
 		calls.push({ cmd, options });
 		return fakeProcess();
 	}
-	return vi.spyOn(Bun, "spawn").mockImplementation(mockSpawn);
+	return trackedSpyOn(Bun, "spawn").mockImplementation(mockSpawn);
 }
 
 function spyWslPath(calls: string[][], output: string, exitCode = 0) {
@@ -66,7 +66,7 @@ function spyWslPath(calls: string[][], output: string, exitCode = 0) {
 		calls.push(Array.isArray(first) ? first : first.cmd);
 		return result;
 	}
-	return vi.spyOn(Bun, "spawnSync").mockImplementation(mockSpawnSync);
+	return trackedSpyOn(Bun, "spawnSync").mockImplementation(mockSpawnSync);
 }
 
 beforeEach(() => {
@@ -84,15 +84,36 @@ afterEach(() => {
 		else process.env[key] = prior;
 	}
 	restorePlatform();
-	vi.restoreAllMocks();
+	restoreTrackedSpies();
 });
+
+// Per-file spy tracking. `vi.restoreAllMocks()` IS `mock.restore()` — the same
+// native function — and that global restore walks Bun's whole mock registry to
+// unpatch spies. When one of them patched a sealed ESM module namespace, the
+// walk segfaults the process (exit 132) once a later file in the same run
+// imports an overlapping module graph, taking the shared-process bucket with it.
+//
+// The tracker is deliberately PER FILE. A module-shared array would let one
+// file's teardown restore another file's still-live spies — the same cross-file
+// leak, pointing the other way.
+const trackedSpies: Array<{ mockRestore: () => void }> = [];
+function trackedSpyOn<T extends object, K extends keyof T>(obj: T, key: K) {
+	const spy = vi.spyOn(obj, key);
+	trackedSpies.push(spy as unknown as { mockRestore: () => void });
+	return spy;
+}
+function restoreTrackedSpies(): void {
+	for (const spy of trackedSpies.splice(0).reverse()) spy.mockRestore();
+}
 
 describe("openPath", () => {
 	it("opens existing WSL mount files through wslview with a Windows path", () => {
 		setPlatform("linux");
 		process.env.WSL_DISTRO_NAME = "Ubuntu";
-		vi.spyOn(piUtils, "$which").mockImplementation(command => (command === "wslview" ? "/usr/bin/wslview" : null));
-		vi.spyOn(fs, "existsSync").mockImplementation(candidate => candidate === existingLinuxPath);
+		trackedSpyOn(piUtils, "$which").mockImplementation(command =>
+			command === "wslview" ? "/usr/bin/wslview" : null,
+		);
+		trackedSpyOn(fs, "existsSync").mockImplementation(candidate => candidate === existingLinuxPath);
 
 		const spawnSyncCalls: string[][] = [];
 		spyWslPath(spawnSyncCalls, windowsPath);
@@ -108,8 +129,8 @@ describe("openPath", () => {
 	it("keeps WSL URL opening on xdg-open without path conversion", () => {
 		setPlatform("linux");
 		process.env.WSL_INTEROP = "/run/WSL/1_interop";
-		vi.spyOn(piUtils, "$which").mockReturnValue("/usr/bin/wslview");
-		const spawnSyncSpy = vi.spyOn(Bun, "spawnSync");
+		trackedSpyOn(piUtils, "$which").mockReturnValue("/usr/bin/wslview");
+		const spawnSyncSpy = trackedSpyOn(Bun, "spawnSync");
 		const spawnCalls: SpawnCall[] = [];
 		spySpawn(spawnCalls);
 
@@ -122,8 +143,8 @@ describe("openPath", () => {
 	it("falls back to xdg-open when wslview is unavailable", () => {
 		setPlatform("linux");
 		process.env.WSL_DISTRO_NAME = "Ubuntu";
-		vi.spyOn(piUtils, "$which").mockReturnValue(null);
-		const spawnSyncSpy = vi.spyOn(Bun, "spawnSync");
+		trackedSpyOn(piUtils, "$which").mockReturnValue(null);
+		const spawnSyncSpy = trackedSpyOn(Bun, "spawnSync");
 		const spawnCalls: SpawnCall[] = [];
 		spySpawn(spawnCalls);
 


### PR DESCRIPTION
Continues NER-134 — takes the converted count from **4 of 11 to 8 of 11**.

Converts `issue-846-repro`, `issue-956-repro`, `memories-runtime` and `utils/open` off the blanket `vi.restoreAllMocks()`.

## Why the tracker is per-file

An earlier attempt used a **shared module-level array** and regressed 4 tests. In a 62-file single-process bucket, one file's teardown restored another file's still-live spies — the same cross-file leak this is meant to fix, pointing the other way. That attempt was reverted.

This shape avoids it because no state crosses a file boundary: each file declares its own `trackedSpyOn` / `restoreTrackedSpies` pair.

Teardown still undoes **every** spy the file created, so nothing leaks to siblings — it just does so by handle instead of asking Bun to walk its global mock registry, which is what segfaults the bucket when a sealed ESM namespace is patched.

## Verification, per file against main

| files | result |
|---|---|
| `issue-846-repro` + `issue-956-repro` | 2 pass / 0 fail |
| `memories-runtime` + `utils/open` | 11 pass / 1 fail — **identical to main** (`openPath` WSL-mount test, pre-existing) |

Lint and typecheck clean.

## Remaining

Three files, all large: `agent-session-auto-compaction-queue` (12 spies), `agent-session-python-cleanup` (17, some created inside shared helper functions so the tracker must be threaded through), `agent-bridge` (57).

As with #24 — **this reduces the crash surface, it does not prove the flake gone.** At ~40% per full-bucket run, a green CI run is not evidence until all 11 are converted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)