### PR TITLE
ci: chunk the singleton bucket to bound the Bun 1.3.14 crash (NER-134)

### DIFF
--- a/scripts/ci-test-ts.ts
+++ b/scripts/ci-test-ts.ts
@@ -49,10 +49,22 @@ const validModes = new Set<Mode>([
 // separate `bun --smol test` child process. A fresh process per chunk resets Bun's
 // heap and reaps any dangling spawned children between groups, keeping peak RSS
 // under the CI runner's OOM ceiling (a single 170–370-file invocation gets
-// SIGKILLed at 137). The singleton/global-state bucket is left whole: its suites
-// co-locate in one process to exercise process-wide state, so they must not split.
+// SIGKILLed at 137).
+//
+// The singleton bucket was historically left whole so its suites co-locate in
+// one process and exercise process-wide state. It is now chunked as a
+// mitigation for a Bun 1.3.14 crash (`panic(main thread): Segmentation fault
+// at address 0x4`, exit 132 — Bun's banner says "a bug in Bun, not your
+// code"): the crash follows accumulated runtime state across many files in one
+// process. A deterministic two-file trigger was removed by disposing leaked
+// harnesses (see acp-agent-fusion-sidekick.test.ts), but CI still crashed
+// ~25s into a single 54-file process (Peak RSS ~2GB, 70+ spawns), so bounding
+// accumulation to 10 files per process is the remaining lever. Groups of 10
+// still share a process, so per-chunk process-wide behaviour is exercised; a
+// suite that needs cross-chunk state must pin its files into one chunk.
+// Tracked in NER-134; revert when a fixed Bun ships.
 const codingAgentBucketPlans: Record<CodingAgentBucket, { label: string; parallel: number; chunkSize?: number }> = {
-	singleton: { label: "singleton/global-state bucket", parallel: 1 },
+	singleton: { label: "singleton/global-state bucket", parallel: 1, chunkSize: 10 },
 	ui: { label: "UI/TUI bucket", parallel: 1, chunkSize: 10 },
 	runtime: { label: "runtime/session bucket", parallel: 1, chunkSize: 10 },
 	native: { label: "native/tooling/browser/unit bucket", parallel: 1, chunkSize: 10 },


### PR DESCRIPTION
The singleton bucket ran all 54 files in one process by design. That single long-lived process is also what the Bun 1.3.14 segfault needs — the crash follows **accumulated runtime state**, and Bun's own banner calls it "a bug in Bun, not your code."

## Why this, why now

- The deterministic two-file trigger was removed by disposing leaked harnesses (**#31**, merged): controlled A/B on the identical 54-file list, 2/2 crash without → 0/4 with.
- **CI on `main` still crashed post-merge** — at a *different* point: ~25s in, Peak RSS ~2GB, `spawn(71)`, deep into the single 54-file process. Same panic address (`0x4`), different accumulation path.
- Bun 1.3.14 is the **latest release** — there is no upgrade to take.

So the remaining lever is bounding accumulation: a fresh process every 10 files, exactly the chunking the other three buckets already use.

## Evidence for the combination

| configuration | full-bucket result |
|---|---|
| unchunked, no dispose fix | crashes (CI + local 2/2) |
| unchunked, dispose fix | local 0/4, **but CI still crashed** |
| chunked, no dispose fix | still crashed (inside chunk 1) |
| **chunked + dispose fix** | **local 2/2 clean** |

Both pieces are needed. This PR's own singleton job is the real test — local greens have been shown non-predictive for this bug twice, which is why the claim here is "bounds the crash's precondition," not "fixed."

## Trade-off

Groups of 10 still share a process, so per-chunk process-wide behaviour is exercised — but nothing may rely on state set by a file in an *earlier* chunk. No such dependency is known; if one surfaces, pin those files into one chunk rather than reverting.

Revert when a fixed Bun ships. Tracked in NER-134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when running singleton test suites by splitting them into smaller groups.
  * Test execution is now distributed across multiple processes instead of running all singleton tests together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->