### PR TITLE
fix(capability): path-qualify context-file disable ids, dual-read legacy (NER-144)

### DIFF
--- a/packages/coding-agent/src/capability/context-file.ts
+++ b/packages/coding-agent/src/capability/context-file.ts
@@ -34,7 +34,16 @@ export const contextFileCapability = defineCapability<ContextFile>({
 	// Clamp depth >= 0: files inside config subdirectories of an ancestor (e.g. .claude/, .github/)
 	// are same-scope as the ancestor itself.
 	key: file => (file.level === "user" ? "user" : `project:${Math.max(0, file.depth ?? 0)}`),
-	toExtensionId: file => `context-file:${file.level}:${path.basename(file.path)}`,
+	// Path-qualified: keying by basename alone made one disabled id suppress
+	// EVERY same-named file at that level (disabling one project's AGENTS.md
+	// silently disabled all of them). Forward slashes keep the id stable across
+	// path separators on the same machine.
+	toExtensionId: file => `context-file:${file.level}:${path.resolve(file.path).split(path.sep).join("/")}`,
+	// Entries persisted before the path-qualified format used the basename form.
+	// Keep honouring them — dropping the legacy key would silently re-enable
+	// files users deliberately disabled. Legacy entries retain the old collision
+	// behaviour (they match by basename); only new disables are precise.
+	toLegacyExtensionIds: file => [`context-file:${file.level}:${path.basename(file.path)}`],
 	validate: file => {
 		if (!file.path) return "Missing path";
 		if (file.content === undefined) return "Missing content";

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -176,6 +176,13 @@ async function loadImpl<T>(
 			if (extensionId && disabledExtensionIds.has(extensionId)) {
 				continue;
 			}
+			// Honour IDs persisted under an older format too — a user's existing
+			// `disabledExtensions` entries must keep disabling after an ID-format
+			// change (see toLegacyExtensionIds in types.ts).
+			const legacyIds = capability.toLegacyExtensionIds?.(itemWithSource);
+			if (legacyIds?.some(id => disabledExtensionIds.has(id))) {
+				continue;
+			}
 
 			itemWithSource._source.providerName = provider.displayName;
 			allItems.push(itemWithSource as T & { _source: SourceMeta; _shadowed?: boolean });

--- a/packages/coding-agent/src/capability/types.ts
+++ b/packages/coding-agent/src/capability/types.ts
@@ -133,6 +133,16 @@ export interface Capability<T> {
 	 */
 	toExtensionId?(item: T): string | undefined;
 
+	/**
+	 * Optional additional IDs under which this item may appear in persisted
+	 * `disabledExtensions` settings. Used when a capability's ID format changes:
+	 * new disables are written in the `toExtensionId` format, but entries users
+	 * persisted under the old format must keep disabling — silently re-enabling
+	 * something a user deliberately turned off is worse than honouring a legacy
+	 * key. Matching is OR across `toExtensionId` and every legacy ID.
+	 */
+	toLegacyExtensionIds?(item: T): string[];
+
 	/** Registered providers, sorted by priority (highest first) */
 	providers: Provider<T>[];
 }

--- a/packages/coding-agent/test/capability/context-file-id-precision.test.ts
+++ b/packages/coding-agent/test/capability/context-file-id-precision.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type ContextFile, contextFileCapability } from "@pk-nerdsaver-ai/pi-coding-agent/capability/context-file";
+import { resetSettingsForTest, Settings } from "@pk-nerdsaver-ai/pi-coding-agent/config/settings";
+import { initializeWithSettings, loadCapability } from "@pk-nerdsaver-ai/pi-coding-agent/discovery";
+import { removeWithRetries } from "@pk-nerdsaver-ai/pi-utils";
+
+/**
+ * Context-file disable ids are path-qualified. The old format keyed by
+ * basename, so one disabled id — `context-file:project:AGENTS.md` — suppressed
+ * EVERY project-level AGENTS.md the process ever discovered. Two contracts:
+ *
+ * 1. Precision: disabling one project's file (new path-qualified id) must not
+ *    disable a same-named file in a different project.
+ * 2. Legacy compat: ids persisted in the old basename format keep disabling —
+ *    silently re-enabling something a user turned off would be worse than
+ *    honouring the old key's collision behaviour.
+ */
+describe("context-file extension id precision", () => {
+	let projectA = "";
+	let projectB = "";
+
+	const agentsMd = (root: string) => path.join(root, ".ompk", "AGENTS.md");
+	const newIdFor = (root: string) => `context-file:project:${path.resolve(agentsMd(root)).split(path.sep).join("/")}`;
+
+	const present = (items: ReadonlyArray<ContextFile>, root: string): boolean =>
+		items.some(item => path.resolve(item.path) === path.resolve(agentsMd(root)));
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		projectA = await fs.mkdtemp(path.join(os.tmpdir(), "omp-ctxid-a-"));
+		projectB = await fs.mkdtemp(path.join(os.tmpdir(), "omp-ctxid-b-"));
+		for (const root of [projectA, projectB]) {
+			await fs.mkdir(path.join(root, ".ompk"), { recursive: true });
+			await fs.writeFile(agentsMd(root), "# project instructions\n");
+		}
+	});
+
+	afterEach(async () => {
+		resetSettingsForTest();
+		await removeWithRetries(projectA).catch(() => {});
+		await removeWithRetries(projectB).catch(() => {});
+	});
+
+	test("path-qualified disable suppresses only that project's file", async () => {
+		const settings = await Settings.init({
+			inMemory: true,
+			cwd: projectA,
+			overrides: { disabledExtensions: [newIdFor(projectA)] },
+		});
+		initializeWithSettings(settings);
+
+		const inA = await loadCapability<ContextFile>(contextFileCapability.id, { cwd: projectA });
+		expect(present(inA.items, projectA)).toBe(false);
+
+		// Same disabled set, different project: the same-named file must survive.
+		const inB = await loadCapability<ContextFile>(contextFileCapability.id, { cwd: projectB });
+		expect(present(inB.items, projectB)).toBe(true);
+	});
+
+	test("legacy basename-format disable keeps working (with its old collision behaviour)", async () => {
+		const settings = await Settings.init({
+			inMemory: true,
+			cwd: projectA,
+			overrides: { disabledExtensions: ["context-file:project:AGENTS.md"] },
+		});
+		initializeWithSettings(settings);
+
+		const inA = await loadCapability<ContextFile>(contextFileCapability.id, { cwd: projectA });
+		expect(present(inA.items, projectA)).toBe(false);
+
+		// Legacy ids match by basename, so the collision is intentionally kept:
+		// project B's AGENTS.md is suppressed too, exactly as before the change.
+		const inB = await loadCapability<ContextFile>(contextFileCapability.id, { cwd: projectB });
+		expect(present(inB.items, projectB)).toBe(false);
+	});
+});


### PR DESCRIPTION
Second half of NER-144 (the settings-pin leak was #25).

## The bug

`contextFileCapability` keyed disable ids by **basename**: one persisted id — `context-file:project:AGENTS.md` — suppressed *every* same-named file at that level, process-wide. Disabling one project's `AGENTS.md` silently disabled all of them.

## Why not just change the id format

That direction has its own failure mode: ids live in users' persisted `disabledExtensions` settings. Changing the format outright stops matching them — **silently re-enabling files people deliberately turned off**, which is worse than the collision.

So: dual-read. New optional `toLegacyExtensionIds` on the capability type; the filter matches OR across current and legacy ids.

- **New disables are precise** — resolved absolute path, forward-slashed for separator stability.
- **Legacy basename entries keep working**, retaining their old collision behaviour by design.

## Tests pin both contracts

1. Path-qualified disable suppresses only its own project's file; a same-named file in a different project survives.
2. Legacy basename disable still suppresses both — byte-identical to pre-change behaviour.

## Verification

Capability suite 11 pass / 0 fail. `disabled-extensions`' 2 known Windows-only `HOME`-mock failures baselined **identical without this change** (green on Linux CI). Lint on changed files and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)