### PR TITLE
test(acp): dispose fusion-sidekick harnesses instead of leaking them

### DIFF
--- a/packages/coding-agent/test/acp-agent-fusion-sidekick.test.ts
+++ b/packages/coding-agent/test/acp-agent-fusion-sidekick.test.ts
@@ -243,6 +243,14 @@ interface AgentHarness {
 	findSession(sessionId: string): FakeAgentSession | undefined;
 }
 
+// Every test builds a real AcpAgent with live sessions. Nothing used to tear
+// them down, so six undisposed harnesses accumulated across the file — open
+// session handles that made Windows refuse the temp-dir delete with EBUSY, and
+// that leave enough runtime state behind to crash Bun 1.3.14 when the next file
+// in the same process loads (`bun --smol test acp-agent-fusion-sidekick
+// system-prompt-model` segfaults 5/5 without this; neither file crashes alone).
+// Disposing per test keeps the accumulation bounded.
+const liveHarnesses: AgentHarness[] = [];
 const cleanupRoots: string[] = [];
 const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
 const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
@@ -269,6 +277,20 @@ afterEach(async () => {
 		delete process.env.PI_CODING_AGENT_DIR;
 	}
 	resetSettingsForTest();
+
+	// Release live sessions before deleting their directories: an undisposed
+	// session keeps handles open, which is both the EBUSY source below and the
+	// state accumulation that trips the runtime in the next file.
+	for (const harness of liveHarnesses.splice(0)) {
+		harness.abortController.abort();
+		for (const session of harness.sessions.splice(0)) {
+			try {
+				await session.dispose();
+			} catch {
+				// A session that never fully started has nothing to release.
+			}
+		}
+	}
 
 	for (const root of cleanupRoots.splice(0)) {
 		// Best-effort: the harness leaves session handles open long enough that
@@ -309,7 +331,7 @@ async function createHarness(): Promise<AgentHarness> {
 	};
 
 	const agent = new AcpAgent(connection, factory, initialSession as unknown as AgentSession);
-	return {
+	const harness: AgentHarness = {
 		agent,
 		abortController,
 		sessions,
@@ -317,6 +339,8 @@ async function createHarness(): Promise<AgentHarness> {
 		cwdB,
 		findSession: (sessionId: string) => sessions.findLast(s => s.sessionId === sessionId),
 	};
+	liveHarnesses.push(harness);
+	return harness;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Every test in `acp-agent-fusion-sidekick.test.ts` builds a real `AcpAgent` with live sessions, and **nothing tore them down**. Six undisposed harnesses accumulated across the file.

That caused two symptoms that looked unrelated:

- **Windows** refused the temp-dir delete with `EBUSY` — open session handles kept the directory locked. Previously worked around by making cleanup best-effort (`02cfe2c2a`); this addresses the cause.
- **Enough runtime state was left behind to crash Bun 1.3.14** when the next file loaded in the same process.

## Measured

On Linux (bun 1.3.14, glibc 2.39), the documented pairing:

```
bun --smol test --parallel=1 acp-agent-fusion-sidekick system-prompt-model
```

| | segfaults |
|---|---|
| before | **5/5** |
| after | **1/5** |

Supporting controls: neither file crashes alone (0/3 each), and a load-only run (`-t` matching nothing) is clean 0/3 — which is what identified *accumulation* rather than any single test as the mechanism.

## This is a reduction, not a fix

1/5 still fails CI. Bun's own crash output says `This indicates a bug in Bun, not your code`, and chunking the bucket so the pair cannot co-reside was **also** tested and did not eliminate it (2/3 still segfault) — so other combinations trip it too.

Merge this for the leak, which is a genuine defect on its own merits. Tracking the crash in NER-134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup by reliably stopping active sessions and releasing resources after each test.
  * Reduced the risk of lingering test processes or open handles affecting subsequent test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->