### PR TITLE
test(eval): give julia-prelude a cold-JIT-sized budget (NER-135 recurrence)

### DIFF
--- a/.wiki/concepts/coding-agent-reliability-hardening.md
+++ b/.wiki/concepts/coding-agent-reliability-hardening.md
@@ -30,6 +30,8 @@ The investigation established two distinct mitigations:
 1. `acp-agent-fusion-sidekick.test.ts` now disposes the harnesses it creates. This removes a deterministic two-file trigger, but was not by itself sufficient for the exact CI file list and invocation.
 2. [PR #32](https://github.com/kingkillery/oh-my-pk/pull/32) chunks the singleton bucket into groups of ten files, retaining per-chunk process-state coverage while bounding heap growth and leaked child-process accumulation. Its PR CI passed the singleton job and every non-release CI job.
 
+The first post-merge `main` run (`30482788360`) kept the singleton job green but failed separately in the native/unit bucket: `julia-prelude.test.ts` timed out in a hook. That bucket then stopped after its first 10-file chunk, leaving the remaining 51 chunks explicitly **unknown**. It is a distinct test-reliability follow-up, not evidence that the singleton crash returned.
+
 The chunking is explicitly a temporary NER-134 mitigation. Re-evaluate and remove it when a Bun release fixes the underlying crash; any suite that genuinely requires cross-file state must keep those files in the same chunk.
 
 ### Context-file disable IDs: precise going forward, compatible for existing users

--- a/.wiki/concepts/coding-agent-reliability-hardening.md
+++ b/.wiki/concepts/coding-agent-reliability-hardening.md
@@ -11,6 +11,33 @@ status: implemented
 
 Recent hardening work focused on making advanced harness paths safer and easier to verify.
 
+## July 29: CI recovery and repeatability
+
+### Treat the CI harness as the test contract
+
+The initial CI-repair work merged as [PR #18](https://github.com/kingkillery/oh-my-pk/pull/18). Its durable lesson is procedural: reproduce the **actual CI unit**, not a convenient local subset.
+
+- `scripts/ci-test-ts.ts` is the authoritative runner. It classifies coding-agent tests into buckets, selects the exact files, runs each group with Bun's `--smol` mode, applies the CI-style environment scrub, and carries the aggregate's `--only-failures` behaviour.
+- Reproduce a failing bucket on Linux with the same native addon and runner flags that CI uses. Windows-only path, casing, and home-directory mocks are useful diagnostics but are not acceptance evidence for the Linux job.
+- The runner fails fast by default. A failure leaves later chunks **unknown**, not green; use `--keep-going` when the goal is the complete failure set. This prevents a fix that merely exposes a later failure from being misreported as a regression.
+
+### Bound Bun runtime-state accumulation
+
+The unchunked singleton/global-state bucket exposed a Bun 1.3.14 runtime crash (`panic(main thread): Segmentation fault at address 0x4`, exit 132) after substantial state accumulated in one process. Bun's own crash banner identifies this as a runtime bug rather than an application exception.
+
+The investigation established two distinct mitigations:
+
+1. `acp-agent-fusion-sidekick.test.ts` now disposes the harnesses it creates. This removes a deterministic two-file trigger, but was not by itself sufficient for the exact CI file list and invocation.
+2. [PR #32](https://github.com/kingkillery/oh-my-pk/pull/32) chunks the singleton bucket into groups of ten files, retaining per-chunk process-state coverage while bounding heap growth and leaked child-process accumulation. Its PR CI passed the singleton job and every non-release CI job.
+
+The chunking is explicitly a temporary NER-134 mitigation. Re-evaluate and remove it when a Bun release fixes the underlying crash; any suite that genuinely requires cross-file state must keep those files in the same chunk.
+
+### Context-file disable IDs: precise going forward, compatible for existing users
+
+[PR #33](https://github.com/kingkillery/oh-my-pk/pull/33) is the remaining context-file follow-up, pending CI at the time this note was written. It changes newly written `disabledExtensions` IDs for context files from a basename-only form to a resolved, path-qualified form with forward slashes. Disabling one project's `AGENTS.md` therefore no longer suppresses same-named context files in another project.
+
+The change deliberately dual-reads the old basename ID. Existing settings continue to disable the files they previously matched, including the old collision behaviour, rather than silently re-enabling a file that a user deliberately disabled. Only newly created disable entries receive the path-level precision.
+
 ## WikiGraph path sandbox
 
 `wikigraph://path/...` is now constrained to the calling session `cwd` plus configured `wikigraph.roots`.

--- a/.wiki/concepts/index.md
+++ b/.wiki/concepts/index.md
@@ -7,7 +7,7 @@
 * [Recent prompt markdown files](recent-prompt-markdown-files.md) - session-observed inventory of recent `packages/coding-agent/src/prompts/**/*.md` files and the `type: prompt(s)` frontmatter caveat.
 * [Context and token optimization](context-optimization.md) - how the system prompt, tool schemas, and context files contribute to the LLM context window, and tunables to keep the baseline small.
 * [Offload trace](offload-trace.md) - opt-in progressive-disclosure compaction memory: raw evidence offloaded to artifact:// with a bounded Mermaid trace canvas preserved across context rebuilds.
-* [Coding-agent reliability hardening](coding-agent-reliability-hardening.md) - implemented safety and verification fixes for WikiGraph path reads, 9router ID normalization, offload artifact drill-down, and bundled-agent checks.
+* [Coding-agent reliability hardening](coding-agent-reliability-hardening.md) - implemented safety and verification fixes for WikiGraph path reads, 9router ID normalization, offload artifact drill-down, bundled-agent checks, CI reproduction discipline, and the temporary Bun 1.3.14 singleton-bucket mitigation.
 * [Light context layer](light-context-layer.md) - implemented `context_oracle` tool and typed LSP evidence seam for compact cited repository answers.
 * [Remote workspace](remote-workspace.md) - phase-1 Docker sandbox jobs (`ompk-remote`); durable lifecycle, not multi-node mesh.
 * [Environments-cloud routing](environments-cloud-routing.md) - MSI pkscloudenvs SoT for mesh/cloud skills and handoff CLIs.

--- a/.wiki/index.md
+++ b/.wiki/index.md
@@ -12,8 +12,9 @@ plain markdown + YAML frontmatter, diffable in git, readable by humans and agent
 
 * [Concepts](concepts/) - design decisions and synthesized patterns for this codebase.
 
-Recent additions (2026-07-12):
+Recent additions (2026-07-29):
 
+* [Coding-agent reliability hardening](concepts/coding-agent-reliability-hardening.md) — CI recovery evidence, Bun 1.3.14 singleton-bucket mitigation, and context-file disable-ID migration status
 * [Environments-cloud routing](concepts/environments-cloud-routing.md) — pkscloudenvs MSI SoT handoff
 * [Remote workspace](concepts/remote-workspace.md) — phase-1 Docker sandbox jobs
 * [Task-contract orchestration](concepts/task-contract-orchestration.md) — ephemeral contracts + evidence stack

--- a/.wiki/log.md
+++ b/.wiki/log.md
@@ -1,5 +1,8 @@
 # Bundle Update Log
 
+## 2026-07-29
+* **Update**: Extended [Coding-agent reliability hardening](concepts/coding-agent-reliability-hardening.md) with the CI-repair conclusions from PR #18, the requirement to reproduce the actual Linux CI harness and treat skipped fail-fast chunks as unknown, and the temporary ten-file singleton-bucket mitigation for the Bun 1.3.14 crash in PR #32. Recorded the path-qualified, dual-read context-file disable-ID migration in pending PR #33 so the wiki distinguishes new precision from legacy compatibility.
+
 ## 2026-07-14
 * **Update**: Documented the uncommitted Snapcompact removal in [Recent History — 2026-07](concepts/recent-history-2026-07.md#july-14-snapcompact-removal): full deletion list (shape-preview component/doc, five system-prompt stub/note markdown files, inline-compaction and savings-journal modules, three test files), the `packages/coding-agent/CHANGELOG.md` `### Removed` justification (unsafe experimental prompt/history/tool-result imaging; stale `Snapcompact` setting migrates to `context-full`), and the surrounding surfaces (`session/*`, `modes/*`, `config/settings*`, `slash-commands/*`) that were updated in lockstep rather than left dangling.
 

--- a/packages/coding-agent/src/eval/__tests__/julia-prelude.test.ts
+++ b/packages/coding-agent/src/eval/__tests__/julia-prelude.test.ts
@@ -6,20 +6,31 @@ import { disposeJuliaKernelSessionsByOwner, executeJulia } from "../jl/executor"
 const HAS_JULIA = Boolean($which("julia"));
 const OWNER_ID = "julia-prelude-tests";
 
+// Julia's cold-start JIT/precompilation on a loaded CI runner has blown a 30s
+// budget twice (the reported "35s hook timeout" is the 30s test budget plus
+// hook overage), and this file is chunk 1 of the native bucket — when it
+// flakes, the abort hides every later chunk. Disposal is already bounded
+// (settleWithin, 10s per phase); the remaining variable is startup, so give
+// the whole test a budget that reflects a cold JIT rather than a warm one.
+// Tracked in NER-135.
+const JULIA_TEST_TIMEOUT_MS = 120_000;
+
 describe.skipIf(!HAS_JULIA)("eval Julia prelude helpers", () => {
 	afterEach(async () => {
 		await disposeJuliaKernelSessionsByOwner(OWNER_ID);
 	});
 
-	it("supports output ranges, JSON queries, metadata, and ANSI stripping", async () => {
-		using tempDir = TempDir.createSync("@omp-eval-julia-output-");
-		const artifactsDir = path.join(tempDir.path(), "session-artifacts");
-		await Bun.write(path.join(artifactsDir, "alpha.md"), "one\ntwo\nthree\nfour");
-		await Bun.write(path.join(artifactsDir, "json.md"), JSON.stringify({ items: [{ name: "a" }, { name: "b" }] }));
-		await Bun.write(path.join(artifactsDir, "ansi.md"), "\u001b[31mred\u001b[0m");
+	it(
+		"supports output ranges, JSON queries, metadata, and ANSI stripping",
+		async () => {
+			using tempDir = TempDir.createSync("@omp-eval-julia-output-");
+			const artifactsDir = path.join(tempDir.path(), "session-artifacts");
+			await Bun.write(path.join(artifactsDir, "alpha.md"), "one\ntwo\nthree\nfour");
+			await Bun.write(path.join(artifactsDir, "json.md"), JSON.stringify({ items: [{ name: "a" }, { name: "b" }] }));
+			await Bun.write(path.join(artifactsDir, "ansi.md"), "\u001b[31mred\u001b[0m");
 
-		const result = await executeJulia(
-			`
+			const result = await executeJulia(
+				`
 println("RANGE=", replace(output("alpha", offset=2, limit=2), "\\n" => "|"))
 println("QUERY=", output("json", query=".items[1].name"))
 println("STRIPPED=", output("ansi", format="stripped"))
@@ -29,38 +40,44 @@ multi = output("alpha", "json")
 println("MULTI=", length(multi), ":", multi[1]["id"], ":", multi[2]["id"])
 nothing
 `,
-			{
+				{
+					cwd: tempDir.path(),
+					artifactsDir,
+					sessionId: `julia-prelude-output:${crypto.randomUUID()}`,
+					kernelOwnerId: OWNER_ID,
+					reset: true,
+				},
+			);
+
+			expect(result.exitCode).toBe(0);
+			expect(result.output).toContain("RANGE=two|three");
+			expect(result.output).toContain('QUERY="b"');
+			expect(result.output).toContain("STRIPPED=red");
+			expect(result.output).toContain("META=alpha:true");
+			expect(result.output).toContain("MULTI=2:alpha:json");
+		},
+		JULIA_TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"surfaces the exception type and message in the error output, not just stack frames",
+		async () => {
+			using tempDir = TempDir.createSync("@omp-eval-julia-error-");
+			const result = await executeJulia(`println("="^8)\nmissing_var_xyz + 1`, {
 				cwd: tempDir.path(),
-				artifactsDir,
-				sessionId: `julia-prelude-output:${crypto.randomUUID()}`,
+				sessionId: `julia-prelude-error:${crypto.randomUUID()}`,
 				kernelOwnerId: OWNER_ID,
 				reset: true,
-			},
-		);
+			});
 
-		expect(result.exitCode).toBe(0);
-		expect(result.output).toContain("RANGE=two|three");
-		expect(result.output).toContain('QUERY="b"');
-		expect(result.output).toContain("STRIPPED=red");
-		expect(result.output).toContain("META=alpha:true");
-		expect(result.output).toContain("MULTI=2:alpha:json");
-	}, 30_000);
-
-	it("surfaces the exception type and message in the error output, not just stack frames", async () => {
-		using tempDir = TempDir.createSync("@omp-eval-julia-error-");
-		const result = await executeJulia(`println("="^8)\nmissing_var_xyz + 1`, {
-			cwd: tempDir.path(),
-			sessionId: `julia-prelude-error:${crypto.randomUUID()}`,
-			kernelOwnerId: OWNER_ID,
-			reset: true,
-		});
-
-		// The rendered error must carry the actual exception, not only the
-		// runner-internal backtrace frames (regression: traceback-only output
-		// hid `ename`/`evalue`).
-		expect(result.output).toContain("UndefVarError");
-		expect(result.output).toContain("missing_var_xyz");
-		// Frames are still present alongside the message.
-		expect(result.output).toContain("top-level scope");
-	}, 30_000);
+			// The rendered error must carry the actual exception, not only the
+			// runner-internal backtrace frames (regression: traceback-only output
+			// hid `ename`/`evalue`).
+			expect(result.output).toContain("UndefVarError");
+			expect(result.output).toContain("missing_var_xyz");
+			// Frames are still present alongside the message.
+			expect(result.output).toContain("top-level scope");
+		},
+		JULIA_TEST_TIMEOUT_MS,
+	);
 });


### PR DESCRIPTION
The Julia hook-timeout flake **recurred on `main`** (rerun of `2a2ef3afc`) with the identical NER-135 signature: 35s hook timeout, assertions unrun.

#21 bounded **disposal** (`settleWithin`, 10s per phase) — but the `30_000` test budgets in this file never accounted for cold-start JIT/precompilation on a loaded 2-core runner. The reported 35s is that 30s budget plus hook overage.

Why it matters disproportionately: this file is **chunk 1 of the native bucket**, so each flake aborts the job and hides the other 50 chunks.

Change: `30_000 → 120_000` on both tests, as a named constant with the rationale inline. A passing run stays exactly as fast — only the ceiling moves.

NER-135's own escalation path was "if it recurs, act." It recurred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)